### PR TITLE
release: v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.2] - 2026-07-09
+
+### Fixed
+
+- **`mcp-execution-introspector`**: `extract_peer_meta` call site migrated to rmcp 1.8's `Peer::peer_info()`
+  return type change (`Option<&R::PeerInfo>` → `Option<Arc<R::PeerInfo>>`, a breaking change despite the
+  minor version bump) by adding `.as_deref()` (#113).
+
+### Changed
+
+- **`mcp-execution-server`**: migrated `CallToolResult::success()` call sites from the `Content` type
+  (removed in rmcp 2.0) to `ContentBlock` (#115).
+- **Dependencies**: Updated to latest stable versions
+  - `rmcp`: 1.7.0 → 2.1.0 (via 1.8.0; see Fixed/Changed entries above for the required call-site migrations)
+  - `clap_complete`: 4.6.5 → 4.6.7
+  - `anyhow`: 1.0.102 → 1.0.103
+  - `handlebars`: 6.4.1 → 6.4.2
+  - `uuid`: 1.23.2 → 1.23.4
+  - `regex`: 1.12.3 → 1.12.4
+  - `which`: 8.0.2 → 8.0.4
+- **CI**: Updated `actions/checkout` v6 → v7, `codecov/codecov-action` v6 → v7,
+  `lewagon/wait-on-check-action` 1.7.0 → 1.8.1
+- **`deny.toml`**: removed the now-unneeded `RUSTSEC-2024-0436` advisory ignore (paste crate advisory,
+  no longer triggered after the rmcp bump)
+
+---
+
 ## [0.7.1] - 2026-06-07
 
 ### Breaking
@@ -1215,12 +1242,13 @@ Phase 6 (Optimization) is currently OPTIONAL and DEFERRED because:
 
 ---
 
-**Last Updated**: 2026-06-07
-**Version**: 0.7.1 (Production Ready)
+**Last Updated**: 2026-07-09
+**Version**: 0.7.2 (Production Ready)
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/mcp-execution/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/bug-ops/mcp-execution/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/bug-ops/mcp-execution/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/bug-ops/mcp-execution/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/bug-ops/mcp-execution/compare/v0.6.6...v0.7.0
 [0.6.6]: https://github.com/bug-ops/mcp-execution/compare/v0.6.5...v0.6.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-codegen"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "handlebars",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-files"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "dhat",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-introspector"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "mcp-execution-core",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-execution-skill"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "dirs",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = [ "crates/*" ]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Andrei G <k05h31@gmail.com>"]
@@ -24,12 +24,12 @@ dhat = "0.3"
 dialoguer = "0.12"
 dirs = "6.0"
 handlebars = "6.4"
-mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.7.1" }
-mcp-execution-core = { path = "crates/mcp-core", version = "0.7.1" }
-mcp-execution-files = { path = "crates/mcp-files", version = "0.7.1" }
-mcp-execution-introspector = { path = "crates/mcp-introspector", version = "0.7.1" }
-mcp-execution-server = { path = "crates/mcp-server", version = "0.7.1" }
-mcp-execution-skill = { path = "crates/mcp-skill", version = "0.7.1" }
+mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.7.2" }
+mcp-execution-core = { path = "crates/mcp-core", version = "0.7.2" }
+mcp-execution-files = { path = "crates/mcp-files", version = "0.7.2" }
+mcp-execution-introspector = { path = "crates/mcp-introspector", version = "0.7.2" }
+mcp-execution-server = { path = "crates/mcp-server", version = "0.7.2" }
+mcp-execution-skill = { path = "crates/mcp-skill", version = "0.7.2" }
 rayon = "1.12"
 regex = "1.12"
 rmcp = "2.1"


### PR DESCRIPTION
## Summary

- Bump version from 0.7.1 to 0.7.2 (workspace)
- Document all commits merged since v0.7.1: rmcp 1.7.0 -> 2.1.0 migration (peer_info Arc change, Content -> ContentBlock rename), plus routine dependency and CI action bumps
- Update CHANGELOG.md with the 0.7.2 release section

## Checklist

- [x] Version updated in all manifests (workspace.package.version, internal path-dependency versions)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version (no hardcoded version strings found)
- [x] All CI checks pass locally (fmt, clippy, nextest, doc-tests, rustdoc gate)
- [ ] Ready for tagging after merge