### PR TITLE
release: v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
 
   # MSRV check (Minimum Supported Rust Version)
   msrv:
-    name: Check MSRV (1.89)
+    name: Check MSRV (1.91)
     needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -188,10 +188,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust 1.89
+      - name: Install Rust 1.91
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.89"
+          toolchain: "1.91"
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] - 2026-04-21
+
 ### Added
 
 - **`--dry-run` flag for `generate` command**: Preview files that would be generated without writing to disk. Outputs file list with sizes and total size in all supported formats (pretty/text/json). Server connection still runs to produce accurate previews based on real tool definitions.
+
+### Fixed
+
+- **`mcp-execution-server`**: Replaced `.map(...).unwrap_or(0)` with `.map_or(0, ...)` on `Result` to satisfy `clippy::map_unwrap_or` (`pedantic` group). Suppressed `dead_code` warning on `tool_router` field, which is required by the `#[tool_router]` macro but not read directly.
+
+### Changed
+
+- **MSRV**: raised from 1.89 to 1.91
+- **`mcp-execution-files`**: replaced `Path::with_extension("tmp")` with `Path::with_added_extension("tmp")` for atomic writes — more precise semantics (appends suffix rather than replacing the last extension)
+- **Dependencies**: Updated to latest stable versions
+  - `rmcp`: 0.16.0 → 1.5.0 (official Rust MCP SDK — major version, stable API)
+  - `clap` / `clap_complete`: 4.5.x → 4.6.1
+  - `tokio`: 1.49.0 → 1.52.0
+  - `rayon`: 1.11 → 1.12
+  - `rand`: 0.10.0 → 0.10.1
+  - `toml`, `uuid`, `chrono`, `tracing-subscriber`, `which` (minor/patch updates)
+- **CI**: Updated `codecov/codecov-action` v5→v6, `lewagon/wait-on-check-action` 1.5→1.6.1, `actions/upload-artifact` v6→v7, `actions/download-artifact` v7→v8
+
+---
+
+## [0.6.7] - 2026-04-21
+
+### Added
+
+- **`--dry-run` flag for `generate` command**: Preview files that would be generated without writing to disk. Outputs file list with sizes and total size in all supported formats (pretty/text/json). Server connection still runs to produce accurate previews based on real tool definitions.
+
+### Fixed
+
+- **`mcp-execution-server`**: Replaced `.map(...).unwrap_or(0)` with `.map_or(0, ...)` on `Result` to satisfy `clippy::map_unwrap_or` (`pedantic` group). Suppressed `dead_code` warning on `tool_router` field, which is required by the `#[tool_router]` macro but not read directly.
+
+### Changed
+
+- **Dependencies**: Updated to latest stable versions
+  - `rmcp`: 0.16.0 → 1.4.0 (official Rust MCP SDK — major version, stable API)
+  - `clap` / `clap_complete`: 4.5.x → 4.6.1
+  - `tokio`: 1.49.0 → 1.50.0
+  - `rand`: 0.10.0 → 0.10.1
+  - `toml`, `uuid`, `chrono`, `tracing-subscriber`, `which` (minor/patch updates)
+- **CI**: Updated `codecov/codecov-action` from v5 to v6, `lewagon/wait-on-check-action` from 1.5.0 to 1.6.1, `actions/upload-artifact` from v6 to v7, `actions/download-artifact` from v7 to v8
 
 ---
 
@@ -1117,12 +1160,13 @@ Phase 6 (Optimization) is currently OPTIONAL and DEFERRED because:
 
 ---
 
-**Last Updated**: 2026-02-22
-**Version**: 0.6.6 (Production Ready)
+**Last Updated**: 2026-04-21
+**Version**: 0.7.0 (Production Ready)
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/mcp-execution/compare/v0.6.6...HEAD
+[Unreleased]: https://github.com/bug-ops/mcp-execution/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/bug-ops/mcp-execution/compare/v0.6.6...v0.7.0
 [0.6.6]: https://github.com/bug-ops/mcp-execution/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/bug-ops/mcp-execution/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/bug-ops/mcp-execution/compare/v0.6.3...v0.6.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -146,9 +146,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -179,9 +179,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -275,18 +275,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -296,15 +296,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -317,13 +317,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys",
 ]
