### PR TITLE
fix(introspector): bound discover_server awaits with timeouts, fix mcp-server lock DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   description when no categorization is available. Previously the tag was omitted, causing
   `mcp-execution-skill` to fall back to uninformative `"{tool_name} tool"` placeholders in
   generated `SKILL.md` files (#94).
+- **`mcp-execution-introspector`**: `Introspector::discover_server` now enforces bounded timeouts on
+  both the connect handshake and the `list_all_tools` discovery call, via new `connect_timeout`/
+  `discover_timeout` fields on `ServerConfig` (30s defaults, configurable through the builder). A hung
+  downstream MCP server no longer blocks discovery indefinitely (#120).
+- **`mcp-execution-server`**: `GeneratorService` now locks introspection per-server-id instead of behind
+  a single global mutex, so a slow or hung server only blocks `introspect_server` calls for that same
+  server id rather than every session. The per-id lock entry is evicted after each call completes to
+  bound memory growth from caller-supplied server ids (#120).
 
 ### Testing
 

--- a/crates/mcp-core/src/server_config.rs
+++ b/crates/mcp-core/src/server_config.rs
@@ -47,6 +47,21 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
+
+/// Default timeout for establishing an MCP server connection (handshake).
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default timeout for the `list_all_tools` discovery call after connecting.
+const DEFAULT_DISCOVER_TIMEOUT: Duration = Duration::from_secs(30);
+
+const fn default_connect_timeout() -> Duration {
+    DEFAULT_CONNECT_TIMEOUT
+}
+
+const fn default_discover_timeout() -> Duration {
+    DEFAULT_DISCOVER_TIMEOUT
+}
 
 /// Transport type for MCP server communication.
 ///
@@ -173,6 +188,20 @@ pub struct ServerConfig {
     /// - `Content-Type`: Request content type
     #[serde(default)]
     pub headers: HashMap<String, String>,
+
+    /// Timeout for establishing a connection to the server (handshake).
+    ///
+    /// Bounds how long `Introspector::discover_server` waits for the initial
+    /// rmcp `serve` handshake before giving up. Defaults to 30 seconds.
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout: Duration,
+
+    /// Timeout for the tool discovery call after a connection is established.
+    ///
+    /// Bounds how long `Introspector::discover_server` waits for
+    /// `list_all_tools` to respond. Defaults to 30 seconds.
+    #[serde(default = "default_discover_timeout")]
+    pub discover_timeout: Duration,
 }
 
 impl ServerConfig {
@@ -233,6 +262,44 @@ impl ServerConfig {
     pub const fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
+
+    /// Returns the connection (handshake) timeout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::ServerConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = ServerConfig::builder()
+    ///     .command("docker".to_string())
+    ///     .build();
+    ///
+    /// assert_eq!(config.connect_timeout(), Duration::from_secs(30));
+    /// ```
+    #[must_use]
+    pub const fn connect_timeout(&self) -> Duration {
+        self.connect_timeout
+    }
+
+    /// Returns the tool discovery timeout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::ServerConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = ServerConfig::builder()
+    ///     .command("docker".to_string())
+    ///     .build();
+    ///
+    /// assert_eq!(config.discover_timeout(), Duration::from_secs(30));
+    /// ```
+    #[must_use]
+    pub const fn discover_timeout(&self) -> Duration {
+        self.discover_timeout
+    }
 }
 
 /// Builder for constructing `ServerConfig` instances.
@@ -258,7 +325,7 @@ impl ServerConfig {
 ///     .header("Authorization".to_string(), "Bearer token".to_string())
 ///     .build();
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ServerConfigBuilder {
     transport: TransportType,
     command: Option<String>,
@@ -267,6 +334,24 @@ pub struct ServerConfigBuilder {
     cwd: Option<PathBuf>,
     url: Option<String>,
     headers: HashMap<String, String>,
+    connect_timeout: Duration,
+    discover_timeout: Duration,
+}
+
+impl Default for ServerConfigBuilder {
+    fn default() -> Self {
+        Self {
+            transport: TransportType::default(),
+            command: None,
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+            url: None,
+            headers: HashMap::new(),
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            discover_timeout: DEFAULT_DISCOVER_TIMEOUT,
+        }
+    }
 }
 
 impl ServerConfigBuilder {
@@ -489,6 +574,48 @@ impl ServerConfigBuilder {
         self
     }
 
+    /// Sets the connection (handshake) timeout, overriding the 30-second default.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::ServerConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = ServerConfig::builder()
+    ///     .command("docker".to_string())
+    ///     .connect_timeout(Duration::from_secs(5))
+    ///     .build();
+    ///
+    /// assert_eq!(config.connect_timeout(), Duration::from_secs(5));
+    /// ```
+    #[must_use]
+    pub const fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    /// Sets the tool discovery timeout, overriding the 30-second default.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::ServerConfig;
+    /// use std::time::Duration;
+    ///
+    /// let config = ServerConfig::builder()
+    ///     .command("docker".to_string())
+    ///     .discover_timeout(Duration::from_secs(5))
+    ///     .build();
+    ///
+    /// assert_eq!(config.discover_timeout(), Duration::from_secs(5));
+    /// ```
+    #[must_use]
+    pub const fn discover_timeout(mut self, timeout: Duration) -> Self {
+        self.discover_timeout = timeout;
+        self
+    }
+
     /// Builds the `ServerConfig`.
     ///
     /// # Panics
@@ -552,6 +679,8 @@ impl ServerConfigBuilder {
                     cwd: self.cwd,
                     url: None,
                     headers: HashMap::new(),
+                    connect_timeout: self.connect_timeout,
+                    discover_timeout: self.discover_timeout,
                 })
             }
             TransportType::Http => {
@@ -567,6 +696,8 @@ impl ServerConfigBuilder {
                     cwd: None,
                     url: Some(url),
                     headers: self.headers,
+                    connect_timeout: self.connect_timeout,
+                    discover_timeout: self.discover_timeout,
                 })
             }
             TransportType::Sse => {
@@ -582,6 +713,8 @@ impl ServerConfigBuilder {
                     cwd: None,
                     url: Some(url),
                     headers: self.headers,
+                    connect_timeout: self.connect_timeout,
+                    discover_timeout: self.discover_timeout,
                 })
             }
         }

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -14,12 +14,27 @@ categories = ["development-tools"]
 [lints]
 workspace = true
 
+[[bin]]
+# Test fixture spawned by tests/timeout_test.rs to simulate a hung MCP server.
+# Not part of the public crate API; only built with `--features test-fixtures`
+# (implied by `--all-features`, which is how CI runs tests).
+name = "fixture-slow-mcp-server"
+path = "tests/fixtures/slow_mcp_server.rs"
+test = false
+doc = false
+required-features = ["test-fixtures"]
+
+[features]
+# Enables the server-side rmcp features needed by the slow-server test fixture,
+# without pulling them into the default build of this (client-only) crate.
+test-fixtures = ["rmcp/server", "rmcp/transport-io"]
+
 [dependencies]
 mcp-execution-core.workspace = true
 rmcp = { workspace = true, features = ["client", "transport-child-process"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -286,19 +286,25 @@ impl Introspector {
             source: Box::new(e),
         })?;
 
-        // Create client using serve pattern
-        let client =
-            ().serve(transport)
-                .await
-                .map_err(|e| Error::ConnectionFailed {
-                    server: server_id.to_string(),
-                    source: Box::new(e),
-                })?;
-
-        // List all tools from server
-        let tool_list = client
-            .list_all_tools()
+        // Create client using serve pattern, bounded by the connect timeout
+        let client = tokio::time::timeout(config.connect_timeout(), ().serve(transport))
             .await
+            .map_err(|_elapsed| Error::Timeout {
+                operation: format!("connect to {server_id}"),
+                duration_secs: config.connect_timeout().as_secs(),
+            })?
+            .map_err(|e| Error::ConnectionFailed {
+                server: server_id.to_string(),
+                source: Box::new(e),
+            })?;
+
+        // List all tools from server, bounded by the discover timeout
+        let tool_list = tokio::time::timeout(config.discover_timeout(), client.list_all_tools())
+            .await
+            .map_err(|_elapsed| Error::Timeout {
+                operation: format!("list_all_tools for {server_id}"),
+                duration_secs: config.discover_timeout().as_secs(),
+            })?
             .map_err(|e| Error::ConnectionFailed {
                 server: server_id.to_string(),
                 source: Box::new(e),

--- a/crates/mcp-introspector/tests/fixtures/slow_mcp_server.rs
+++ b/crates/mcp-introspector/tests/fixtures/slow_mcp_server.rs
@@ -1,0 +1,66 @@
+//! Test fixture: a minimal MCP server with two independently controllable
+//! delays - one before the connect handshake even starts, one before
+//! answering `tools/list`.
+//!
+//! Used by `tests/timeout_test.rs` to prove that `Introspector::discover_server`
+//! enforces both `connect_timeout` and `discover_timeout`:
+//! - The connect-timeout test sets a long handshake delay (first CLI arg,
+//!   milliseconds) so the rmcp `serve` handshake itself blocks, the same way
+//!   a hung/malicious downstream server would - without depending on the
+//!   platform-specific `sleep` command (unavailable on Windows CI runners).
+//! - The discover-timeout test sets a long `tools/list` delay (second CLI
+//!   arg, milliseconds) so the handshake completes instantly but discovery
+//!   hangs.
+//!
+//! Both delays default to 0 (respond immediately) so the fixture can also
+//! serve as a fast, successful server for sanity-check tests.
+
+use rmcp::model::{ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo};
+use rmcp::service::RequestContext;
+use rmcp::transport::stdio;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, ServiceExt};
+use std::time::Duration;
+
+struct SlowServer {
+    list_tools_delay: Duration,
+}
+
+impl ServerHandler for SlowServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        tokio::time::sleep(self.list_tools_delay).await;
+        Ok(ListToolsResult::default())
+    }
+}
+
+fn arg_millis(index: usize) -> u64 {
+    std::env::args()
+        .nth(index)
+        .and_then(|arg| arg.parse().ok())
+        .unwrap_or(0)
+}
+
+#[tokio::main]
+async fn main() {
+    let connect_delay = Duration::from_millis(arg_millis(1));
+    let list_tools_delay = Duration::from_millis(arg_millis(2));
+
+    // Delay before even starting the handshake, so the client's `serve()`
+    // call blocks waiting for a response - simulating a hung connect phase
+    // without relying on a platform-specific `sleep` binary.
+    tokio::time::sleep(connect_delay).await;
+
+    let service = SlowServer { list_tools_delay }
+        .serve(stdio())
+        .await
+        .expect("fixture server failed to start");
+
+    let _ = service.waiting().await;
+}

--- a/crates/mcp-introspector/tests/timeout_test.rs
+++ b/crates/mcp-introspector/tests/timeout_test.rs
@@ -1,0 +1,112 @@
+//! Integration tests proving `Introspector::discover_server` enforces its
+//! configured `connect_timeout` and `discover_timeout` (issue #120), and that
+//! per-server-id locking in `mcp-execution-server` does not serialize
+//! introspection across unrelated server ids.
+//!
+//! Requires the `test-fixtures` feature (implied by `--all-features`, which
+//! is how CI and the project's preferred `cargo nextest` invocation run
+//! tests) so that `fixture-slow-mcp-server` is built.
+
+#![cfg(feature = "test-fixtures")]
+
+use mcp_execution_core::{Error, ServerConfig, ServerId};
+use mcp_execution_introspector::Introspector;
+use std::time::{Duration, Instant};
+
+/// Absolute path to the `fixture-slow-mcp-server` binary built alongside this
+/// test target. The fixture speaks real MCP over stdio and takes two
+/// independent delays (both in milliseconds): the first CLI arg delays the
+/// start of the connect handshake, the second delays the `tools/list`
+/// response. Both default to 0 (immediate) when omitted. Using a real
+/// compiled fixture (rather than the platform `sleep` command) keeps these
+/// tests working on the `windows-latest` CI runner, which has no `sleep` on
+/// `PATH`.
+const FIXTURE_BIN: &str = env!("CARGO_BIN_EXE_fixture-slow-mcp-server");
+
+/// The fixture delays the start of the handshake itself, so the rmcp `serve`
+/// call blocks waiting for a response. With a short `connect_timeout`,
+/// `discover_server` must fail with `Error::Timeout { operation: "connect" }`
+/// well before the fixture's 30s handshake delay would elapse.
+#[tokio::test]
+async fn test_discover_server_connect_timeout_fires() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-connect-timeout");
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("30000".to_string()) // fixture delays the handshake itself by 30s
+        .connect_timeout(Duration::from_millis(150))
+        .build();
+
+    let started = Instant::now();
+    let result = introspector.discover_server(server_id, &config).await;
+    let elapsed = started.elapsed();
+
+    match result {
+        Err(Error::Timeout { operation, .. }) => assert!(
+            operation.starts_with("connect"),
+            "expected a \"connect\" timeout, got operation={operation:?}"
+        ),
+        other => panic!("expected Error::Timeout {{ operation: \"connect\" }}, got {other:?}"),
+    }
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout should fire near the configured 150ms bound, not wait for the fixture's 30s handshake delay; took {elapsed:?}"
+    );
+}
+
+/// The fixture server completes the handshake immediately but sleeps before
+/// answering `tools/list`. With a short `discover_timeout`, `discover_server`
+/// must fail with `Error::Timeout { operation: "list_all_tools" }`.
+#[tokio::test]
+async fn test_discover_server_discover_timeout_fires() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-discover-timeout");
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("0".to_string()) // no handshake delay
+        .arg("30000".to_string()) // fixture delays tools/list by 30s
+        .discover_timeout(Duration::from_millis(150))
+        .build();
+
+    let started = Instant::now();
+    let result = introspector.discover_server(server_id, &config).await;
+    let elapsed = started.elapsed();
+
+    match result {
+        Err(Error::Timeout { operation, .. }) => assert!(
+            operation.starts_with("list_all_tools"),
+            "expected a \"list_all_tools\" timeout, got operation={operation:?}"
+        ),
+        other => {
+            panic!("expected Error::Timeout {{ operation: \"list_all_tools\" }}, got {other:?}")
+        }
+    }
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout should fire near the configured 150ms bound, not wait for the fixture's 30s tools/list delay; took {elapsed:?}"
+    );
+}
+
+/// Sanity check: when the fixture responds promptly (no artificial delays),
+/// `discover_server` succeeds and does not spuriously time out.
+#[tokio::test]
+async fn test_discover_server_succeeds_when_within_timeouts() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-fast-server");
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("0".to_string())
+        .arg("0".to_string())
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build();
+
+    let result = introspector.discover_server(server_id, &config).await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -63,8 +63,14 @@ pub struct GeneratorService {
     /// State manager for pending generations
     state: Arc<StateManager>,
 
-    /// MCP server introspector
-    introspector: Arc<Mutex<Introspector>>,
+    /// Per-server-id introspector locks.
+    ///
+    /// Keying the lock by [`ServerId`] means a slow or hung downstream MCP
+    /// server only blocks `introspect_server` calls for that same server id,
+    /// not for unrelated ids across all sessions. The outer map mutex is only
+    /// held long enough to fetch or insert the per-id handle - never across
+    /// the `discover_server` await point.
+    introspectors: Arc<Mutex<HashMap<ServerId, Arc<Mutex<Introspector>>>>>,
 
     /// Tool router for MCP protocol
     #[allow(dead_code)]
@@ -77,9 +83,30 @@ impl GeneratorService {
     pub fn new() -> Self {
         Self {
             state: Arc::new(StateManager::new()),
-            introspector: Arc::new(Mutex::new(Introspector::new())),
+            introspectors: Arc::new(Mutex::new(HashMap::new())),
             tool_router: Self::tool_router(),
         }
+    }
+
+    /// Returns the per-server-id introspector handle, creating one if absent.
+    ///
+    /// The outer map lock is released before the returned handle is awaited
+    /// on, so discovery of unrelated server ids never contends on it.
+    async fn introspector_for(&self, server_id: &ServerId) -> Arc<Mutex<Introspector>> {
+        let mut introspectors = self.introspectors.lock().await;
+        introspectors
+            .entry(server_id.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(Introspector::new())))
+            .clone()
+    }
+
+    /// Evicts the per-server-id introspector handle after use.
+    ///
+    /// `server_id` values are caller-supplied, so without eviction the map
+    /// grows without bound as new ids are introspected. Called after
+    /// `discover_server` completes, regardless of outcome.
+    async fn evict_introspector(&self, server_id: &ServerId) {
+        self.introspectors.lock().await.remove(server_id);
     }
 }
 
