### PR TITLE
fix(codegen): emit @description in header JSDoc without categorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mcp-execution-codegen`**: CLI-generated TypeScript files (`generate` without LLM categorization)
+  now always emit an `@description` tag in the header JSDoc, falling back to the tool's own
+  description when no categorization is available. Previously the tag was omitted, causing
+  `mcp-execution-skill` to fall back to uninformative `"{tool_name} tool"` placeholders in
+  generated `SKILL.md` files (#94).
+
+### Documentation
+
+- **`mcp-execution-codegen`**: documented that `ToolContext.input_schema` always holds the
+  JSDoc-sanitized schema, and added a regression test locking in that invariant (#102).
+
 ---
 
 ## [0.7.2] - 2026-07-09

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -349,16 +349,24 @@ impl<'a> ProgressiveGenerator<'a> {
         // Extract properties from input schema
         let properties = self.extract_property_infos(&tool.input_schema)?;
 
+        let description = sanitize_jsdoc(&tool.description, 256);
+        // Falls back to the tool's own description when no LLM categorization is
+        // available, so the header JSDoc always emits `@description` (issue #94).
+        let short_description = Some(categorization.map_or_else(
+            || description.clone(),
+            |c| sanitize_jsdoc(&c.short_description, 256),
+        ));
+
         Ok(ToolContext {
             server_id: server_id.to_string(),
             name: sanitize_jsdoc(tool.name.as_str(), 256),
             typescript_name,
-            description: sanitize_jsdoc(&tool.description, 256),
+            description,
             input_schema: sanitize_schema_jsdoc_descriptions(tool.input_schema.clone()),
             properties,
             category: categorization.map(|c| sanitize_jsdoc(&c.category, 128)),
             keywords: categorization.map(|c| sanitize_jsdoc(&c.keywords, 256)),
-            short_description: categorization.map(|c| sanitize_jsdoc(&c.short_description, 256)),
+            short_description,
         })
     }
 
@@ -643,6 +651,68 @@ mod tests {
         assert_eq!(
             context.short_description,
             Some("Send a message".to_string())
+        );
+    }
+
+    #[test]
+    fn test_create_tool_context_without_categorization_falls_back_to_description() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let tool = ToolInfo {
+            name: ToolName::new("format_document"),
+            description: "Format document with language-specific rules".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"}
+                },
+                "required": ["text"]
+            }),
+            output_schema: None,
+        };
+
+        let context = generator
+            .create_tool_context("test-server", &tool, None)
+            .unwrap();
+
+        assert_eq!(
+            context.short_description,
+            Some("Format document with language-specific rules".to_string())
+        );
+
+        // The header JSDoc must emit @description even without LLM categorization.
+        let rendered = generator
+            .engine
+            .render("progressive/tool", &context)
+            .unwrap();
+        assert!(rendered.contains("@description Format document with language-specific rules"));
+    }
+
+    #[test]
+    fn test_create_tool_context_input_schema_is_sanitized() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let tool = ToolInfo {
+            name: ToolName::new("send_message"),
+            description: "Sends a message".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "description": "Schema */ injected\nnext",
+                "properties": {
+                    "text": {"type": "string"}
+                },
+                "required": ["text"]
+            }),
+            output_schema: None,
+        };
+
+        let context = generator
+            .create_tool_context("test-server", &tool, None)
+            .unwrap();
+
+        let expected = sanitize_schema_jsdoc_descriptions(tool.input_schema);
+        assert_eq!(context.input_schema, expected);
+        assert_eq!(
+            context.input_schema["description"],
+            json!("Schema *\\/ injected next")
         );
     }
 

--- a/crates/mcp-codegen/src/progressive/types.rs
+++ b/crates/mcp-codegen/src/progressive/types.rs
@@ -40,7 +40,8 @@ pub struct ToolContext {
     pub typescript_name: String,
     /// Human-readable description
     pub description: String,
-    /// JSON Schema for input parameters
+    /// JSON Schema for input parameters, with `description` fields sanitized
+    /// for safe interpolation into JSDoc block comments (see issue #102).
     pub input_schema: serde_json::Value,
     /// Extracted properties for template rendering
     pub properties: Vec<PropertyInfo>,


### PR DESCRIPTION
## Summary
- `create_tool_context()` now falls back `short_description` to the tool's own `description` when no LLM categorization is provided, so the generated header JSDoc always includes `@description`. Fixes the plain `generate` CLI path producing SKILL.md files with uninformative `"{tool_name} tool"` placeholders (#94).
- Documents that `ToolContext.input_schema` always holds the JSDoc-sanitized schema and adds a regression test locking in that invariant. Investigation confirmed the sanitize call already predates this branch (introduced in PR #100, commit 7b4c953) — no production code change was needed for #102, only documentation and test coverage to close the gap the issue described (#102).

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (659/659 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] New unit tests: `test_create_tool_context_without_categorization_falls_back_to_description`, `test_create_tool_context_input_schema_is_sanitized`

Closes #94
Closes #102