### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.7.1] - 2026-06-07
+
 ### Breaking
 
 - **`skill` command stdout shape changed** (#82): previously printed a raw JSON blob of `GenerateSkillResult` (the generation context). Now prints a compact `SkillWriteResult` (`{success, output_path, bytes_written, tool_count}`). Scripts or tooling parsing the old JSON output must be updated.
@@ -1195,12 +1199,13 @@ Phase 6 (Optimization) is currently OPTIONAL and DEFERRED because:
 
 ---
 
-**Last Updated**: 2026-04-21
-**Version**: 0.7.0 (Production Ready)
+**Last Updated**: 2026-06-07
+**Version**: 0.7.1 (Production Ready)
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/mcp-execution/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/bug-ops/mcp-execution/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/bug-ops/mcp-execution/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/bug-ops/mcp-execution/compare/v0.6.6...v0.7.0
 [0.6.6]: https://github.com/bug-ops/mcp-execution/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/bug-ops/mcp-execution/compare/v0.6.4...v0.6.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eliminating the false-positive when servers advertise `resources: null` (issue #80).
 - **`mcp-execution-introspector`**: `supports_prompts` now derived from
   `capabilities.prompts.is_some()` (was always `false`).
+- **`mcp-execution-codegen`**: JSDoc sanitization extended to `input_schema` property descriptions,
+  `category`, `keywords`, and `short_description` from categorization data (#100). A new recursive
+  `sanitize_schema_jsdoc_descriptions` pass covers all `description` fields in the JSON schema tree;
+  non-string description values are replaced with `null` to prevent injection via schema metadata.
+- **`mcp-execution-cli`**: All help text examples updated from the incorrect `mcp-cli` binary name
+  to the correct `mcp-execution-cli` (#98).
+
+### Changed
+
+- **Dependencies**: Updated transitive dependencies (Cargo.lock only, no API changes)
+  - `clap` / `clap_complete`: 4.6.2 → 4.6.5
+  - `rmcp`: 1.5.0 → 1.7.0
+  - `tokio`: 1.52.1 → 1.52.3
+  - `handlebars`: 6.4.0 → 6.4.1
+  - `serde_json`: 1.0.149 → 1.0.150
+  - `uuid`: 1.23.1 → 1.23.2
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -146,9 +146,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -179,9 +179,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -595,9 +595,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -865,7 +865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -893,10 +893,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -915,15 +917,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -945,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -960,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -987,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-codegen"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "handlebars",
@@ -1000,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1016,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-files"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "dhat",
@@ -1029,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-introspector"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "mcp-execution-core",
@@ -1042,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1067,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-skill"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "dirs",
  "handlebars",
@@ -1083,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -1104,9 +1106,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1115,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1226,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pest"
@@ -1668,9 +1670,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1934,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -2029,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2042,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2052,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2065,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2108,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2277,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -2377,18 +2379,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [ "crates/*" ]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Andrei G <k05h31@gmail.com>"]
@@ -24,12 +24,12 @@ dhat = "0.3"
 dialoguer = "0.12"
 dirs = "6.0"
 handlebars = "6.4"
-mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.7.0" }
-mcp-execution-core = { path = "crates/mcp-core", version = "0.7.0" }
-mcp-execution-files = { path = "crates/mcp-files", version = "0.7.0" }
-mcp-execution-introspector = { path = "crates/mcp-introspector", version = "0.7.0" }
-mcp-execution-server = { path = "crates/mcp-server", version = "0.7.0" }
-mcp-execution-skill = { path = "crates/mcp-skill", version = "0.7.0" }
+mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.7.1" }
+mcp-execution-core = { path = "crates/mcp-core", version = "0.7.1" }
+mcp-execution-files = { path = "crates/mcp-files", version = "0.7.1" }
+mcp-execution-introspector = { path = "crates/mcp-introspector", version = "0.7.1" }
+mcp-execution-server = { path = "crates/mcp-server", version = "0.7.1" }
+mcp-execution-skill = { path = "crates/mcp-skill", version = "0.7.1" }
 rayon = "1.12"
 regex = "1.12"
 rmcp = "1.7"

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ node ~/.claude/servers/github/createIssue.ts --repo="owner/repo" --title="Bug"
 | **Type-Safe** | Full TypeScript interfaces from MCP JSON schemas |
 | **Lightning Fast** | 526x faster than target (0.19ms for 10 tools) |
 | **100% MCP Compatible** | Works with all MCP servers via [rmcp SDK](https://docs.rs/rmcp) |
-| **Thoroughly Tested** | 626 tests with 100% pass rate |
+| **Thoroughly Tested** | 657 tests with 100% pass rate |
 
 ## Workspace Crates
 

--- a/crates/mcp-cli/README.md
+++ b/crates/mcp-cli/README.md
@@ -98,7 +98,9 @@ mcp-execution-cli generate <SERVER> [OPTIONS]
 - `--from-config <NAME>`: Load config from mcp.json
 - `--arg <ARG>`: Server command argument (repeatable)
 - `--env <KEY=VALUE>`: Environment variable (repeatable)
+- `--name <NAME>`: Custom server name for output directory
 - `--progressive-output <PATH>`: Custom output directory
+- `--dry-run`: Preview files that would be generated without writing to disk
 - `--format <FORMAT>`: Output format (json, text, pretty)
 
 **Examples**:
@@ -107,11 +109,15 @@ mcp-execution-cli generate <SERVER> [OPTIONS]
 # From config
 mcp-execution-cli generate --from-config github
 
-# Docker container
+# Preview without writing
+mcp-execution-cli generate --from-config github --dry-run
+
+# Docker container with custom name
 mcp-execution-cli generate docker \
   --arg=run --arg=-i --arg=--rm \
   --arg=ghcr.io/org/server \
-  --env=API_KEY=xxx
+  --env=API_KEY=xxx \
+  --name=myserver
 ```
 
 ### `introspect`

--- a/crates/mcp-codegen/README.md
+++ b/crates/mcp-codegen/README.md
@@ -119,6 +119,21 @@ JSON Schema types are converted to TypeScript:
 | 50 tools | <20ms | **0.97ms** (20.6x faster) |
 | VFS export | <10ms | **1.2ms** (8.3x faster) |
 
+## Security
+
+> [!IMPORTANT]
+> All server-controlled strings are sanitized before interpolation into generated TypeScript.
+
+The code generator applies JSDoc sanitization to every field that originates from an MCP server:
+
+- Tool `name` and `description` (truncated to 256 chars, `*/` escaped, CR/LF stripped)
+- Server `name` and `version` (same rules, `version` truncated to 64 chars)
+- Every `description` field inside `input_schema` JSON recursively
+- Categorization fields: `category` (128 chars), `keywords`, `short_description` (256 chars each)
+- Non-string `description` values in schemas are replaced with `null`
+
+This prevents malicious MCP servers from injecting arbitrary TypeScript by embedding `*/` in their metadata.
+
 ## Related Crates
 
 This crate is part of the [mcp-execution](https://github.com/bug-ops/mcp-execution) workspace:

--- a/crates/mcp-server/README.md
+++ b/crates/mcp-server/README.md
@@ -34,7 +34,7 @@ cargo run -p mcp-execution-server
 
 ### Claude Code Configuration
 
-Add to `~/.config/claude/mcp.json`:
+Add to `~/.claude/mcp.json`:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.7.0 to 0.7.1
- Update CHANGELOG.md with all changes since v0.7.0

## Changes included

### Breaking
- `skill` command stdout shape changed (#82): now prints `SkillWriteResult` instead of raw `GenerateSkillResult` JSON

### Fixed
- `server` subcommand unified to read from `~/.claude/mcp.json` (#81)
- `skill` command renders SKILL.md via Handlebars template and writes atomically (#82)
- TypeScript property parser handles blank/comment lines and inline comments (#83)
- `mcp-execution-cli --version` and completions report correct binary name (#89)
- `mcp-execution-server` MCP handshake reports correct name and version (#85)
- `mcp-execution-codegen` JSDoc sanitization for server-controlled strings (#87)
- `mcp-execution-codegen` generated output includes `package.json` with `{"type":"module"}` (#86)
- `mcp-execution-codegen` JSDoc sanitization extended to `input_schema` descriptions and categorization fields (#100)
- `mcp-execution-cli` help text examples corrected to use `mcp-execution-cli` (#98)
- `mcp-execution-introspector` server name/version read from MCP handshake (#84, #79)
- `mcp-execution-introspector` `supports_resources` and `supports_prompts` derived from capabilities (#80)

### Changed
- Dependencies: `clap` 4.6.2→4.6.5, `rmcp` 1.5.0→1.7.0, `tokio` 1.52.1→1.52.3, `handlebars` 6.4.0→6.4.1, `serde_json` 1.0.149→1.0.150, `uuid` 1.23.1→1.23.2

## Checklist

- [x] Version updated in all manifests (`[workspace.package]` only — members inherit via `version.workspace = true`)
- [x] CHANGELOG.md has release section with date and all commits from git history verified
- [x] All CI checks pass (`fmt`, `clippy`, `nextest` 657 tests, doc tests 10 tests)
- [x] Docs build without broken intra-doc links
- [ ] Ready for tagging after merge