@@ -624,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -757,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -813,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -861,12 +860,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -888,15 +887,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -916,25 +915,24 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -962,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-cli"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -989,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-codegen"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "handlebars",
@@ -1002,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-core"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1018,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-files"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "dhat",
@@ -1031,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-introspector"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "mcp-execution-core",
@@ -1044,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-server"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1069,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-skill"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "dirs",
  "handlebars",
@@ -1106,9 +1104,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1117,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1171,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1277,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1330,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.0.3"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd9713fe2c91c3c85ac388b31b89de339365d2c995146e630b5e0da9d06526a"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
@@ -1353,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1364,21 +1362,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1459,15 +1457,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64",
@@ -1489,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1514,9 +1512,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1575,9 +1573,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1715,12 +1713,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1773,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1788,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1936,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -1972,11 +1970,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "rand",
  "serde_core",
@@ -2013,11 +2011,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2026,14 +2024,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2044,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2054,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2067,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2110,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2279,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -2291,6 +2289,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2373,18 +2377,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ default-members = [ "crates/*" ]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.6"
+version = "0.7.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.91"
 authors = ["Andrei G <k05h31@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bug-ops/mcp-execution"
@@ -24,22 +24,22 @@ dhat = "0.3"
 dialoguer = "0.12"
 dirs = "6.0"
 handlebars = "6.4"
-mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.6.6" }
-mcp-execution-core = { path = "crates/mcp-core", version = "0.6.6" }
-mcp-execution-files = { path = "crates/mcp-files", version = "0.6.6" }
-mcp-execution-introspector = { path = "crates/mcp-introspector", version = "0.6.6" }
-mcp-execution-server = { path = "crates/mcp-server", version = "0.6.6" }
-mcp-execution-skill = { path = "crates/mcp-skill", version = "0.6.6" }
-rayon = "1.11"
+mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.7.0" }
+mcp-execution-core = { path = "crates/mcp-core", version = "0.7.0" }
+mcp-execution-files = { path = "crates/mcp-files", version = "0.7.0" }
+mcp-execution-introspector = { path = "crates/mcp-introspector", version = "0.7.0" }
+mcp-execution-server = { path = "crates/mcp-server", version = "0.7.0" }
+mcp-execution-skill = { path = "crates/mcp-skill", version = "0.7.0" }
+rayon = "1.12"
 regex = "1.12"
-rmcp = "1.4"
+rmcp = "1.5"
 schemars = "1.2"
 serde = "1.0"
 serde_json = "1.0"
 static_assertions = "1.1"
-tempfile = "3.25"
+tempfile = "3.27"
 thiserror = "2.0"
-tokio = "1.50"
+tokio = "1.52"
 toml = "1.1"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-core)](https://docs.rs/mcp-execution-core)
 [![CI](https://github.com/bug-ops/mcp-execution/actions/workflows/ci.yml/badge.svg)](https://github.com/bug-ops/mcp-execution/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://blog.rust-lang.org/2025/01/23/Rust-1.89.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://blog.rust-lang.org/2025/01/23/Rust-1.91.0.html)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE.md)
 
 Transform any MCP server into executable, type-safe TypeScript tools using progressive loading pattern. Achieve **98% token savings** by loading only what you need.
@@ -82,15 +82,15 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcp-execution-core = "0.6"
-mcp-execution-introspector = "0.6"
-mcp-execution-codegen = "0.6"
+mcp-execution-core = "0.7"
+mcp-execution-introspector = "0.7"
+mcp-execution-codegen = "0.7"
 ```
 
 </details>
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later for building from source.
+> Requires Rust 1.91 or later for building from source.
 
 ## Usage
 
@@ -132,7 +132,7 @@ node ~/.claude/servers/github/createIssue.ts --repo="owner/repo" --title="Bug"
 | **Type-Safe** | Full TypeScript interfaces from MCP JSON schemas |
 | **Lightning Fast** | 526x faster than target (0.19ms for 10 tools) |
 | **100% MCP Compatible** | Works with all MCP servers via [rmcp SDK](https://docs.rs/rmcp) |
-| **Thoroughly Tested** | 556 tests with 100% pass rate |
+| **Thoroughly Tested** | 626 tests with 100% pass rate |
 
 ## Workspace Crates
 
@@ -165,7 +165,10 @@ See [mcp-cli README](crates/mcp-cli) for full reference.
 # Generate TypeScript tools from config (recommended)
 mcp-execution-cli generate --from-config github
 
-# Introspect MCP server from config (v0.6.3+)
+# Preview what would be generated without writing to disk
+mcp-execution-cli generate --from-config github --dry-run
+
+# Introspect MCP server from config
 mcp-execution-cli introspect --from-config github
 
 # Introspect with detailed schemas
@@ -210,7 +213,7 @@ cargo +nightly fmt --workspace # Format
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-cli/README.md
+++ b/crates/mcp-cli/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-cli.svg)](https://crates.io/crates/mcp-execution-cli)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-cli)](https://docs.rs/mcp-execution-cli)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-cli)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 Command-line interface for MCP Code Execution progressive loading. Achieves **98% token savings** by generating one TypeScript file per MCP tool.
@@ -40,7 +40,7 @@ cargo install --path crates/mcp-cli
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later for building from source.
+> Requires Rust 1.91 or later for building from source.
 
 ## Usage
 
@@ -256,7 +256,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-codegen/README.md
+++ b/crates/mcp-codegen/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-codegen.svg)](https://crates.io/crates/mcp-execution-codegen)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-codegen)](https://docs.rs/mcp-execution-codegen)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-codegen)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 Progressive loading TypeScript code generation for MCP tools. Achieves **98% token savings** by generating one file per tool.
@@ -12,7 +12,7 @@ Progressive loading TypeScript code generation for MCP tools. Achieves **98% tok
 
 ```toml
 [dependencies]
-mcp-execution-codegen = "0.6"
+mcp-execution-codegen = "0.7"
 ```
 
 Or with cargo-add:
@@ -22,7 +22,7 @@ cargo add mcp-execution-codegen
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 
@@ -129,7 +129,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-core/README.md
+++ b/crates/mcp-core/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-core.svg)](https://crates.io/crates/mcp-execution-core)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-core)](https://docs.rs/mcp-execution-core)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-core)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 Foundation types, traits, and error handling for MCP Code Execution.
@@ -12,7 +12,7 @@ Foundation types, traits, and error handling for MCP Code Execution.
 
 ```toml
 [dependencies]
-mcp-execution-core = "0.6"
+mcp-execution-core = "0.7"
 ```
 
 Or with cargo-add:
@@ -22,7 +22,7 @@ cargo add mcp-execution-core
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 
@@ -125,7 +125,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-files/README.md
+++ b/crates/mcp-files/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-files.svg)](https://crates.io/crates/mcp-execution-files)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-files)](https://docs.rs/mcp-execution-files)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-files)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 In-memory virtual filesystem for MCP tools organization and export.
@@ -12,7 +12,7 @@ In-memory virtual filesystem for MCP tools organization and export.
 
 ```toml
 [dependencies]
-mcp-execution-files = "0.6"
+mcp-execution-files = "0.7"
 ```
 
 Or with cargo-add:
@@ -22,7 +22,7 @@ cargo add mcp-execution-files
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 
@@ -135,7 +135,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-files/src/builder.rs
+++ b/crates/mcp-files/src/builder.rs
@@ -370,7 +370,7 @@ fn write_file_atomic(base_path: &Path, vfs_path: &str, content: &str) -> Result<
     }
 
     // Atomic write: write to temp file, then rename
-    let temp_path = disk_path.with_extension("tmp");
+    let temp_path = disk_path.with_added_extension("tmp");
 
     fs::write(&temp_path, content).map_err(|e| FilesError::IoError {
         path: temp_path.display().to_string(),

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -631,7 +631,7 @@ fn write_file_atomic(path: &Path, content: &str, options: &ExportOptions) -> Res
 
     if options.atomic {
         // Atomic write: temp file + rename
-        let temp_path = path.with_extension("tmp");
+        let temp_path = path.with_added_extension("tmp");
 
         // Write to temp file
         let mut file = fs::File::create(&temp_path).map_err(|e| FilesError::InvalidPath {

--- a/crates/mcp-introspector/README.md
+++ b/crates/mcp-introspector/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-introspector.svg)](https://crates.io/crates/mcp-execution-introspector)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-introspector)](https://docs.rs/mcp-execution-introspector)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-introspector)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 MCP server introspection using the official [rmcp](https://docs.rs/rmcp) SDK.
@@ -12,7 +12,7 @@ MCP server introspection using the official [rmcp](https://docs.rs/rmcp) SDK.
 
 ```toml
 [dependencies]
-mcp-execution-introspector = "0.6"
+mcp-execution-introspector = "0.7"
 ```
 
 Or with cargo-add:
@@ -22,7 +22,7 @@ cargo add mcp-execution-introspector
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 
@@ -131,7 +131,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-server/README.md
+++ b/crates/mcp-server/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-server.svg)](https://crates.io/crates/mcp-execution-server)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-server)](https://docs.rs/mcp-execution-server)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-server)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 MCP server for generating progressive loading TypeScript files. Achieves **98% token savings** by leveraging Claude's natural language understanding for tool categorization.
@@ -18,7 +18,7 @@ cargo build --release -p mcp-execution-server
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 
@@ -141,7 +141,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 

--- a/crates/mcp-skill/README.md
+++ b/crates/mcp-skill/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcp-execution-skill.svg)](https://crates.io/crates/mcp-execution-skill)
 [![docs.rs](https://img.shields.io/docsrs/mcp-execution-skill)](https://docs.rs/mcp-execution-skill)
 [![codecov](https://codecov.io/gh/bug-ops/mcp-execution/graph/badge.svg?token=2UEW36O9AN&flag=mcp-skill)](https://codecov.io/gh/bug-ops/mcp-execution)
-[![MSRV](https://img.shields.io/badge/MSRV-1.89-blue.svg)](https://github.com/bug-ops/mcp-execution)
+[![MSRV](https://img.shields.io/badge/MSRV-1.91-blue.svg)](https://github.com/bug-ops/mcp-execution)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE.md)
 
 Skill generation for MCP progressive loading. Generates Claude Code skill files (SKILL.md) from TypeScript tool files.
@@ -18,11 +18,11 @@ Or add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcp-execution-skill = "0.6"
+mcp-execution-skill = "0.7"
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.89 or later.
+> Requires Rust 1.91 or later.
 
 ## Usage
 
@@ -140,7 +140,7 @@ This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-executi
 
 ## MSRV Policy
 
-Minimum Supported Rust Version: **1.89**
+Minimum Supported Rust Version: **1.91**
 
 MSRV increases are considered minor version bumps.
 


### PR DESCRIPTION
## Summary

- Bump version from 0.6.6 to 0.7.0
- Raise MSRV from 1.89 to 1.91 (driven by `clap 4.6` requiring 1.85 and availability of `Path::with_added_extension`)
- Update CHANGELOG.md with release section
- Update CI MSRV job from 1.89 to 1.91

## Changes included

- `feat(cli)`: `--dry-run` flag for `generate` command
- `fix(server)`: clippy `map_unwrap_or` and `dead_code` warnings in `GeneratorService`
- `chore`: MSRV 1.89 → 1.91; `with_added_extension` in atomic file writes
- `chore(deps)`: rmcp 0.16→1.5, clap 4.6, tokio 1.52, rayon 1.12, and minor dep updates
- `ci`: action version bumps (codecov v6, upload/download-artifact, wait-on-check-action)

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] MSRV updated in Cargo.toml and CI workflow
- [x] 626 tests passing
- [x] clippy clean
- [x] fmt clean