### PR TITLE
fix(cli,skill): unify config source, write SKILL.md, fix TS param parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **`skill` command stdout shape changed** (#82): previously printed a raw JSON blob of `GenerateSkillResult` (the generation context). Now prints a compact `SkillWriteResult` (`{success, output_path, bytes_written, tool_count}`). Scripts or tooling parsing the old JSON output must be updated.
+
 ### Fixed
 
+- **`server` subcommand** (#81): unified all server subcommands (`list`, `info`, `validate`) to read from `~/.claude/mcp.json` — previously `server list` used the Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`) while `introspect` and `generate --from-config` used `mcp.json`. Removed `ServerManager` and all Claude Desktop config logic. `load_mcp_config_from(path)` is now the primary testable entry point; `load_mcp_config()` is a thin wrapper. `server list` returns an empty list (no error) when the config file does not exist.
+- **`skill` command** (#82): command now renders SKILL.md directly via a new Handlebars template (`skill-md.hbs`) and writes the file atomically (temp-then-rename), instead of printing a raw JSON dump of the generation context to stdout and logging a false "Output path" line.
+- **TypeScript property parser** (#83): `parse_parameters` now iterates interface body line-by-line, skipping blank lines and comment lines (`//`, `/*`, `*`) before applying the regex. Trailing `//` and `/* */` inline comments are stripped (bounded before string-literal type delimiters to avoid false truncation). Replaced the unanchored `PROP_REGEX` with the anchored `PROP_LINE_REGEX` to prevent false positives from `JSDoc` `@default` and similar comment content being extracted as parameters.
 - **`mcp-execution-cli`**: `--version` output and generated shell completions now correctly
   report `mcp-execution-cli` instead of `mcp-cli`. Removed hardcoded `#[command(name = "mcp-cli")]`
   so clap derives the binary name from argv\[0\] at runtime (issue #89).

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -1,66 +1,186 @@
 //! Common utilities shared across CLI commands.
 //!
-//! Provides shared functionality for building server configurations from CLI arguments.
+//! Provides shared functionality for building server configurations from CLI arguments
+//! and loading MCP server definitions from `~/.claude/mcp.json`.
 
 use anyhow::{Context, Result, bail};
 use mcp_execution_core::{ServerConfig, ServerConfigBuilder, ServerId};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-/// MCP configuration file structure (~/.claude/mcp.json)
+/// MCP configuration file structure (`~/.claude/mcp.json`).
+///
+/// The `mcp_servers` field defaults to an empty map so that an absent file or
+/// a file containing only `{}` does not produce a deserialization error.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct McpConfig {
-    mcp_servers: HashMap<String, McpServerConfig>,
+pub struct McpConfig {
+    /// Map of server name → server configuration entry.
+    #[serde(default)]
+    pub mcp_servers: HashMap<String, McpServerEntry>,
 }
 
-/// Individual MCP server configuration
-#[derive(Debug, Deserialize)]
-struct McpServerConfig {
-    command: String,
+/// Individual MCP server configuration entry from `mcp.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct McpServerEntry {
+    /// Command to execute (binary name or absolute path).
+    pub command: String,
+    /// Arguments to pass to the command.
     #[serde(default)]
-    args: Vec<String>,
+    pub args: Vec<String>,
+    /// Environment variables for the server process.
     #[serde(default)]
-    env: HashMap<String, String>,
+    pub env: HashMap<String, String>,
 }
 
-/// Loads MCP configuration from ~/.claude/mcp.json
+/// Loads MCP configuration from the given path.
+///
+/// This is the primary, testable entry point. [`load_mcp_config`] is a thin
+/// wrapper that resolves the default `~/.claude/mcp.json` location.
 ///
 /// # Errors
 ///
-/// Returns error if:
-/// - Home directory cannot be determined
-/// - Config file cannot be read
-/// - JSON is malformed
-fn load_mcp_config() -> Result<McpConfig> {
-    let home = dirs::home_dir().context("failed to get home directory")?;
-    let config_path = home.join(".claude").join("mcp.json");
+/// Returns an error if the file cannot be read or the JSON is malformed.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_cli::commands::common::load_mcp_config_from;
+/// use std::path::Path;
+///
+/// let config = load_mcp_config_from(Path::new("/tmp/mcp.json")).unwrap();
+/// println!("{} servers configured", config.mcp_servers.len());
+/// ```
+pub fn load_mcp_config_from(path: &Path) -> Result<McpConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read MCP config from {}", path.display()))?;
 
-    let content = std::fs::read_to_string(&config_path)
-        .with_context(|| "failed to read MCP config from ~/.claude/mcp.json")?;
-
-    let config: McpConfig =
-        serde_json::from_str(&content).context("failed to parse MCP config JSON")?;
-
-    Ok(config)
+    serde_json::from_str(&content).context("failed to parse MCP config JSON")
 }
 
-/// Loads server configuration from ~/.claude/mcp.json by server name.
+/// Loads MCP configuration from `~/.claude/mcp.json`.
+///
+/// Delegates to [`load_mcp_config_from`] after resolving the default path.
+///
+/// # Errors
+///
+/// Returns an error if the home directory cannot be determined, the file
+/// cannot be read, or the JSON is malformed.
+pub fn load_mcp_config() -> Result<McpConfig> {
+    let home = dirs::home_dir().context("failed to get home directory")?;
+    load_mcp_config_from(&home.join(".claude").join("mcp.json"))
+}
+
+/// Lists all servers defined in the given `mcp.json` file.
+///
+/// Returns an empty list when the file does not exist — the primary testable
+/// entry point for the "fresh machine" code path (no config file yet).
+///
+/// # Errors
+///
+/// Returns an error if the file exists but cannot be read or parsed.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_cli::commands::common::list_mcp_servers_from;
+/// use std::path::Path;
+///
+/// let servers = list_mcp_servers_from(Path::new("/tmp/mcp.json")).unwrap();
+/// println!("{} servers", servers.len());
+/// ```
+pub fn list_mcp_servers_from(path: &Path) -> Result<Vec<(String, McpServerEntry)>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let config = load_mcp_config_from(path)?;
+    Ok(config.mcp_servers.into_iter().collect())
+}
+
+/// Lists all servers defined in `~/.claude/mcp.json`.
+///
+/// Returns an empty list when the config file does not exist so that
+/// `server list` shows a clear empty result rather than hard-failing.
+///
+/// Delegates to [`list_mcp_servers_from`] after resolving the default path.
+///
+/// # Errors
+///
+/// Returns an error if the home directory cannot be determined, or the config
+/// file exists but cannot be read or parsed.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_cli::commands::common::list_mcp_servers;
+///
+/// for (name, entry) in list_mcp_servers().unwrap() {
+///     println!("{}: {} {:?}", name, entry.command, entry.args);
+/// }
+/// ```
+pub fn list_mcp_servers() -> Result<Vec<(String, McpServerEntry)>> {
+    let home = dirs::home_dir().context("failed to get home directory")?;
+    list_mcp_servers_from(&home.join(".claude").join("mcp.json"))
+}
+
+/// Retrieves a named server from `~/.claude/mcp.json`.
 ///
 /// # Arguments
 ///
-/// * `name` - Server name from mcp.json (e.g., "github")
+/// * `name` - Server name as defined under `mcpServers` in `mcp.json`
 ///
 /// # Returns
 ///
-/// Returns `(ServerId, ServerConfig)` if server is found in config.
+/// A tuple of `(ServerId, ServerConfig, McpServerEntry)`:
+/// - [`ServerId`] — typed server identifier
+/// - [`ServerConfig`] — ready-to-use connection config for `Introspector`
+/// - [`McpServerEntry`] — raw entry for display purposes (command, args, env)
 ///
 /// # Errors
 ///
-/// Returns error if:
-/// - Config file doesn't exist or is malformed
-/// - Server name not found in config
+/// Returns an error if the config file is missing, malformed, or the named
+/// server is not present.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_cli::commands::common::get_mcp_server;
+///
+/// let (id, _config, entry) = get_mcp_server("github").unwrap();
+/// assert_eq!(id.as_str(), "github");
+/// println!("command: {}", entry.command);
+/// ```
+pub fn get_mcp_server(name: &str) -> Result<(ServerId, ServerConfig, McpServerEntry)> {
+    let config = load_mcp_config()?;
+
+    let entry = config
+        .mcp_servers
+        .get(name)
+        .with_context(|| {
+            format!(
+                "server '{name}' not found in ~/.claude/mcp.json\n\
+                 Hint: ensure the server is defined in ~/.claude/mcp.json under \"mcpServers\""
+            )
+        })?
+        .clone();
+
+    let server_config = build_core_config(&entry);
+    Ok((ServerId::new(name), server_config, entry))
+}
+
+/// Loads server configuration from `~/.claude/mcp.json` by server name.
+///
+/// Convenience wrapper around [`get_mcp_server`] that drops the raw entry.
+///
+/// # Arguments
+///
+/// * `name` - Server name from `mcp.json` (e.g., `"github"`)
+///
+/// # Errors
+///
+/// Returns an error if the config file is missing, malformed, or the server
+/// name is not present.
 ///
 /// # Examples
 ///
@@ -71,27 +191,23 @@ fn load_mcp_config() -> Result<McpConfig> {
 /// assert_eq!(id.as_str(), "github");
 /// ```
 pub fn load_server_from_config(name: &str) -> Result<(ServerId, ServerConfig)> {
-    let config = load_mcp_config()?;
+    let (id, config, _) = get_mcp_server(name)?;
+    Ok((id, config))
+}
 
-    let server_config = config.mcp_servers.get(name).with_context(|| {
-        format!(
-            "server '{name}' not found in MCP config at ~/.claude/mcp.json\n\
-             Hint: Use 'mcp-execution-cli server list' to see available servers"
-        )
-    })?;
+/// Builds a core [`ServerConfig`] from an [`McpServerEntry`].
+fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
+    let mut builder = ServerConfig::builder().command(entry.command.clone());
 
-    let id = ServerId::new(name);
-    let mut builder = ServerConfig::builder().command(server_config.command.clone());
-
-    if !server_config.args.is_empty() {
-        builder = builder.args(server_config.args.clone());
+    if !entry.args.is_empty() {
+        builder = builder.args(entry.args.clone());
     }
 
-    for (key, value) in &server_config.env {
+    for (key, value) in &entry.env {
         builder = builder.env(key.clone(), value.clone());
     }
 
-    Ok((id, builder.build()))
+    builder.build()
 }
 
 /// Builds `ServerConfig` from CLI arguments.
@@ -208,6 +324,79 @@ pub fn build_server_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    /// Creates a temporary mcp.json file for testing.
+    fn create_test_config(content: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_load_mcp_config_from_valid() {
+        let json = r#"{"mcpServers": {"github": {"command": "node", "args": ["server.js"]}}}"#;
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        assert_eq!(config.mcp_servers.len(), 1);
+        assert!(config.mcp_servers.contains_key("github"));
+    }
+
+    #[test]
+    fn test_load_mcp_config_from_empty_servers() {
+        // mcp_servers defaults to empty map when key is absent
+        let json = r"{}";
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        assert!(config.mcp_servers.is_empty());
+    }
+
+    #[test]
+    fn test_load_mcp_config_from_minimal_server() {
+        // Server with only command (args and env should default)
+        let json = r#"{"mcpServers": {"minimal": {"command": "python"}}}"#;
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        let entry = &config.mcp_servers["minimal"];
+        assert_eq!(entry.command, "python");
+        assert!(entry.args.is_empty());
+        assert!(entry.env.is_empty());
+    }
+
+    #[test]
+    fn test_load_mcp_config_from_multiple_servers() {
+        let json = r#"{
+            "mcpServers": {
+                "server1": {"command": "node", "args": ["s1.js"]},
+                "server2": {"command": "python", "args": ["s2.py"]}
+            }
+        }"#;
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        assert_eq!(config.mcp_servers.len(), 2);
+        assert!(config.mcp_servers.contains_key("server1"));
+        assert!(config.mcp_servers.contains_key("server2"));
+    }
+
+    #[test]
+    fn test_load_mcp_config_from_not_found() {
+        let result = load_mcp_config_from(Path::new("/nonexistent/path/mcp.json"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("failed to read"));
+    }
+
+    #[test]
+    fn test_load_mcp_config_from_malformed_json() {
+        let file = create_test_config("not valid json");
+        let result = load_mcp_config_from(file.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("parse MCP config"));
+    }
 
     #[test]
     fn test_build_server_config_stdio() {
@@ -620,20 +809,16 @@ mod tests {
 
     #[test]
     fn test_load_server_from_config_not_found() {
-        // Test with non-existent server name
-        let result = load_server_from_config("nonexistent");
-
         // Should fail because either config doesn't exist or server not in it
+        let result = load_server_from_config("nonexistent");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_load_mcp_config_no_file() {
         // Should fail gracefully when config file doesn't exist
-        let result = load_mcp_config();
+        let result = load_mcp_config_from(Path::new("/nonexistent/mcp.json"));
 
-        // Can fail either because home dir not found or config file missing
-        // Both are acceptable error states
         if let Err(error) = result {
             let error = error.to_string();
             assert!(
@@ -642,5 +827,46 @@ mod tests {
                 "Expected config read error or home dir error, got: {error}"
             );
         }
+    }
+
+    #[test]
+    fn test_list_mcp_servers_from_missing_file_returns_empty() {
+        // GAP-1: the primary UX fix for #81 — missing config → empty list, not error.
+        let result = list_mcp_servers_from(Path::new("/nonexistent/path/mcp.json"));
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_list_mcp_servers_from_valid_file() {
+        let json = r#"{"mcpServers": {"github": {"command": "node"}}}"#;
+        let file = create_test_config(json);
+
+        let servers = list_mcp_servers_from(file.path()).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].0, "github");
+        assert_eq!(servers[0].1.command, "node");
+    }
+
+    #[test]
+    fn test_list_mcp_servers_from_empty_servers_key() {
+        let json = r#"{"mcpServers": {}}"#;
+        let file = create_test_config(json);
+
+        let servers = list_mcp_servers_from(file.path()).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn test_load_mcp_config_serde_default_on_missing_mcp_servers() {
+        // When mcp.json has no mcpServers key, should deserialize to empty map
+        let json = r#"{"someOtherKey": "value"}"#;
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        assert!(
+            config.mcp_servers.is_empty(),
+            "missing mcpServers key must produce empty map, not error"
+        );
     }
 }

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -980,8 +980,9 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("not found in MCP config")
-                || err_msg.contains("failed to read MCP config"),
+            err_msg.contains("not found in")
+                || err_msg.contains("failed to read MCP config")
+                || err_msg.contains("mcp.json"),
             "Expected config-related error, got: {err_msg}"
         );
     }

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -1,47 +1,22 @@
 //! Server command implementation.
 //!
-//! Manages MCP server connections and configurations.
+//! Manages MCP server listing, inspection, and validation using
+//! `~/.claude/mcp.json` as the single source of truth for server definitions.
 
 use crate::actions::ServerAction;
+use crate::commands::common::{McpServerEntry, get_mcp_server, list_mcp_servers};
 use anyhow::{Context, Result};
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
-use mcp_execution_core::{ServerConfig as CoreServerConfig, ServerId};
 use mcp_execution_introspector::Introspector;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::PathBuf;
-use tracing::{debug, info, warn};
-
-/// Claude Desktop configuration file structure.
-///
-/// Represents the JSON structure of `claude_desktop_config.json`.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-struct ClaudeDesktopConfig {
-    #[serde(rename = "mcpServers")]
-    mcp_execution_servers: HashMap<String, ServerConfig>,
-}
-
-/// MCP server configuration from Claude Desktop config.
-///
-/// Represents a single server entry with command, args, and environment variables.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-struct ServerConfig {
-    /// Command to execute (e.g., "node", "python", "npx")
-    command: String,
-    /// Command arguments
-    #[serde(default)]
-    args: Vec<String>,
-    /// Environment variables
-    #[serde(default)]
-    env: HashMap<String, String>,
-}
+use serde::Serialize;
+use tracing::{info, warn};
 
 /// Status of a configured server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ServerStatus {
-    /// Server is available and responds
+    /// Server command exists and is executable.
     Available,
-    /// Server command not found or not executable
+    /// Server command not found in PATH.
     Unavailable,
 }
 
@@ -57,230 +32,64 @@ impl ServerStatus {
 /// Represents a configured server entry for output.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ServerEntry {
-    /// Server identifier
+    /// Server identifier.
     pub id: String,
-    /// Command used to start the server
+    /// Command used to start the server.
     pub command: String,
-    /// Current server status
+    /// Current server status.
     pub status: String,
 }
 
 /// List of configured servers.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ServerList {
-    /// All configured servers
+    /// All configured servers.
     pub servers: Vec<ServerEntry>,
 }
 
 /// Detailed server information for output.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ServerInfo {
-    /// Server identifier
+    /// Server identifier.
     pub id: String,
-    /// Server name from introspection
+    /// Server name from introspection.
     pub name: String,
-    /// Server version
+    /// Server version.
     pub version: String,
-    /// Command used to start the server
+    /// Command used to start the server.
     pub command: String,
-    /// Current server status
+    /// Current server status.
     pub status: String,
-    /// Available tools
+    /// Available tools.
     pub tools: Vec<ToolSummary>,
-    /// Server capabilities
+    /// Server capabilities.
     pub capabilities: Vec<String>,
 }
 
 /// Tool summary for output.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ToolSummary {
-    /// Tool name
+    /// Tool name.
     pub name: String,
-    /// Tool description
+    /// Tool description.
     pub description: String,
 }
 
 /// Validation result for a server command.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ValidationResult {
-    /// The validated command
+    /// The validated command.
     pub command: String,
-    /// Whether the command is valid
+    /// Whether the command is valid.
     pub valid: bool,
-    /// Validation message
+    /// Validation message.
     pub message: String,
-}
-
-/// Manages MCP server discovery and validation.
-///
-/// Reads Claude Desktop configuration and provides server management operations.
-#[derive(Debug)]
-struct ServerManager {
-    config_path: PathBuf,
-}
-
-impl ServerManager {
-    /// Creates a new server manager.
-    ///
-    /// Discovers the Claude Desktop config file location automatically.
-    fn new() -> Result<Self> {
-        let config_path = Self::find_config_path()?;
-        Ok(Self { config_path })
-    }
-
-    /// Finds the Claude Desktop configuration file.
-    ///
-    /// Searches in platform-specific locations:
-    /// - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-    /// - Linux: `~/.config/Claude/claude_desktop_config.json`
-    /// - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-    fn find_config_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().context("Failed to determine home directory")?;
-
-        let paths = if cfg!(target_os = "macos") {
-            vec![
-                home.join("Library")
-                    .join("Application Support")
-                    .join("Claude")
-                    .join("claude_desktop_config.json"),
-            ]
-        } else if cfg!(target_os = "windows") {
-            let appdata = std::env::var("APPDATA")
-                .map_or_else(|_| home.join("AppData").join("Roaming"), PathBuf::from);
-            vec![appdata.join("Claude").join("claude_desktop_config.json")]
-        } else {
-            // Linux and other Unix-like systems
-            vec![
-                home.join(".config")
-                    .join("Claude")
-                    .join("claude_desktop_config.json"),
-            ]
-        };
-
-        // Check environment variable override
-        if let Ok(custom_path) = std::env::var("CLAUDE_CONFIG_PATH") {
-            let custom = PathBuf::from(custom_path);
-            if custom.exists() {
-                debug!("Using config from CLAUDE_CONFIG_PATH: {}", custom.display());
-                return Ok(custom);
-            }
-        }
-
-        // Find first existing path
-        for path in paths {
-            if path.exists() {
-                debug!("Found Claude Desktop config at: {}", path.display());
-                return Ok(path);
-            }
-        }
-
-        anyhow::bail!(
-            "Claude Desktop configuration not found. \
-             Please ensure Claude Desktop is installed or set CLAUDE_CONFIG_PATH environment variable."
-        )
-    }
-
-    /// Reads and parses the Claude Desktop configuration file.
-    fn read_config(&self) -> Result<ClaudeDesktopConfig> {
-        let contents = std::fs::read_to_string(&self.config_path).context(format!(
-            "Failed to read config file: {}",
-            self.config_path.display()
-        ))?;
-
-        let config: ClaudeDesktopConfig = serde_json::from_str(&contents).context(format!(
-            "Failed to parse config file: {}",
-            self.config_path.display()
-        ))?;
-
-        Ok(config)
-    }
-
-    /// Lists all configured servers.
-    fn list_servers(&self) -> Result<Vec<(String, ServerConfig)>> {
-        let config = self.read_config()?;
-        Ok(config.mcp_execution_servers.into_iter().collect())
-    }
-
-    /// Gets configuration for a specific server.
-    fn get_server_config(&self, server_name: &str) -> Result<ServerConfig> {
-        let config = self.read_config()?;
-        config
-            .mcp_execution_servers
-            .get(server_name)
-            .cloned()
-            .context(format!("Server '{server_name}' not found in configuration"))
-    }
-
-    /// Builds the full command string for a server.
-    fn build_command_string(config: &ServerConfig) -> String {
-        if config.args.is_empty() {
-            config.command.clone()
-        } else {
-            format!("{} {}", config.command, config.args.join(" "))
-        }
-    }
-
-    /// Checks if a command is executable.
-    fn check_command_exists(command: &str) -> bool {
-        which::which(command).is_ok()
-    }
-
-    /// Validates a server by attempting to connect and introspect it.
-    async fn validate_server(&self, server_name: &str) -> Result<ServerStatus> {
-        let config = self.get_server_config(server_name)?;
-
-        // First check if command exists
-        if !Self::check_command_exists(&config.command) {
-            warn!(
-                "Command '{}' not found in PATH for server '{}'",
-                config.command, server_name
-            );
-            return Ok(ServerStatus::Unavailable);
-        }
-
-        // Try to connect and introspect
-        match self.introspect_server(server_name).await {
-            Ok(_) => Ok(ServerStatus::Available),
-            Err(e) => {
-                warn!("Failed to introspect server '{}': {}", server_name, e);
-                Ok(ServerStatus::Unavailable)
-            }
-        }
-    }
-
-    /// Introspects a server using mcp-introspector.
-    async fn introspect_server(
-        &self,
-        server_name: &str,
-    ) -> Result<mcp_execution_introspector::ServerInfo> {
-        let config = self.get_server_config(server_name)?;
-
-        let mut introspector = Introspector::new();
-        let server_id = ServerId::new(server_name);
-
-        // Build ServerConfig with proper args and env
-        let mut builder = CoreServerConfig::builder().command(config.command.clone());
-
-        if !config.args.is_empty() {
-            builder = builder.args(config.args.clone());
-        }
-
-        for (key, value) in &config.env {
-            builder = builder.env(key.clone(), value.clone());
-        }
-
-        let server_config = builder.build();
-
-        introspector
-            .discover_server(server_id, &server_config)
-            .await
-            .context(format!("Failed to introspect server '{server_name}'"))
-    }
 }
 
 /// Runs the server command.
 ///
