### PR TITLE
fix(introspector): migrate to rmcp 1.8 peer_info() API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,9 +1465,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ mcp-execution-server = { path = "crates/mcp-server", version = "0.7.1" }
 mcp-execution-skill = { path = "crates/mcp-skill", version = "0.7.1" }
 rayon = "1.12"
 regex = "1.12"
-rmcp = "1.7"
+rmcp = "1.8"
 schemars = "1.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -327,7 +327,7 @@ impl Introspector {
         // Extract name, version, and capabilities from the MCP handshake result.
         // Falls back to the command string / "unknown" if the server did not send peer info.
         let (server_name, server_version, has_resources, has_prompts) =
-            extract_peer_meta(config, client.peer_info());
+            extract_peer_meta(config, client.peer_info().as_deref());
 
         let capabilities = ServerCapabilities {
             supports_tools: !tools.is_empty(),

--- a/deny.toml
+++ b/deny.toml
@@ -11,12 +11,7 @@
 [advisories]
 
 # Ignore specific advisories if needed (add RUSTSEC IDs here)
-ignore = [
-    # paste crate - unmaintained but used by rmcp (transitive dependency)
-    # Only used at compile-time for macros, low security risk
-    # Tracking: https://github.com/modelcontextprotocol/rust-sdk/issues
-    "RUSTSEC-2024-0436",
-]
+ignore = []
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

- `rmcp` 1.8.0 changed `Peer::peer_info()` return type from `Option<&R::PeerInfo>` to `Option<Arc<R::PeerInfo>>` — a source-breaking change despite a minor version bump (acknowledged upstream as should-have-been `2.0.0`)
- Add `.as_deref()` at the `extract_peer_meta` call site in `mcp-introspector` to coerce `Option<Arc<InitializeResult>>` → `Option<&InitializeResult>`
- Bump workspace dependency from `"1.7"` to `"1.8"`

Fixes the clippy/build failure on dependabot PR #112.

## Test plan

- [ ] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings` passes
- [ ] `cargo nextest run --all-features --workspace --no-fail-fast` — 657 tests pass
- [ ] `cargo test --doc --all-features --workspace` — 10 doc-tests pass
- [ ] `cargo +nightly fmt --check` passes