### PR TITLE
fix(cli,server): report correct binary name and server identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-cli`**: `--version` output and generated shell completions now correctly
+  report `mcp-execution-cli` instead of `mcp-cli`. Removed hardcoded `#[command(name = "mcp-cli")]`
+  so clap derives the binary name from argv\[0\] at runtime (issue #89).
+- **`mcp-execution-server`**: MCP initialization handshake now correctly reports
+  `"mcp-execution-server"` and the crate version instead of `"rmcp"` / `"1.5.0"`. Replaced
+  `Implementation::from_build_env()` (which expands `env!()` at rmcp's compile time) with a
+  direct construction using `env!("CARGO_PKG_NAME")` and `env!("CARGO_PKG_VERSION")` at the
+  call site in `service.rs` (issue #85).
 - **`mcp-execution-introspector`**: Server `name` now read from MCP handshake
   (`peer_info().server_info.name`) instead of `config.command` (issue #84).
 - **`mcp-execution-introspector`**: Server `version` now read from MCP handshake

--- a/crates/mcp-cli/src/cli.rs
+++ b/crates/mcp-cli/src/cli.rs
@@ -15,7 +15,6 @@ use crate::actions::ServerAction;
 /// This CLI provides secure execution of MCP tools in a WebAssembly sandbox,
 /// achieving 90-98% token savings through progressive tool loading.
 #[derive(Parser, Debug)]
-#[command(name = "mcp-cli")]
 #[command(version, about, long_about = None)]
 #[command(author = "MCP Execution Team")]
 pub struct Cli {

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -519,7 +519,7 @@ impl ServerHandler for GeneratorService {
         let mut info = ServerInfo::default();
         info.protocol_version = ProtocolVersion::V_2025_06_18;
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
-        info.server_info = Implementation::from_build_env();
+        info.server_info = Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
             "Generate progressive loading TypeScript files for MCP servers. \
              Use introspect_server to discover tools, then save_categorized_tools \
@@ -783,6 +783,8 @@ mod tests {
         assert_eq!(info.protocol_version, ProtocolVersion::V_2025_06_18);
         assert!(info.capabilities.tools.is_some());
         assert!(info.instructions.is_some());
+        assert_eq!(info.server_info.name, env!("CARGO_PKG_NAME"));
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- Remove hardcoded `#[command(name = "mcp-cli")]` from `Cli` in `crates/mcp-cli/src/cli.rs` so clap derives the binary name from argv[0] at runtime — fixes `--version` output and generated shell completions targeting the wrong name
- Replace `Implementation::from_build_env()` with `Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))` in `crates/mcp-server/src/service.rs` — fixes MCP handshake reporting `rmcp/1.5.0` instead of `mcp-execution-server/<version>`

Closes #89, #85.

## Test plan

- [ ] `cargo run -p mcp-execution-cli -- --version` outputs `mcp-execution-cli <version>`
- [ ] `cargo run -p mcp-execution-cli -- completions bash | head -1` shows `_mcp-execution-cli()`
- [ ] `cargo run -p mcp-execution-cli -- completions zsh | head -1` shows `#compdef mcp-execution-cli`
- [ ] MCP initialize handshake returns `"serverInfo": {"name": "mcp-execution-server", "version": "<version>"}`
- [ ] All 636 unit tests pass (`cargo nextest run --all-features --workspace`)
- [ ] `test_get_info` now asserts correct name and version via `env!("CARGO_PKG_NAME")` / `env!("CARGO_PKG_VERSION")`