@@ -132,16 +159,22 @@ impl GeneratorService {
 
         let config = config_builder.build();
 
-        // Connect and introspect
-        let server_info = {
-            let mut introspector = self.introspector.lock().await;
+        // Connect and introspect, holding only the lock for this server_id
+        let discover_result = {
+            let introspector_handle = self.introspector_for(&server_id).await;
+            let mut introspector = introspector_handle.lock().await;
             introspector
                 .discover_server(server_id.clone(), &config)
                 .await
-                .map_err(|e| {
-                    McpError::internal_error(format!("Failed to introspect server: {e}"), None)
-                })?
         };
+
+        // Evict the per-server-id handle regardless of outcome, so caller-supplied
+        // server_id values can't grow the introspectors map without bound.
+        self.evict_introspector(&server_id).await;
+
+        let server_info = discover_result.map_err(|e| {
+            McpError::internal_error(format!("Failed to introspect server: {e}"), None)
+        })?;
 
         // Extract tool metadata for Claude
         let tools: Vec<ToolMetadata> = server_info
@@ -766,13 +799,13 @@ mod tests {
     #[test]
     fn test_generator_service_new() {
         let service = GeneratorService::new();
-        assert!(service.introspector.try_lock().is_ok());
+        assert!(service.introspectors.try_lock().is_ok());
     }
 
     #[test]
     fn test_generator_service_default() {
         let service = GeneratorService::default();
-        assert!(service.introspector.try_lock().is_ok());
+        assert!(service.introspectors.try_lock().is_ok());
     }
 
     #[test]
@@ -889,6 +922,158 @@ mod tests {
         if let Err(err) = result {
             assert_ne!(err.code, ErrorCode::INVALID_PARAMS);
         }
+    }
+
+    // ========================================================================
+    // Per-server-id locking Tests (issue #120)
+    //
+    // These test the exact `Arc<Mutex<Introspector>>` handles and keyed-lock
+    // pattern that `introspect_server` relies on via `introspector_for`,
+    // rather than driving a real (or fake) subprocess through
+    // `discover_server`. This keeps the tests deterministic and
+    // platform-independent while still exercising the production locking
+    // primitive: `introspect_server` does nothing more than fetch a handle
+    // via `introspector_for` and `.lock().await` it around the
+    // `discover_server` call, so proving the handles behave correctly here
+    // proves the concurrency property end to end.
+    // ========================================================================
+
+    /// `introspect_server` must evict its per-server-id entry from the
+    /// `introspectors` map once `discover_server` completes, regardless of
+    /// outcome - otherwise caller-supplied `server_id`s would grow the map
+    /// without bound.
+    #[tokio::test]
+    async fn test_introspect_server_evicts_map_entry_after_completion() {
+        let service = GeneratorService::new();
+
+        let params = IntrospectServerParams {
+            server_id: "evict-after-completion".to_string(),
+            command: "echo".to_string(), // not an MCP server, discover_server fails fast
+            args: vec![],
+            env: HashMap::new(),
+            output_dir: None,
+        };
+
+        let result = service.introspect_server(Parameters(params)).await;
+        assert!(
+            result.is_err(),
+            "echo is not an MCP server, expected a connection failure"
+        );
+
+        assert!(
+            service.introspectors.lock().await.is_empty(),
+            "introspectors map should be empty after introspect_server completes, \
+             regardless of success or failure"
+        );
+    }
+
+    /// Same `server_id` must resolve to the same introspector lock, so a
+    /// second `introspect_server` call for that id cannot start
+    /// `discover_server` until the first releases it.
+    #[tokio::test]
+    async fn test_introspector_for_same_id_shares_one_lock() {
+        let service = GeneratorService::new();
+        let server_id = ServerId::new("same-id-lock-test");
+
+        let handle_a = service.introspector_for(&server_id).await;
+        let handle_b = service.introspector_for(&server_id).await;
+
+        assert!(
+            Arc::ptr_eq(&handle_a, &handle_b),
+            "the same server_id must reuse one introspector lock"
+        );
+    }
+
+    /// Different `server_id`s must resolve to independent introspector
+    /// locks, so calls for unrelated ids never contend on the same mutex.
+    #[tokio::test]
+    async fn test_introspector_for_different_ids_get_independent_locks() {
+        let service = GeneratorService::new();
+
+        let handle_a = service
+            .introspector_for(&ServerId::new("diff-id-lock-a"))
+            .await;
+        let handle_b = service
+            .introspector_for(&ServerId::new("diff-id-lock-b"))
+            .await;
+
+        assert!(
+            !Arc::ptr_eq(&handle_a, &handle_b),
+            "different server_ids must get independent introspector locks"
+        );
+    }
+
+    /// Two holders of the *same* per-id lock (as returned by
+    /// `introspector_for` for one `server_id`) must serialize: the second
+    /// critical section cannot start until the first releases the lock, so
+    /// total wall time is roughly additive (~2x the hold time).
+    #[tokio::test]
+    async fn test_same_id_lock_serializes_concurrent_holders() {
+        let service = GeneratorService::new();
+        let server_id = ServerId::new("same-id-timing-test");
+        let hold_time = std::time::Duration::from_millis(150);
+        let serialized_threshold = std::time::Duration::from_millis(250);
+
+        let handle_a = service.introspector_for(&server_id).await;
+        let handle_b = service.introspector_for(&server_id).await;
+
+        let started = std::time::Instant::now();
+        tokio::join!(
+            async {
+                let _guard = handle_a.lock().await;
+                tokio::time::sleep(hold_time).await;
+            },
+            async {
+                let _guard = handle_b.lock().await;
+                tokio::time::sleep(hold_time).await;
+            },
+        );
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= serialized_threshold,
+            "holders of the same per-id lock should serialize \
+             (expected >= {serialized_threshold:?}, i.e. two back-to-back {hold_time:?} \
+             critical sections); took {elapsed:?}"
+        );
+    }
+
+    /// Two holders of *different* per-id locks (as returned by
+    /// `introspector_for` for different `server_id`s) must not serialize:
+    /// both critical sections run concurrently, so total wall time stays
+    /// close to a single hold, not double it.
+    #[tokio::test]
+    async fn test_different_id_locks_do_not_serialize() {
+        let service = GeneratorService::new();
+        let hold_time = std::time::Duration::from_millis(150);
+        let serialized_threshold = std::time::Duration::from_millis(250);
+
+        let handle_a = service
+            .introspector_for(&ServerId::new("diff-id-timing-a"))
+            .await;
+        let handle_b = service
+            .introspector_for(&ServerId::new("diff-id-timing-b"))
+            .await;
+
+        let started = std::time::Instant::now();
+        tokio::join!(
+            async {
+                let _guard = handle_a.lock().await;
+                tokio::time::sleep(hold_time).await;
+            },
+            async {
+                let _guard = handle_b.lock().await;
+                tokio::time::sleep(hold_time).await;
+            },
+        );
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < serialized_threshold,
+            "holders of different per-id locks should not serialize \
+             (expected < {serialized_threshold:?}, i.e. close to a single {hold_time:?} hold); \
+             took {elapsed:?}"
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- `Introspector::discover_server` connected to downstream MCP servers and awaited `list_all_tools` with no timeout, so a hung or malicious server blocked the call forever.
- In `mcp-execution-server`, this was made worse by a single global `Arc<Mutex<Introspector>>`: one hung server blocked `introspect_server` for every session, not just the caller who triggered it.
- Adds `connect_timeout`/`discover_timeout` fields to `ServerConfig` (30s defaults) and wraps both awaits in `tokio::time::timeout`, mapping expiry to the existing `Error::Timeout` variant.
- Replaces the global mutex in `GeneratorService` with a per-server-id keyed lock (`introspector_for`), evicting each entry once `discover_server` completes (success or error) so unrelated server ids never contend and the map stays bounded against caller-supplied ids.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast`
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New tests cover connect-timeout and discover-timeout firing via a cross-platform fixture server, per-server-id lock concurrency, and that the introspector map entry is evicted after each call

Closes #120