### PR TITLE
chore: remove unused dependencies across workspace

### DIFF
--- a/crates/mcp-bridge/Cargo.toml
+++ b/crates/mcp-bridge/Cargo.toml
@@ -9,18 +9,13 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-trait.workspace = true
-blake3.workspace = true
 lru.workspace = true
 mcp-core.workspace = true
 rmcp = { workspace = true, features = ["client", "transport-child-process"] }
-serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync", "process"] }
 tracing.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
-mockall.workspace = true
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/mcp-cli/Cargo.toml
+++ b/crates/mcp-cli/Cargo.toml
@@ -22,24 +22,19 @@ chrono.workspace = true
 clap = { workspace = true, features = ["derive", "env", "cargo", "color"] }
 clap_complete.workspace = true
 colored.workspace = true
-console.workspace = true
 dialoguer.workspace = true
 dirs.workspace = true
-human-panic.workspace = true
-indicatif.workspace = true
 mcp-bridge.workspace = true
 mcp-codegen = { workspace = true, features = ["skills"] }
 mcp-core.workspace = true
 mcp-introspector.workspace = true
 mcp-skill-store.workspace = true
-mcp-vfs.workspace = true
 mcp-wasm-runtime.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 toml.workspace = true
 tracing.workspace = true
-tracing-appender.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 wasmtime.workspace = true
 which.workspace = true

--- a/crates/mcp-codegen/Cargo.toml
+++ b/crates/mcp-codegen/Cargo.toml
@@ -19,16 +19,10 @@ chrono = { workspace = true, features = ["serde"] }
 handlebars.workspace = true
 mcp-core.workspace = true
 mcp-introspector.workspace = true
-proc-macro2.workspace = true
-quote.workspace = true
-regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-syn = { workspace = true, features = ["full", "parsing", "proc-macro"] }
-thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
 mcp-vfs.workspace = true
-tempfile.workspace = true

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -13,7 +13,6 @@ async-trait.workspace = true
 blake3.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 dirs.workspace = true
-secrecy.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mcp-examples/Cargo.toml
+++ b/crates/mcp-examples/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-blake3.workspace = true
 mcp-bridge.workspace = true
 mcp-codegen.workspace = true
 mcp-core.workspace = true
@@ -19,7 +18,6 @@ mcp-introspector.workspace = true
 mcp-skill-store.workspace = true
 mcp-vfs.workspace = true
 mcp-wasm-runtime.workspace = true
-serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -9,12 +9,10 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-trait.workspace = true
 mcp-core.workspace = true
 rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process"] }
 tracing.workspace = true
 

--- a/crates/mcp-skill-generator/Cargo.toml
+++ b/crates/mcp-skill-generator/Cargo.toml
@@ -18,12 +18,8 @@ workspace = true
 chrono = { workspace = true, features = ["serde"] }
 mcp-codegen.workspace = true
 mcp-core.workspace = true
-mcp-introspector.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/mcp-skill-store/Cargo.toml
+++ b/crates/mcp-skill-store/Cargo.toml
@@ -15,7 +15,6 @@ dirs.workspace = true
 mcp-codegen = { workspace = true, features = ["skills"] }
 mcp-core.workspace = true
 mcp-vfs.workspace = true
-secrecy.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
@@ -25,7 +24,6 @@ walkdir.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros"] }
 
 [[bench]]
 name = "large_vfs"

--- a/crates/mcp-vfs/Cargo.toml
+++ b/crates/mcp-vfs/Cargo.toml
@@ -10,10 +10,7 @@ workspace = true
 
 [dependencies]
 mcp-codegen.workspace = true
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dependencies.dhat]
 version = "0.3"
@@ -21,7 +18,6 @@ optional = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
-tempfile.workspace = true
 
 [features]
 dhat-heap = ["dhat"]

--- a/crates/mcp-wasm-runtime/Cargo.toml
+++ b/crates/mcp-wasm-runtime/Cargo.toml
@@ -10,19 +10,14 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 blake3.workspace = true
 lru.workspace = true
 mcp-bridge.workspace = true
 mcp-core.workspace = true
-serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-tempfile.workspace = true
-thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }
 tracing.workspace = true
 wasmtime.workspace = true
-wasmtime-wasi.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true


### PR DESCRIPTION
## Summary

Removed 36 unused dependencies identified by `cargo-machete` across all workspace crates.

## Motivation

- Reduce compilation time
- Reduce binary size
- Improve dependency tree clarity
- Reduce security surface area
- Follow best practices for dependency management

## Changes

### Dependencies Removed by Crate

1. **mcp-vfs** (4 dependencies)
   - `serde`, `serde_json`, `tempfile`, `tracing`

2. **mcp-codegen** (6 dependencies)
   - `proc-macro2`, `quote`, `regex`, `syn`, `tempfile`, `thiserror`

3. **mcp-core** (1 dependency)
   - `secrecy`

4. **mcp-cli** (5 dependencies)
   - `console`, `human-panic`, `indicatif`, `mcp-vfs`, `tracing-appender`

5. **mcp-bridge** (5 dependencies)
   - `async-trait`, `blake3`, `mockall`, `serde`, `thiserror`

6. **mcp-skill-generator** (4 dependencies)
   - `mcp-introspector`, `tempfile`, `tokio`, `tracing`

7. **mcp-examples** (2 dependencies)
   - `blake3`, `serde`

8. **mcp-introspector** (2 dependencies)
   - `async-trait`, `thiserror`

9. **mcp-wasm-runtime** (5 dependencies)
   - `async-trait`, `serde`, `tempfile`, `thiserror`, `wasmtime-wasi`

10. **mcp-skill-store** (2 dependencies)
    - `secrecy`, `tokio`

**Total**: 36 dependencies removed

## Verification

### Tool Used
```bash
cargo machete --with-metadata
```

### Test Results
```bash
cargo nextest run --workspace
```
- ✅ **969/969 tests passing** (6 skipped)
- ✅ **0 test failures**

### Clippy Check
```bash
cargo +stable clippy --all-targets --all-features --workspace -- -D warnings
```
- ✅ **0 warnings**

### Final Verification
```bash
cargo machete --with-metadata
```
**Result**: No unused dependencies found ✅

## Impact

- **Build time**: Expected slight improvement due to fewer dependencies to compile
- **Binary size**: Potential reduction in binary size
- **Security**: Reduced attack surface by removing unused code
- **Maintainability**: Cleaner dependency tree, easier to understand

## Files Changed

- `crates/mcp-vfs/Cargo.toml`
- `crates/mcp-codegen/Cargo.toml`
- `crates/mcp-core/Cargo.toml`
- `crates/mcp-cli/Cargo.toml`
- `crates/mcp-bridge/Cargo.toml`
- `crates/mcp-skill-generator/Cargo.toml`
- `crates/mcp-examples/Cargo.toml`
- `crates/mcp-introspector/Cargo.toml`
- `crates/mcp-wasm-runtime/Cargo.toml`
- `crates/mcp-skill-store/Cargo.toml`

**Total changes**: 10 files, 36 deletions

## Checklist

- [x] All tests pass (969/969)
- [x] No clippy warnings
- [x] No unused dependencies remain (verified with cargo-machete)
- [x] Changes follow Microsoft Rust Guidelines
- [x] Commit message follows project conventions