### PR TITLE
docs: fix stale API references and broken links across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ mcp-execution-cli completions bash
 ## Documentation
 
 - [Progressive Loading Tutorial](examples/progressive-loading-usage.md) - Complete guide
-- [Claude Code Integration](examples/SKILL.md) - Skill setup
-- [Architecture Decisions](docs/adr/) - ADRs explaining design choices
+- [Claude Code Integration](crates/mcp-skill) - SKILL.md generation (`mcp-execution-cli skill`)
+- [Architecture Overview](docs/ARCHITECTURE.md) - System architecture and design
 
 ## Development
 

--- a/crates/mcp-cli/README.md
+++ b/crates/mcp-cli/README.md
@@ -205,13 +205,35 @@ mcp-execution-cli skill --server github --overwrite
 > The MCP server can leverage LLM capabilities to summarize tool descriptions and reduce
 > context size, resulting in more concise and effective skill files.
 
-### `stats`
+### `server`
 
-View cache statistics:
+Manage MCP server configurations from `~/.claude/mcp.json`:
 
 ```bash
-mcp-execution-cli stats
+# List all configured servers
+mcp-execution-cli server list
+
+# Show detailed information about a server
+mcp-execution-cli server info github
+
+# Validate a server command
+mcp-execution-cli server validate docker
 ```
+
+### `setup`
+
+Validate the runtime environment for generated MCP tool execution:
+
+```bash
+mcp-execution-cli setup
+
+# Output:
+# ✓ Node.js v20.10.0 detected
+# ✓ MCP configuration found
+# ✓ Runtime setup complete
+```
+
+Checks that Node.js 18+ is installed, `~/.claude/mcp.json` exists, and makes generated TypeScript files executable (Unix only).
 
 ### `completions`
 

--- a/crates/mcp-core/README.md
+++ b/crates/mcp-core/README.md
@@ -66,7 +66,7 @@ use mcp_execution_core::{Error, Result};
 
 fn process_server(id: &str) -> Result<()> {
     if id.is_empty() {
-        return Err(Error::InvalidConfiguration {
+        return Err(Error::ConfigError {
             message: "Server ID cannot be empty".to_string(),
         });
     }

--- a/crates/mcp-files/README.md
+++ b/crates/mcp-files/README.md
@@ -93,8 +93,12 @@ let fs = FilesBuilder::new()
     .build()
     .unwrap();
 
-let options = ExportOptions::default();
-fs.export_to_disk(Path::new("~/.claude/servers"), &options)?;
+// Default options (atomic writes enabled)
+fs.export_to_filesystem(Path::new("~/.claude/servers"))?;
+
+// Or with custom options
+let options = ExportOptions::default().with_atomic_writes(false);
+fs.export_to_filesystem_with_options(Path::new("~/.claude/servers"), &options)?;
 ```
 
 > [!NOTE]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -21,13 +21,13 @@ This module provides the bridge between generated TypeScript tool definitions an
 This module is automatically used by generated tool files. When you generate tools via:
 
 ```bash
-mcp-execution-cli generate github
+mcp-execution-cli generate --from-config github
 ```
 
 Each tool file imports `callMCPTool` from this module:
 
 ```typescript
-import { callMCPTool } from '../_runtime/mcp-bridge.js';
+import { callMCPTool } from './_runtime/mcp-bridge.ts';
 
 export async function createIssue(params) {
   return callMCPTool('github', 'create_issue', params);


### PR DESCRIPTION
## Summary

Audited every README in the workspace (root + 7 crates + examples + runtime) against the current source and fixed real drift found along the way:

- `crates/mcp-cli/README.md`: documented a `stats` command that no longer exists; added the missing `server` and `setup` subcommands
- `crates/mcp-core/README.md`: example used `Error::InvalidConfiguration` which does not exist (actual variant is `ConfigError`)
- `crates/mcp-files/README.md`: example called `export_to_disk`, which does not exist (actual API is `export_to_filesystem` / `export_to_filesystem_with_options`)
- `runtime/README.md`: import example used a stale `.js` extension for the runtime bridge (actual template emits `.ts`); `generate` example omitted the required `--from-config` flag
- Root `README.md`: Documentation section linked to `examples/SKILL.md` and `docs/adr/`, both removed in earlier releases

All other crate READMEs (mcp-codegen, mcp-introspector, mcp-skill, mcp-server) and examples/README.md were checked against their public API and found accurate; no changes needed there.

## Test plan

- [x] Verified every fixed API/type/method exists in current source via grep
- [x] Checked all relative links across the 10 README files resolve to existing paths
- [x] No source files touched, so no build/test re-run required