-/// Manages server connections, listing, and validation.
+/// Manages server listing, detailed info, and validation.
+/// All server definitions are loaded from `~/.claude/mcp.json`.
 ///
 /// # Arguments
 ///
@@ -289,7 +98,7 @@ impl ServerManager {
 ///
 /// # Errors
 ///
-/// Returns an error if server operation fails.
+/// Returns an error if the server operation fails.
 ///
 /// # Examples
 ///
@@ -317,18 +126,15 @@ pub async fn run(action: ServerAction, output_format: OutputFormat) -> Result<Ex
     }
 }
 
-/// Lists all configured servers.
+/// Lists all servers configured in `~/.claude/mcp.json`.
 ///
-/// Reads Claude Desktop configuration and returns list of all servers with their status.
+/// Returns an empty list (not an error) when the config file does not exist.
 async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
-    let manager = ServerManager::new().context("Failed to initialize server manager")?;
-
-    let servers = manager
-        .list_servers()
-        .context("Failed to read server configuration")?;
+    let servers = list_mcp_servers()
+        .context("failed to read server configuration from ~/.claude/mcp.json")?;
 
     if servers.is_empty() {
-        info!("No MCP servers configured in Claude Desktop");
+        info!("No MCP servers configured in ~/.claude/mcp.json");
         let server_list = ServerList {
             servers: Vec::new(),
         };
@@ -337,11 +143,10 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    // Build server entries
     let mut entries = Vec::new();
-    for (name, config) in servers {
-        let command = ServerManager::build_command_string(&config);
-        let status = if ServerManager::check_command_exists(&config.command) {
+    for (name, entry) in servers {
+        let command = build_command_string(&entry);
+        let status = if check_command_exists(&entry.command) {
             ServerStatus::Available
         } else {
             ServerStatus::Unavailable
@@ -355,7 +160,6 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
     }
 
     let server_list = ServerList { servers: entries };
-
     let formatted = crate::formatters::format_output(&server_list, output_format)?;
     println!("{formatted}");
 
@@ -366,19 +170,19 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
 ///
 /// Connects to the server and introspects its capabilities, tools, and status.
 async fn show_server_info(server: String, output_format: OutputFormat) -> Result<ExitCode> {
-    let manager = ServerManager::new().context("Failed to initialize server manager")?;
+    let (server_id, server_config, entry) = get_mcp_server(&server)
+        .with_context(|| format!("server '{server}' not found in ~/.claude/mcp.json"))?;
 
-    let config = manager
-        .get_server_config(&server)
-        .context(format!("Server '{server}' not found in configuration"))?;
+    let command = build_command_string(&entry);
 
-    let command = ServerManager::build_command_string(&config);
-
-    // Try to introspect the server
     info!("Introspecting server '{}'...", server);
-    match manager.introspect_server(&server).await {
+
+    let mut introspector = Introspector::new();
+    match introspector
+        .discover_server(server_id, &server_config)
+        .await
+    {
         Ok(introspected) => {
-            // Successfully introspected
             let mut capabilities = Vec::new();
             if introspected.capabilities.supports_tools {
                 capabilities.push("tools".to_string());
@@ -415,7 +219,6 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
             Ok(ExitCode::SUCCESS)
         }
         Err(e) => {
-            // Failed to introspect - return basic info
             warn!("Failed to introspect server '{}': {}", server, e);
 
             let server_info = ServerInfo {
@@ -431,22 +234,17 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
             let formatted = crate::formatters::format_output(&server_info, output_format)?;
             println!("{formatted}");
 
-            // Return error code since introspection failed
             Ok(ExitCode::ERROR)
         }
     }
 }
 
-/// Validates a server by checking if it can be reached and introspected.
+/// Validates a server by checking its command and attempting introspection.
 ///
-/// This validates a server name (not a raw command). The server must be configured
-/// in Claude Desktop configuration.
+/// The server must be configured in `~/.claude/mcp.json`.
 async fn validate_command(server_name: String, output_format: OutputFormat) -> Result<ExitCode> {
-    let manager = ServerManager::new().context("Failed to initialize server manager")?;
-
-    // Get server configuration
-    let config = match manager.get_server_config(&server_name) {
-        Ok(cfg) => cfg,
+    let (server_id, server_config, entry) = match get_mcp_server(&server_name) {
+        Ok(result) => result,
         Err(e) => {
             let result = ValidationResult {
                 command: server_name,
@@ -459,24 +257,26 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
         }
     };
 
-    let command = ServerManager::build_command_string(&config);
+    let command = build_command_string(&entry);
     info!("Validating server '{}'...", server_name);
 
-    // Check if command exists
-    if !ServerManager::check_command_exists(&config.command) {
+    if !check_command_exists(&entry.command) {
         let result = ValidationResult {
             command: command.clone(),
             valid: false,
-            message: format!("Command '{}' not found in PATH", config.command),
+            message: format!("Command '{}' not found in PATH", entry.command),
         };
         let formatted = crate::formatters::format_output(&result, output_format)?;
         println!("{formatted}");
         return Ok(ExitCode::ERROR);
     }
 
-    // Try to connect and introspect
-    match manager.validate_server(&server_name).await? {
-        ServerStatus::Available => {
+    let mut introspector = Introspector::new();
+    match introspector
+        .discover_server(server_id, &server_config)
+        .await
+    {
+        Ok(_) => {
             let result = ValidationResult {
                 command,
                 valid: true,
@@ -488,7 +288,11 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
             println!("{formatted}");
             Ok(ExitCode::SUCCESS)
         }
-        ServerStatus::Unavailable => {
+        Err(e) => {
+            warn!(
+                "Failed to introspect server '{}' during validation: {}",
+                server_name, e
+            );
             let result = ValidationResult {
                 command,
                 valid: false,
@@ -503,18 +307,24 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
     }
 }
 
+/// Builds a displayable command string from a server entry.
+fn build_command_string(entry: &McpServerEntry) -> String {
+    if entry.args.is_empty() {
+        entry.command.clone()
+    } else {
+        format!("{} {}", entry.command, entry.args.join(" "))
+    }
+}
+
+/// Returns `true` if the given command binary is available in PATH.
+fn check_command_exists(command: &str) -> bool {
+    which::which(command).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-
-    /// Creates a temporary config file for testing.
-    fn create_test_config(content: &str) -> tempfile::NamedTempFile {
-        let mut file = tempfile::NamedTempFile::new().unwrap();
-        file.write_all(content.as_bytes()).unwrap();
-        file.flush().unwrap();
-        file
-    }
+    use std::collections::HashMap;
 
     #[test]
     fn test_server_status_as_str() {
@@ -523,175 +333,34 @@ mod tests {
     }
 
     #[test]
-    fn test_server_config_deserialization() {
-        let json = r#"{
-            "command": "node",
-            "args": ["/path/to/server.js"],
-            "env": {"KEY": "value"}
-        }"#;
-
-        let config: ServerConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.command, "node");
-        assert_eq!(config.args, vec!["/path/to/server.js"]);
-        assert_eq!(config.env.get("KEY"), Some(&"value".to_string()));
-    }
-
-    #[test]
-    fn test_server_config_deserialization_minimal() {
-        let json = r#"{
-            "command": "python"
-        }"#;
-
-        let config: ServerConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.command, "python");
-        assert!(config.args.is_empty());
-        assert!(config.env.is_empty());
-    }
-
-    #[test]
-    fn test_claude_desktop_config_deserialization() {
-        let json = r#"{
-            "mcpServers": {
-                "test-server": {
-                    "command": "node",
-                    "args": ["server.js"]
-                }
-            }
-        }"#;
-
-        let config: ClaudeDesktopConfig = serde_json::from_str(json).unwrap();
-        assert!(config.mcp_execution_servers.contains_key("test-server"));
-    }
-
-    #[test]
     fn test_build_command_string_no_args() {
-        let config = ServerConfig {
+        let entry = McpServerEntry {
             command: "node".to_string(),
             args: Vec::new(),
-            env: HashMap::new(),
+            env: HashMap::default(),
         };
-
-        assert_eq!(ServerManager::build_command_string(&config), "node");
+        assert_eq!(build_command_string(&entry), "node");
     }
 
     #[test]
     fn test_build_command_string_with_args() {
-        let config = ServerConfig {
+        let entry = McpServerEntry {
             command: "node".to_string(),
             args: vec!["/path/to/server.js".to_string(), "--verbose".to_string()],
-            env: HashMap::new(),
+            env: HashMap::default(),
         };
-
         assert_eq!(
-            ServerManager::build_command_string(&config),
+            build_command_string(&entry),
             "node /path/to/server.js --verbose"
         );
     }
 
     #[test]
     fn test_check_command_exists() {
-        // Should exist on all platforms
-        assert!(ServerManager::check_command_exists("ls"));
-
-        // Should not exist
-        assert!(!ServerManager::check_command_exists(
+        assert!(check_command_exists("ls"));
+        assert!(!check_command_exists(
             "this_command_definitely_does_not_exist_12345"
         ));
-    }
-
-    #[test]
-    fn test_server_manager_read_config() {
-        let config_content = r#"{
-            "mcpServers": {
-                "test-server": {
-                    "command": "node",
-                    "args": ["server.js"]
-                }
-            }
-        }"#;
-
-        let temp_file = create_test_config(config_content);
-
-        let manager = ServerManager {
-            config_path: temp_file.path().to_path_buf(),
-        };
-
-        let config = manager.read_config().unwrap();
-        assert_eq!(config.mcp_execution_servers.len(), 1);
-        assert!(config.mcp_execution_servers.contains_key("test-server"));
-    }
-
-    #[test]
-    fn test_server_manager_list_servers() {
-        let config_content = r#"{
-            "mcpServers": {
-                "server1": {
-                    "command": "node",
-                    "args": ["s1.js"]
-                },
-                "server2": {
-                    "command": "python",
-                    "args": ["s2.py"]
-                }
-            }
-        }"#;
-
-        let temp_file = create_test_config(config_content);
-
-        let manager = ServerManager {
-            config_path: temp_file.path().to_path_buf(),
-        };
-
-        let servers = manager.list_servers().unwrap();
-        assert_eq!(servers.len(), 2);
-
-        let names: Vec<String> = servers.iter().map(|(name, _)| name.clone()).collect();
-        assert!(names.contains(&"server1".to_string()));
-        assert!(names.contains(&"server2".to_string()));
-    }
-
-    #[test]
-    fn test_server_manager_get_server_config() {
-        let config_content = r#"{
-            "mcpServers": {
-                "test-server": {
-                    "command": "node",
-                    "args": ["server.js"]
-                }
-            }
-        }"#;
-
-        let temp_file = create_test_config(config_content);
-
-        let manager = ServerManager {
-            config_path: temp_file.path().to_path_buf(),
-        };
-
-        let config = manager.get_server_config("test-server").unwrap();
-        assert_eq!(config.command, "node");
-        assert_eq!(config.args, vec!["server.js"]);
-    }
-
-    #[test]
-    fn test_server_manager_get_server_config_not_found() {
-        let config_content = r#"{
-            "mcpServers": {}
-        }"#;
-
-        let temp_file = create_test_config(config_content);
-
-        let manager = ServerManager {
-            config_path: temp_file.path().to_path_buf(),
-        };
-
-        let result = manager.get_server_config("nonexistent");
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("not found in configuration")
-        );
     }
 
     #[test]
@@ -769,39 +438,5 @@ mod tests {
         assert!(json.contains("command"));
         assert!(json.contains("valid"));
         assert!(json.contains("message"));
-    }
-
-    // Integration tests (require CLAUDE_CONFIG_PATH or Claude Desktop installed)
-    #[tokio::test]
-    #[ignore = "requires CLAUDE_CONFIG_PATH environment variable"]
-    async fn test_list_servers_integration() {
-        // This test requires CLAUDE_CONFIG_PATH to be set
-        if std::env::var("CLAUDE_CONFIG_PATH").is_err() {
-            return;
-        }
-
-        let result = run(ServerAction::List, OutputFormat::Json).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    #[ignore = "requires CLAUDE_CONFIG_PATH and configured server"]
-    async fn test_server_info_integration() {
-        // This test requires CLAUDE_CONFIG_PATH and a configured server
-        if std::env::var("CLAUDE_CONFIG_PATH").is_err() {
-            return;
-        }
-
-        // Note: Replace with actual server name from your config
-        let result = run(
-            ServerAction::Info {
-                server: "test-server".to_string(),
-            },
-            OutputFormat::Json,
-        )
-        .await;
-
-        // May fail if server doesn't exist or can't be reached
-        assert!(result.is_ok());
     }
 }

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -9,11 +9,23 @@
 
 use anyhow::{Context, Result, bail};
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
-use mcp_execution_skill::{build_skill_context, scan_tools_directory, validate_server_id};
+use mcp_execution_skill::{
+    build_skill_context, render_skill_md, scan_tools_directory, validate_server_id,
+};
+use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 use crate::formatters::format_output;
+
+/// Output of a successful `skill` command invocation.
+#[derive(Debug, Serialize)]
+struct SkillWriteResult {
+    success: bool,
+    output_path: String,
+    bytes_written: usize,
+    tool_count: usize,
+}
 
 /// Default base directory for generated servers.
 const DEFAULT_SERVERS_DIR: &str = ".claude/servers";
@@ -164,17 +176,39 @@ pub async fn run(
         );
     }
 
-    // Step 7: Format and output
-    let output = format_output(&context, output_format)?;
-    println!("{output}");
+    // Step 7: Render SKILL.md and write atomically.
+    let rendered = render_skill_md(&context).context("failed to render SKILL.md template")?;
 
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+    }
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    // `with_added_extension` appends `.tmp` without removing `.md` (N1).
+    let tmp_path = output_path.with_added_extension("tmp");
+    std::fs::write(&tmp_path, &rendered)
+        .with_context(|| format!("failed to write temp file: {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, &output_path)
+        .with_context(|| format!("failed to rename to: {}", output_path.display()))?;
+
+    let bytes_written = rendered.len();
     info!(
-        "Skill context generated successfully for server '{}'",
-        server
+        "SKILL.md written to {} ({} bytes, {} tools)",
+        output_path.display(),
+        bytes_written,
+        context.tool_count,
     );
-    info!("Output path: {}", context.output_path);
-    info!("Tool count: {}", context.tool_count);
-    info!("Categories: {}", context.categories.len());
+
+    let result = SkillWriteResult {
+        success: true,
+        output_path: output_path.display().to_string(),
+        bytes_written,
+        tool_count: context.tool_count,
+    };
+
+    let output = format_output(&result, output_format)?;
+    println!("{output}");
 
     Ok(ExitCode::SUCCESS)
 }
@@ -538,10 +572,12 @@ async function testTool(input: string): Promise<void> {
 ";
         std::fs::write(server_dir.join("test_tool.ts"), ts_content).unwrap();
 
+        let output_path = temp.path().join("SKILL.md");
+
         let result = run(
             "test-server".to_string(),
             Some(temp.path().to_path_buf()),
-            None,
+            Some(output_path.clone()),
             None,
             vec![],
             false,
@@ -553,6 +589,12 @@ async function testTool(input: string): Promise<void> {
             result.is_ok(),
             "Expected success but got: {:?}",
             result.err()
+        );
+        assert!(output_path.exists(), "SKILL.md must be written to disk");
+        let content = std::fs::read_to_string(&output_path).unwrap();
+        assert!(
+            content.starts_with("---\n"),
+            "SKILL.md must start with YAML frontmatter"
         );
     }
 
@@ -722,10 +764,11 @@ async function test(x: string): Promise<void> {}
         std::fs::write(server_dir.join("test.ts"), ts_content).unwrap();
 
         for format in [OutputFormat::Json, OutputFormat::Text, OutputFormat::Pretty] {
+            let output_path = temp.path().join(format!("SKILL-{format}.md"));
             let result = run(
                 "test".to_string(),
                 Some(temp.path().to_path_buf()),
-                None,
+                Some(output_path),
                 None,
                 vec![],
                 false,

--- a/crates/mcp-skill/src/lib.rs
+++ b/crates/mcp-skill/src/lib.rs
@@ -33,7 +33,7 @@ pub use parser::{
     MAX_FILE_SIZE, MAX_TOOL_FILES, ParseError, ParsedParameter, ParsedToolFile, ScanError,
     extract_skill_metadata, parse_tool_file, scan_tools_directory,
 };
-pub use template::{TemplateError, render_generation_prompt};
+pub use template::{TemplateError, render_generation_prompt, render_skill_md};
 pub use types::{
     GenerateSkillParams, GenerateSkillResult, SaveSkillParams, SaveSkillResult, SkillCategory,
     SkillMetadata, SkillTool, ToolExample, validate_server_id,

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -45,8 +45,23 @@ static DESC_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"@description[ \t]+(.+)").expect("valid regex"));
 static INTERFACE_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"interface\s+\w+Params\s*\{([^}]*)\}").expect("valid regex"));
-static PROP_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(\w+)(\?)?:\s*([^;]+);").expect("valid regex"));
+// TODO(review): INTERFACE_REGEX body truncation — nested-type bodies containing `}` are cut off
+// (e.g., `{ foo: string }` as a property type truncates the interface match early).
+// Suggested action: switch to a balanced-brace parser or accept multi-pass scanning.
+
+/// Anchored single-line property pattern.
+///
+/// Matches TypeScript interface properties like:
+/// - `name: string;`
+/// - `count?: number;`
+/// - `readonly id: string;`
+///
+/// The `^...$` anchors, combined with line-by-line iteration, prevent false
+/// positives from `JSDoc` comment lines such as `* Tags to include: foo, bar`.
+static PROP_LINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:readonly\s+)?([A-Za-z_$][A-Za-z0-9_$]*)(\?)?\s*:\s*([^;]+?)\s*[;,]?\s*$")
+        .expect("valid regex")
+});
 
 // Regexes for SKILL.md frontmatter parsing
 static FRONTMATTER_REGEX: LazyLock<Regex> =
@@ -266,30 +281,69 @@ pub fn parse_tool_file(content: &str, filename: &str) -> Result<ParsedToolFile, 
 ///   body?: string;  // optional
 /// }
 /// ```
+///
+/// Each line is processed individually so that `JSDoc` comment lines (e.g.
+/// `* Tags to include: foo, bar`) are rejected before the regex runs.
+/// Trailing `// ...` inline comments are stripped from each property line
+/// before matching.
+///
+/// # Limitations
+///
+/// Multi-line property declarations (type wraps to the next line) are not
+/// supported — each property must fit on a single line.
+/// TODO(review): Add multi-line property support if generated TS ever wraps types.
 fn parse_parameters(content: &str) -> Vec<ParsedParameter> {
     let mut parameters = Vec::new();
 
-    // Find interface block (Params suffix) using pre-compiled regex
     if let Some(captures) = INTERFACE_REGEX.captures(content)
         && let Some(body) = captures.get(1)
     {
-        // Parse each property line using pre-compiled regex
-        for cap in PROP_REGEX.captures_iter(body.as_str()) {
-            let name = cap
-                .get(1)
-                .map(|m| m.as_str().to_string())
-                .unwrap_or_default();
-            let optional = cap.get(2).is_some();
-            let typescript_type = cap
-                .get(3)
-                .map_or_else(|| "unknown".to_string(), |m| m.as_str().trim().to_string());
+        for raw in body.as_str().lines() {
+            let line = raw.trim_start();
 
-            parameters.push(ParsedParameter {
-                name,
-                typescript_type,
-                required: !optional,
-                description: None,
-            });
+            // Skip blank lines and comment lines before applying the regex.
+            if line.is_empty()
+                || line.starts_with("//")
+                || line.starts_with("/*")
+                || line.starts_with('*')
+            {
+                continue;
+            }
+
+            // Bound comment search before the first string delimiter so that
+            // `//` or `/*` inside a string-literal type (e.g. `"https://x"`)
+            // does not falsely truncate the property line (S2).
+            let comment_search_end = line
+                .find('"')
+                .or_else(|| line.find('\''))
+                .unwrap_or(line.len());
+            let search_region = &line[..comment_search_end];
+
+            // Find the earliest `//` or `/*` comment marker within the safe region,
+            // then strip everything from that position to end-of-line (S1 + C1).
+            let comment_start = [search_region.find("//"), search_region.find("/*")]
+                .into_iter()
+                .flatten()
+                .min();
+            let line = comment_start.map_or(line, |i| line[..i].trim_end());
+
+            if let Some(cap) = PROP_LINE_REGEX.captures(line) {
+                let name = cap
+                    .get(1)
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
+                let optional = cap.get(2).is_some();
+                let typescript_type = cap
+                    .get(3)
+                    .map_or_else(|| "unknown".to_string(), |m| m.as_str().trim().to_string());
+
+                parameters.push(ParsedParameter {
+                    name,
+                    typescript_type,
+                    required: !optional,
+                    description: None,
+                });
+            }
         }
     }
 
@@ -874,11 +928,100 @@ interface TestParams {
 ";
 
         let params = parse_parameters(content);
-        // Readonly modifier is not currently handled by the regex.
-        // This is a known limitation - the parser is lenient.
-        // If params is empty, readonly fields were not parsed (expected).
-        // If params has items, the regex matched something (acceptable).
-        let _ = params; // Acknowledge the result without asserting specific behavior
+        // PROP_LINE_REGEX handles `readonly` — both fields must be extracted.
+        assert_eq!(params.len(), 2);
+
+        let id = params.iter().find(|p| p.name == "id").unwrap();
+        assert!(id.required);
+        assert_eq!(id.typescript_type, "string");
+
+        let count = params.iter().find(|p| p.name == "count").unwrap();
+        assert!(!count.required);
+        assert_eq!(count.typescript_type, "number");
+    }
+
+    #[test]
+    fn test_parse_parameters_inline_block_comment_stripped() {
+        // S1 regression: inline `/* */` block comments must not drop the parameter.
+        let content = r"
+interface TestParams {
+  name: string; /* required */
+  count?: number; /* default: 5 */
+}
+";
+
+        let params = parse_parameters(content);
+        assert_eq!(params.len(), 2);
+        assert!(params.iter().any(|p| p.name == "name" && p.required));
+        assert!(params.iter().any(|p| p.name == "count" && !p.required));
+    }
+
+    #[test]
+    fn test_parse_parameters_url_type_not_stripped() {
+        // S2 regression: `//` inside a string-literal type must not truncate the line.
+        let content = r"
+interface TestParams {
+  url: string; // endpoint URL
+  mode: string;
+}
+";
+
+        let params = parse_parameters(content);
+        assert_eq!(params.len(), 2);
+        assert!(
+            params.iter().any(|p| p.name == "url"),
+            "url must not be dropped"
+        );
+        assert!(params.iter().any(|p| p.name == "mode"));
+    }
+
+    #[test]
+    fn test_parse_parameters_jsdoc_body_comments_not_extracted() {
+        // Regression: comment lines inside JSDoc must NOT produce parameters.
+        let content = r"
+interface FooParams {
+  /**
+   * @default 4
+   * Tags to include: foo, bar
+   */
+  count?: number;
+  name: string;
+}
+";
+
+        let params = parse_parameters(content);
+        assert_eq!(
+            params.len(),
+            2,
+            "expected exactly count and name, got: {params:?}"
+        );
+
+        let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"count"), "missing 'count'");
+        assert!(names.contains(&"name"), "missing 'name'");
+        assert!(!names.contains(&"default"), "false positive: 'default'");
+        assert!(!names.contains(&"include"), "false positive: 'include'");
+    }
+
+    #[test]
+    fn test_parse_parameters_inline_comment_stripped() {
+        // C1: trailing `// ...` inline comment must be stripped before matching.
+        let content = r"
+interface TestParams {
+  name: string; // parameter name
+  count?: number; // how many
+}
+";
+
+        let params = parse_parameters(content);
+        assert_eq!(params.len(), 2);
+
+        let name = params.iter().find(|p| p.name == "name").unwrap();
+        assert!(name.required);
+        assert_eq!(name.typescript_type, "string");
+
+        let count = params.iter().find(|p| p.name == "count").unwrap();
+        assert!(!count.required);
     }
 
     #[test]

--- a/crates/mcp-skill/src/template.rs
+++ b/crates/mcp-skill/src/template.rs
@@ -142,7 +142,8 @@ pub fn render_skill_md(context: &GenerateSkillResult) -> Result<String, Template
     }
 
     let rendered = HANDLEBARS.render("skill-md", &value)?;
-    Ok(rendered)
+    // Normalize CRLF → LF so output is consistent across platforms (Windows CI).
+    Ok(rendered.replace("\r\n", "\n"))
 }
 
 #[cfg(test)]

--- a/crates/mcp-skill/src/template.rs
+++ b/crates/mcp-skill/src/template.rs
@@ -1,7 +1,7 @@
 //! Template rendering for skill generation.
 //!
-//! Uses Handlebars templates to render the skill generation prompt.
-//! The template is embedded at compile time for reliability.
+//! Uses Handlebars templates to render the skill generation prompt and
+//! the final SKILL.md file. Both templates are embedded at compile time.
 
 use std::sync::LazyLock;
 
@@ -22,19 +22,38 @@ pub enum TemplateError {
     RegistrationFailed(#[from] handlebars::TemplateError),
 }
 
-/// Embedded Handlebars template for skill generation.
+/// Embedded Handlebars template for the LLM skill generation prompt.
 const SKILL_GENERATION_TEMPLATE: &str = include_str!("templates/skill-generation.hbs");
+
+/// Embedded Handlebars template that renders SKILL.md directly (no LLM required).
+const SKILL_MD_TEMPLATE: &str = include_str!("templates/skill-md.hbs");
 
 /// Handlebars instance with pre-registered templates.
 ///
 /// Initialized once per process using `LazyLock` for optimal performance.
-/// Template is parsed and validated on first access.
+/// Templates are parsed and validated on first access.
 static HANDLEBARS: LazyLock<Handlebars<'static>> = LazyLock::new(|| {
     let mut hb = Handlebars::new();
     hb.register_template_string("skill", SKILL_GENERATION_TEMPLATE)
-        .expect("embedded template must be valid Handlebars syntax");
+        .expect("embedded skill-generation template must be valid Handlebars syntax");
+    hb.register_template_string("skill-md", SKILL_MD_TEMPLATE)
+        .expect("embedded skill-md template must be valid Handlebars syntax");
     hb
 });
+
+/// Wraps a string in YAML double-quote scalars, escaping `\`, `"`, and newlines.
+///
+/// Produces a value that can be embedded directly after a YAML key as a
+/// quoted scalar — safe against `:` in the middle, leading `-`, and
+/// newline injection.
+fn yaml_quote(s: &str) -> String {
+    let escaped = s
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "");
+    format!("\"{escaped}\"")
+}
 
 /// Render the skill generation prompt.
 ///
@@ -62,19 +81,68 @@ static HANDLEBARS: LazyLock<Handlebars<'static>> = LazyLock::new(|| {
 /// let prompt = render_generation_prompt(&context).unwrap();
 /// ```
 pub fn render_generation_prompt(context: &GenerateSkillResult) -> Result<String, TemplateError> {
-    // Use pre-compiled template instance
     let rendered = HANDLEBARS.render("skill", context)?;
     Ok(rendered)
 }
 
-/// Alternative: Use the pre-built prompt from context.
+/// Render SKILL.md content directly from skill context.
 ///
-/// The `GenerateSkillResult` already contains a `generation_prompt` field
-/// built by `build_skill_context`. This function is provided for cases
-/// where custom template rendering is needed.
-#[allow(dead_code)]
-pub fn get_prebuilt_prompt(context: &GenerateSkillResult) -> &str {
-    &context.generation_prompt
+/// Produces the final SKILL.md file content without requiring an LLM. Uses the
+/// embedded `skill-md.hbs` template with the same [`GenerateSkillResult`] context
+/// as [`render_generation_prompt`].
+///
+/// Tool descriptions are rendered with triple-stash (`{{{...}}}`) to avoid
+/// HTML-escaping characters such as `<`, `>`, and `&`.
+///
+/// YAML frontmatter scalars (`description`) are pre-quoted so that special
+/// characters in MCP server metadata (`:`, newlines, leading `-`) cannot
+/// corrupt the frontmatter or inject additional YAML keys (S3).
+///
+/// # Arguments
+///
+/// * `context` - Skill generation context from [`crate::build_skill_context`]
+///
+/// # Returns
+///
+/// Rendered SKILL.md string ready to write to disk.
+///
+/// # Panics
+///
+/// Does not panic in practice: `serde_json::to_value` is infallible for
+/// `GenerateSkillResult` because all fields are standard Rust types with
+/// derived `Serialize` implementations.
+///
+/// # Errors
+///
+/// Returns [`TemplateError`] if Handlebars rendering fails.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_skill::{build_skill_context, render_skill_md};
+///
+/// let context = build_skill_context("github", &[], None);
+/// let md = render_skill_md(&context).unwrap();
+/// assert!(md.starts_with("---\n"));
+/// ```
+pub fn render_skill_md(context: &GenerateSkillResult) -> Result<String, TemplateError> {
+    // SAFETY: `GenerateSkillResult` derives `Serialize` with only primitive and
+    // standard-library types — `to_value` is infallible for this type.
+    let mut value =
+        serde_json::to_value(context).expect("GenerateSkillResult serialization is infallible");
+
+    // YAML-quote server_description so that `:`, newlines, and leading `-` in
+    // MCP server metadata cannot corrupt the frontmatter or inject keys (S3).
+    if let Some(desc) = value
+        .get("server_description")
+        .and_then(|v| v.as_str())
+        .map(yaml_quote)
+    {
+        value["server_description"] = serde_json::Value::String(desc);
+    }
+
+    let rendered = HANDLEBARS.render("skill-md", &value)?;
+    Ok(rendered)
 }
 
 #[cfg(test)]
@@ -118,7 +186,6 @@ mod tests {
 
         match result {
             Ok(prompt) => {
-                // Verify key sections are present
                 assert!(prompt.contains("test"));
                 assert!(prompt.contains("SKILL.md"));
             }
@@ -127,10 +194,84 @@ mod tests {
     }
 
     #[test]
-    fn test_get_prebuilt_prompt() {
+    fn test_render_skill_md() {
         let context = create_test_context();
-        let prompt = get_prebuilt_prompt(&context);
+        let result = render_skill_md(&context);
 
-        assert_eq!(prompt, "Pre-built prompt");
+        match result {
+            Ok(md) => {
+                assert!(md.starts_with("---\n"), "must start with YAML frontmatter");
+                assert!(md.contains("name: test-progressive"));
+                assert!(md.contains("# test-progressive"));
+                assert!(md.contains("~/.claude/servers/test/"));
+                assert!(md.contains("testTool"));
+            }
+            Err(e) => panic!("render_skill_md failed: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_render_skill_md_html_special_chars_not_escaped() {
+        let mut context = create_test_context();
+        context.categories = vec![SkillCategory {
+            name: "test".to_string(),
+            display_name: "Test".to_string(),
+            tools: vec![SkillTool {
+                name: "my_tool".to_string(),
+                typescript_name: "myTool".to_string(),
+                description: "Create & update <items> with \"quotes\"".to_string(),
+                keywords: vec![],
+                required_params: vec![],
+                optional_params: vec![],
+            }],
+        }];
+
+        let md = render_skill_md(&context).unwrap();
+        // Triple-stash in template must prevent HTML escaping.
+        assert!(md.contains('&'), "& must not be HTML-escaped");
+        assert!(md.contains('<'), "< must not be HTML-escaped");
+    }
+
+    #[test]
+    fn test_render_skill_md_yaml_frontmatter_safe() {
+        // S3: malicious server_description must not inject YAML keys or corrupt frontmatter.
+        let mut context = create_test_context();
+        context.server_description = Some("GitHub: issues & CI\nname: injected".to_string());
+
+        let md = render_skill_md(&context).unwrap();
+
+        // Extract frontmatter block (between the two "---" markers).
+        let after_open = md.strip_prefix("---\n").expect("must start with ---");
+        let fm_end = after_open.find("\n---").expect("must have closing ---");
+        let frontmatter = &after_open[..fm_end];
+
+        // There must be exactly one `name:` key — no injected sibling.
+        let name_count = frontmatter
+            .lines()
+            .filter(|l| l.starts_with("name:"))
+            .count();
+        assert_eq!(
+            name_count, 1,
+            "YAML key injection detected in: {frontmatter}"
+        );
+
+        // The description value must be quoted (YAML double-quoted scalar).
+        let desc_line = frontmatter
+            .lines()
+            .find(|l| l.starts_with("description:"))
+            .expect("description key must be present");
+        assert!(
+            desc_line.contains('"'),
+            "description must be YAML-quoted: {desc_line}"
+        );
+    }
+
+    #[test]
+    fn test_yaml_quote() {
+        assert_eq!(yaml_quote("simple"), "\"simple\"");
+        assert_eq!(yaml_quote("GitHub: issues"), "\"GitHub: issues\"");
+        assert_eq!(yaml_quote("line1\nline2"), "\"line1\\nline2\"");
+        assert_eq!(yaml_quote(r#"has "quotes""#), r#""has \"quotes\"""#);
+        assert_eq!(yaml_quote("has \\backslash"), "\"has \\\\backslash\"");
     }
 }

--- a/crates/mcp-skill/src/templates/skill-md.hbs
+++ b/crates/mcp-skill/src/templates/skill-md.hbs
@@ -1,0 +1,43 @@
+---
+name: {{skill_name}}
+description: {{#if server_description}}{{{server_description}}}{{else}}"{{server_id}} MCP server tools ({{tool_count}} tools)"{{/if}}
+---
+
+# {{skill_name}}
+
+Progressive loading skill for the `{{server_id}}` MCP server ({{tool_count}} tools).
+
+## Usage
+
+**Discover tools:**
+```bash
+ls ~/.claude/servers/{{server_id}}/
+```
+
+**Load a tool:**
+```bash
+cat ~/.claude/servers/{{server_id}}/<tool>.ts
+```
+
+**Execute:**
+```bash
+node ~/.claude/servers/{{server_id}}/<tool>.ts '<json params>'
+```
+
+**Search by keyword:**
+```bash
+grep -l "<keyword>" ~/.claude/servers/{{server_id}}/*.ts
+```
+
+## Tools by Category
+
+{{#each categories}}
+### {{display_name}}
+
+{{#each tools}}
+- `{{typescript_name}}` — {{{description}}}
+{{/each}}
+
+{{else}}
+No tools categorized.
+{{/each}}


### PR DESCRIPTION
## Summary

- **#81** — `server list/info/validate` now read from `~/.claude/mcp.json` (same source as `introspect`/`generate`). Removes `ServerManager` and all Claude Desktop config logic. Missing config file returns an empty list instead of an error.
- **#82** — `skill` CLI writes `SKILL.md` directly via a new Handlebars template, atomically (temp + rename). Frontmatter values are YAML-quoted. Replaces the misleading JSON context dump + false "Output path" log.
- **#83** — TypeScript property parser iterates lines and skips comment-prefix lines; strips inline `// ...` and `/* */` comments (bounded at the first string-literal delimiter to avoid false truncation on URL types). Eliminates `default`/`include` false-positive parameters.

## Breaking change

`skill` command stdout shape changed from a raw `GenerateSkillResult` JSON dump to a `SkillWriteResult` object (`success`, `output_path`, `bytes_written`, `tool_count`).

## Test plan

- [ ] `cargo nextest run --workspace --all-features` — 639/639 pass
- [ ] `cargo +nightly fmt --check` — clean
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean
- [ ] `cargo test --doc --all-features --workspace` — 10/10 pass
- [ ] `server list` returns `[]` when `~/.claude/mcp.json` is absent (not an error)
- [ ] `skill --server <id>` writes `SKILL.md` to `~/.claude/skills/<id>/SKILL.md`
- [ ] `skill --server <id> --format json` outputs `SkillWriteResult` JSON
- [ ] Parser: `name: string; /* required */` and `name: string; // comment` both produce param `name`
- [ ] Parser: JSDoc `default:` and `include:` tokens do not appear as parameters

Closes #81, #82, #83