### PR TITLE
refactor(mcp-server): add injectable clock for session expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of silently overwriting one another's generated file and producing a duplicate `index.ts`
   export.
 
+### Changed
+
+- **`mcp-execution-server`**: introduced an injectable `Clock` trait (`SystemClock` in production)
+  for `PendingGeneration` session expiry, replacing direct `Utc::now()` calls. Tests can now inject
+  a fake clock to exercise the 30-minute TTL boundary deterministically instead of rewinding
+  `expires_at` after construction (#121).
+
 ### Fixed
 
 - **`mcp-execution-codegen`**: CLI-generated TypeScript files (`generate` without LLM categorization)

--- a/crates/mcp-cli/src/main.rs
+++ b/crates/mcp-cli/src/main.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::unused_async)]
 #![allow(clippy::cast_possible_truncation)]
 // u128->u64 for millis is safe in practice
-// TODO(phase-7.3): Add comprehensive error documentation to all public CLI functions
+// TODO(#126): Add comprehensive error documentation to all public CLI functions
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::needless_collect)]
 #![allow(clippy::unnecessary_wraps)] // API design requires Result for consistency across commands

--- a/crates/mcp-server/src/clock.rs
+++ b/crates/mcp-server/src/clock.rs
@@ -1,0 +1,103 @@
+//! Injectable clock abstraction for session expiry.
+//!
+//! Production code uses [`SystemClock`], a zero-cost wrapper around
+//! [`Utc::now`](chrono::Utc::now). Tests can inject a fake clock to
+//! deterministically exercise expiry boundaries instead of rewinding
+//! [`PendingGeneration::expires_at`](crate::types::PendingGeneration::expires_at)
+//! after construction.
+
+use chrono::{DateTime, Utc};
+use std::fmt::Debug;
+
+/// Provides the current time for session expiry calculations.
+///
+/// Implementors must be [`Send`] + [`Sync`] so they can be shared across
+/// async tasks via `Arc<dyn Clock>`.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::clock::{Clock, SystemClock};
+///
+/// let clock = SystemClock;
+/// assert!(clock.now().timestamp() > 0);
+/// ```
+pub trait Clock: Send + Sync + Debug {
+    /// Returns the current time.
+    fn now(&self) -> DateTime<Utc>;
+}
+
+/// Real-time [`Clock`] backed by [`Utc::now`].
+///
+/// This is the default clock used in production; it matches the previous
+/// unconditional `Utc::now()` calls exactly.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::clock::{Clock, SystemClock};
+///
+/// let clock = SystemClock;
+/// assert!(clock.now().timestamp() > 0);
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+#[cfg(test)]
+pub use test_support::TestClock;
+
+#[cfg(test)]
+mod test_support {
+    use super::Clock;
+    use chrono::{DateTime, Duration, Utc};
+    use std::sync::{Arc, Mutex};
+
+    /// Fake clock for tests: holds a mutable timestamp that can be advanced
+    /// or set directly, so expiry boundaries can be exercised deterministically
+    /// without rewinding `expires_at` after construction.
+    ///
+    /// Cloning shares the underlying timestamp (`Arc<Mutex<_>>`), so a clone
+    /// handed to a `StateManager` or `PendingGeneration` observes the same
+    /// advances as the original.
+    #[derive(Debug, Clone)]
+    pub struct TestClock(Arc<Mutex<DateTime<Utc>>>);
+
+    impl TestClock {
+        /// Creates a fake clock fixed at `now`.
+        #[must_use]
+        pub fn new(now: DateTime<Utc>) -> Self {
+            Self(Arc::new(Mutex::new(now)))
+        }
+
+        /// Sets the clock to an arbitrary point in time.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the internal mutex is poisoned.
+        pub fn set(&self, now: DateTime<Utc>) {
+            *self.0.lock().unwrap() = now;
+        }
+
+        /// Advances the clock forward by `duration`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the internal mutex is poisoned.
+        pub fn advance(&self, duration: Duration) {
+            let mut guard = self.0.lock().unwrap();
+            *guard += duration;
+        }
+    }
+
+    impl Clock for TestClock {
+        fn now(&self) -> DateTime<Utc> {
+            *self.0.lock().unwrap()
+        }
+    }
+}

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -49,10 +49,12 @@
 //! - **Type-safe**: Full TypeScript types from MCP schemas
 //! - **Discoverable**: grep-friendly headers for tool discovery
 
+pub mod clock;
 pub mod service;
 pub mod state;
 pub mod types;
 
+pub use clock::{Clock, SystemClock};
 pub use service::GeneratorService;
 pub use state::StateManager;
 pub use types::{

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -5,6 +5,7 @@
 //! 2. `save_categorized_tools` - Generate TypeScript files with categorization
 //! 3. `list_generated_servers` - List all servers with generated files
 
+use crate::clock::{Clock, SystemClock};
 use crate::state::StateManager;
 use crate::types::{
     CategorizedTool, GeneratedServerInfo, IntrospectServerParams, IntrospectServerResult,
@@ -72,18 +73,30 @@ pub struct GeneratorService {
     /// the `discover_server` await point.
     introspectors: Arc<Mutex<HashMap<ServerId, Arc<Mutex<Introspector>>>>>,
 
+    /// Clock used to construct pending generations (shared with `state`)
+    clock: Arc<dyn Clock>,
+
     /// Tool router for MCP protocol
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
 
 impl GeneratorService {
-    /// Creates a new generator service.
+    /// Creates a new generator service using the real system clock.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    /// Creates a new generator service backed by a custom clock.
+    ///
+    /// Used in tests to inject a fake clock so session expiry can be
+    /// exercised deterministically.
+    fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
-            state: Arc::new(StateManager::new()),
+            state: Arc::new(StateManager::with_clock(Arc::clone(&clock))),
             introspectors: Arc::new(Mutex::new(HashMap::new())),
+            clock,
             tool_router: Self::tool_router(),
         }
     }
@@ -192,8 +205,13 @@ impl GeneratorService {
             .collect();
 
         // Store pending generation
-        let pending =
-            PendingGeneration::new(server_id, server_info.clone(), config, output_dir.clone());
+        let pending = PendingGeneration::new(
+            server_id,
+            server_info.clone(),
+            config,
+            output_dir.clone(),
+            self.clock.as_ref(),
+        );
 
         let session_id = self.state.store(pending.clone()).await;
 
@@ -1125,6 +1143,7 @@ mod tests {
             server_info,
             ServerConfig::builder().command("echo".to_string()).build(),
             PathBuf::from("/tmp/test"),
+            &SystemClock,
         );
 
         let session_id = service.state.store(pending).await;
@@ -1150,6 +1169,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_save_categorized_tools_expired_session() {
+        use crate::clock::TestClock;
         use chrono::Duration;
 
         let service = GeneratorService::new();
@@ -1168,17 +1188,73 @@ mod tests {
             tools: vec![],
         };
 
-        let mut pending = PendingGeneration::new(
+        // Inject a clock fixed an hour in the past so `expires_at` is already
+        // behind us, instead of rewinding `expires_at` after construction.
+        let past_clock = TestClock::new(Utc::now() - Duration::hours(1));
+        let pending = PendingGeneration::new(
             server_id,
             server_info,
             ServerConfig::builder().command("echo".to_string()).build(),
             PathBuf::from("/tmp/test"),
+            &past_clock,
         );
 
-        // Manually expire it
-        pending.expires_at = Utc::now() - Duration::hours(1);
+        let session_id = service.state.store(pending).await;
+
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    }
+
+    /// Proves `GeneratorService::with_clock` actually drives session expiry end
+    /// to end through `save_categorized_tools`: a session stored while the
+    /// shared clock is fresh must become unreachable once that same clock (not
+    /// the real wall clock) is advanced past the TTL. This exercises the
+    /// `Arc<dyn Clock>` shared between `GeneratorService` and its
+    /// `StateManager` (`with_clock` clones the same `Arc` into both).
+    #[tokio::test]
+    async fn test_shared_clock_drives_save_categorized_tools_expiry() {
+        use crate::clock::TestClock;
+        use chrono::Duration;
+
+        let start = Utc::now();
+        let clock = Arc::new(TestClock::new(start));
+        let service = GeneratorService::with_clock(Arc::clone(&clock) as Arc<dyn Clock>);
+
+        let server_id = ServerId::new("test");
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: server_id.clone(),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![],
+        };
+
+        let pending = PendingGeneration::new(
+            server_id,
+            server_info,
+            ServerConfig::builder().command("echo".to_string()).build(),
+            PathBuf::from("/tmp/test"),
+            clock.as_ref(),
+        );
 
         let session_id = service.state.store(pending).await;
+
+        // Advance the service's own shared clock, not the real wall clock, past the TTL.
+        clock.advance(
+            Duration::minutes(PendingGeneration::DEFAULT_TIMEOUT_MINUTES) + Duration::seconds(1),
+        );
 
         let params = SaveCategorizedToolsParams {
             session_id,

--- a/crates/mcp-server/src/state.rs
+++ b/crates/mcp-server/src/state.rs
@@ -4,6 +4,7 @@
 //! and `save_categorized_tools` calls. Sessions expire after 30 minutes and
 //! are cleaned up lazily on each operation.
 
+use crate::clock::{Clock, SystemClock};
 use crate::types::PendingGeneration;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -20,6 +21,7 @@ use uuid::Uuid;
 /// ```
 /// use mcp_execution_server::state::StateManager;
 /// use mcp_execution_server::types::PendingGeneration;
+/// use mcp_execution_server::clock::SystemClock;
 /// use mcp_execution_core::{ServerId, ServerConfig};
 /// use mcp_execution_introspector::ServerInfo;
 /// use std::path::PathBuf;
@@ -43,6 +45,7 @@ use uuid::Uuid;
 ///     server_info,
 ///     ServerConfig::builder().command("npx".to_string()).build(),
 ///     PathBuf::from("/tmp/output"),
+///     &SystemClock,
 /// );
 ///
 /// // Store and get session ID
@@ -53,16 +56,35 @@ use uuid::Uuid;
 /// assert!(retrieved.is_some());
 /// # }
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct StateManager {
     pending: Arc<RwLock<HashMap<Uuid, PendingGeneration>>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl Default for StateManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl StateManager {
-    /// Creates a new state manager.
+    /// Creates a new state manager using the real system clock.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    /// Creates a new state manager backed by a custom clock.
+    ///
+    /// Used in tests to inject a fake clock so session expiry can be
+    /// exercised deterministically.
+    #[must_use]
+    pub(crate) fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            pending: Arc::new(RwLock::new(HashMap::new())),
+            clock,
+        }
     }
 
     /// Stores a pending generation and returns a session ID.
@@ -88,7 +110,8 @@ impl StateManager {
         let mut pending = self.pending.write().await;
 
         // Clean up expired sessions
-        pending.retain(|_, g| !g.is_expired());
+        let clock = self.clock.as_ref();
+        pending.retain(|_, g| !g.is_expired(clock));
 
         pending.insert(session_id, generation);
         session_id
@@ -125,13 +148,14 @@ impl StateManager {
             let mut pending = self.pending.write().await;
 
             // Clean up expired sessions
-            pending.retain(|_, g| !g.is_expired());
+            let clock = self.clock.as_ref();
+            pending.retain(|_, g| !g.is_expired(clock));
 
             pending.remove(&session_id)?
         };
 
         // Verify not expired (lock already released)
-        if generation.is_expired() {
+        if generation.is_expired(self.clock.as_ref()) {
             return None;
         }
 
@@ -166,9 +190,10 @@ impl StateManager {
     /// ```
     pub async fn get(&self, session_id: Uuid) -> Option<PendingGeneration> {
         let pending = self.pending.read().await;
+        let clock = self.clock.as_ref();
         pending
             .get(&session_id)
-            .filter(|g| !g.is_expired())
+            .filter(|g| !g.is_expired(clock))
             .cloned()
     }
 
@@ -186,7 +211,8 @@ impl StateManager {
     /// ```
     pub async fn pending_count(&self) -> usize {
         let pending = self.pending.read().await;
-        pending.values().filter(|g| !g.is_expired()).count()
+        let clock = self.clock.as_ref();
+        pending.values().filter(|g| !g.is_expired(clock)).count()
     }
 
     /// Cleans up all expired sessions.
@@ -207,7 +233,8 @@ impl StateManager {
     pub async fn cleanup_expired(&self) -> usize {
         let mut pending = self.pending.write().await;
         let before = pending.len();
-        pending.retain(|_, g| !g.is_expired());
+        let clock = self.clock.as_ref();
+        pending.retain(|_, g| !g.is_expired(clock));
         before - pending.len()
     }
 }
@@ -215,13 +242,17 @@ impl StateManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::clock::{SystemClock, TestClock};
     use crate::types::PendingGeneration;
-    use chrono::{Duration, Utc};
     use mcp_execution_core::{ServerConfig, ServerId, ToolName};
     use mcp_execution_introspector::ServerInfo;
     use std::path::PathBuf;
 
     fn create_test_pending() -> PendingGeneration {
+        create_test_pending_with_clock(&SystemClock)
+    }
+
+    fn create_test_pending_with_clock(clock: &dyn Clock) -> PendingGeneration {
         use mcp_execution_introspector::{ServerCapabilities, ToolInfo};
 
         let server_id = ServerId::new("test");
@@ -244,13 +275,15 @@ mod tests {
         let config = ServerConfig::builder().command("echo".to_string()).build();
         let output_dir = PathBuf::from("/tmp/test");
 
-        PendingGeneration::new(server_id, server_info, config, output_dir)
+        PendingGeneration::new(server_id, server_info, config, output_dir, clock)
     }
 
+    /// Builds an already-expired pending generation by constructing it with a
+    /// clock fixed an hour in the past, instead of rewinding `expires_at`
+    /// after construction.
     fn create_expired_pending() -> PendingGeneration {
-        let mut pending = create_test_pending();
-        pending.expires_at = Utc::now() - Duration::hours(1);
-        pending
+        let past_clock = TestClock::new(chrono::Utc::now() - chrono::Duration::hours(1));
+        create_test_pending_with_clock(&past_clock)
     }
 
     #[tokio::test]
@@ -340,6 +373,42 @@ mod tests {
 
         let removed = state.cleanup_expired().await;
         assert_eq!(removed, 1); // One expired session removed
+    }
+
+    /// Proves `StateManager` consults the clock it was constructed with (not a
+    /// hardcoded `SystemClock`): a session created and stored while the shared
+    /// clock is fresh must flip to expired across `get`/`pending_count`/
+    /// `cleanup_expired`/`take` once that same clock is moved past the TTL —
+    /// real wall-clock time barely advances during the test, so this would fail
+    /// if any of those call sites silently used `SystemClock` instead of
+    /// `self.clock`.
+    #[tokio::test]
+    async fn test_shared_clock_drives_expiry() {
+        let start = chrono::Utc::now();
+        let clock = Arc::new(TestClock::new(start));
+        let state = StateManager::with_clock(Arc::clone(&clock) as Arc<dyn Clock>);
+
+        let pending = create_test_pending_with_clock(clock.as_ref());
+        let session_id = state.store(pending).await;
+
+        // Fresh session is visible while the clock is still within the TTL window.
+        assert!(state.get(session_id).await.is_some());
+        assert_eq!(state.pending_count().await, 1);
+
+        // Jump the shared clock straight past the 30-minute boundary.
+        clock.set(
+            start
+                + chrono::Duration::minutes(PendingGeneration::DEFAULT_TIMEOUT_MINUTES)
+                + chrono::Duration::seconds(1),
+        );
+
+        assert!(
+            state.get(session_id).await.is_none(),
+            "expiry should track the injected clock, not Utc::now()"
+        );
+        assert_eq!(state.pending_count().await, 0);
+        assert_eq!(state.cleanup_expired().await, 1);
+        assert!(state.take(session_id).await.is_none());
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -5,6 +5,7 @@
 //! - `save_categorized_tools`: Generate TypeScript files with categorization
 //! - `list_generated_servers`: List all servers with generated files
 
+use crate::clock::Clock;
 use chrono::{DateTime, Utc};
 use mcp_execution_core::{ServerConfig, ServerId};
 use mcp_execution_introspector::ServerInfo;
@@ -254,10 +255,15 @@ impl PendingGeneration {
 
     /// Creates a new pending generation session.
     ///
+    /// The session's `created_at`/`expires_at` are derived from `clock.now()`,
+    /// so tests can inject a fake clock instead of rewinding `expires_at`
+    /// after construction. Production callers should pass [`SystemClock`](crate::clock::SystemClock).
+    ///
     /// # Examples
     ///
     /// ```
     /// use mcp_execution_server::types::PendingGeneration;
+    /// use mcp_execution_server::clock::SystemClock;
     /// use mcp_execution_core::{ServerId, ServerConfig};
     /// use mcp_execution_introspector::ServerInfo;
     /// use std::path::PathBuf;
@@ -276,6 +282,7 @@ impl PendingGeneration {
     ///     server_info,
     ///     config,
     ///     output_dir,
+    ///     &SystemClock,
     /// );
     /// # }
     /// ```
@@ -285,8 +292,9 @@ impl PendingGeneration {
         server_info: ServerInfo,
         config: ServerConfig,
         output_dir: PathBuf,
+        clock: &dyn Clock,
     ) -> Self {
-        let now = Utc::now();
+        let now = clock.now();
         Self {
             server_id,
             server_info,
@@ -297,12 +305,13 @@ impl PendingGeneration {
         }
     }
 
-    /// Checks if this session has expired.
+    /// Checks if this session has expired, using `clock.now()` as the current time.
     ///
     /// # Examples
     ///
     /// ```
     /// use mcp_execution_server::types::PendingGeneration;
+    /// use mcp_execution_server::clock::SystemClock;
     /// # use mcp_execution_core::{ServerId, ServerConfig};
     /// # use mcp_execution_introspector::ServerInfo;
     /// # use std::path::PathBuf;
@@ -313,25 +322,63 @@ impl PendingGeneration {
     ///     server_info,
     ///     ServerConfig::builder().command("echo".to_string()).build(),
     ///     PathBuf::from("/tmp"),
+    ///     &SystemClock,
     /// );
     ///
-    /// assert!(!pending.is_expired());
+    /// assert!(!pending.is_expired(&SystemClock));
     /// # }
     /// ```
     #[must_use]
-    pub fn is_expired(&self) -> bool {
-        Utc::now() > self.expires_at
+    pub fn is_expired(&self, clock: &dyn Clock) -> bool {
+        clock.now() > self.expires_at
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::clock::{SystemClock, TestClock};
 
     #[test]
     fn test_pending_generation_not_expired() {
         let pending = create_test_pending();
-        assert!(!pending.is_expired());
+        assert!(!pending.is_expired(&SystemClock));
+    }
+
+    #[test]
+    fn test_pending_generation_not_expired_at_exact_boundary() {
+        let clock = TestClock::new(Utc::now());
+        let pending = create_test_pending_with_clock(&clock);
+
+        // `is_expired` uses strict `>`, so the exact expiry instant is not expired.
+        clock.advance(chrono::Duration::minutes(
+            PendingGeneration::DEFAULT_TIMEOUT_MINUTES,
+        ));
+        assert!(!pending.is_expired(&clock));
+    }
+
+    #[test]
+    fn test_pending_generation_not_expired_one_second_before_boundary() {
+        let clock = TestClock::new(Utc::now());
+        let pending = create_test_pending_with_clock(&clock);
+
+        clock.advance(
+            chrono::Duration::minutes(PendingGeneration::DEFAULT_TIMEOUT_MINUTES)
+                - chrono::Duration::seconds(1),
+        );
+        assert!(!pending.is_expired(&clock));
+    }
+
+    #[test]
+    fn test_pending_generation_expired_one_second_after_boundary() {
+        let clock = TestClock::new(Utc::now());
+        let pending = create_test_pending_with_clock(&clock);
+
+        clock.advance(
+            chrono::Duration::minutes(PendingGeneration::DEFAULT_TIMEOUT_MINUTES)
+                + chrono::Duration::seconds(1),
+        );
+        assert!(pending.is_expired(&clock));
     }
 
     #[test]
@@ -347,8 +394,12 @@ mod tests {
         let _deserialized: CategorizedTool = serde_json::from_str(&json).unwrap();
     }
 
-    // Test helper
+    // Test helpers
     fn create_test_pending() -> PendingGeneration {
+        create_test_pending_with_clock(&SystemClock)
+    }
+
+    fn create_test_pending_with_clock(clock: &dyn Clock) -> PendingGeneration {
         use mcp_execution_core::ToolName;
         use mcp_execution_introspector::{ServerCapabilities, ToolInfo};
 
@@ -372,6 +423,6 @@ mod tests {
         let config = ServerConfig::builder().command("echo".to_string()).build();
         let output_dir = PathBuf::from("/tmp/test");
 
-        PendingGeneration::new(server_id, server_info, config, output_dir)
+        PendingGeneration::new(server_id, server_info, config, output_dir, clock)
     }
 }

--- a/crates/mcp-server/tests/integration_tests.rs
+++ b/crates/mcp-server/tests/integration_tests.rs
@@ -7,7 +7,9 @@
 use chrono::Duration;
 use mcp_execution_core::{ServerConfig, ServerId, ToolName};
 use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
-use mcp_execution_server::{CategorizedTool, GeneratorService, PendingGeneration, StateManager};
+use mcp_execution_server::{
+    CategorizedTool, GeneratorService, PendingGeneration, StateManager, SystemClock,
+};
 use rmcp::handler::server::ServerHandler;
 use std::sync::Arc;
 
@@ -70,7 +72,7 @@ async fn test_state_manager_workflow() {
     let output_dir = std::env::temp_dir().join("mcp-server-test");
 
     // Store pending generation
-    let pending = PendingGeneration::new(server_id, server_info, config, output_dir);
+    let pending = PendingGeneration::new(server_id, server_info, config, output_dir, &SystemClock);
     let session_id = state.store(pending.clone()).await;
 
     // Verify it's stored
@@ -112,7 +114,8 @@ async fn test_multiple_concurrent_sessions() {
         let config = ServerConfig::builder().command("echo".to_string()).build();
         let output_dir = std::env::temp_dir().join(format!("mcp-test-{i}"));
 
-        let pending = PendingGeneration::new(server_id, server_info, config, output_dir);
+        let pending =
+            PendingGeneration::new(server_id, server_info, config, output_dir, &SystemClock);
         let session_id = state.store(pending).await;
         sessions.push(session_id);
     }
@@ -140,7 +143,8 @@ async fn test_state_manager_handles_expiration() {
     let output_dir = std::env::temp_dir().join("mcp-expire-test");
 
     // Create and manually expire a session
-    let mut pending = PendingGeneration::new(server_id, server_info, config, output_dir);
+    let mut pending =
+        PendingGeneration::new(server_id, server_info, config, output_dir, &SystemClock);
     pending.expires_at = chrono::Utc::now() - Duration::hours(1);
 
     let session_id = state.store(pending).await;
@@ -208,14 +212,14 @@ async fn test_state_manager_get_without_consuming() {
 #[test]
 fn test_pending_generation_not_expired_initially() {
     let pending = create_test_pending("test");
-    assert!(!pending.is_expired());
+    assert!(!pending.is_expired(&SystemClock));
 }
 
 #[test]
 fn test_pending_generation_expires_correctly() {
     let mut pending = create_test_pending("test");
     pending.expires_at = chrono::Utc::now() - Duration::minutes(1);
-    assert!(pending.is_expired());
+    assert!(pending.is_expired(&SystemClock));
 }
 
 #[test]
@@ -348,5 +352,5 @@ fn create_test_pending(server_id_str: &str) -> PendingGeneration {
     let config = ServerConfig::builder().command("echo".to_string()).build();
     let output_dir = std::env::temp_dir().join(format!("mcp-test-{server_id_str}"));
 
-    PendingGeneration::new(server_id, server_info, config, output_dir)
+    PendingGeneration::new(server_id, server_info, config, output_dir, &SystemClock)
 }

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -45,7 +45,7 @@ static DESC_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"@description[ \t]+(.+)").expect("valid regex"));
 static INTERFACE_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"interface\s+\w+Params\s*\{([^}]*)\}").expect("valid regex"));
-// TODO(review): INTERFACE_REGEX body truncation — nested-type bodies containing `}` are cut off
+// TODO(#124): INTERFACE_REGEX body truncation — nested-type bodies containing `}` are cut off
 // (e.g., `{ foo: string }` as a property type truncates the interface match early).
 // Suggested action: switch to a balanced-brace parser or accept multi-pass scanning.
 
@@ -291,7 +291,7 @@ pub fn parse_tool_file(content: &str, filename: &str) -> Result<ParsedToolFile, 
 ///
 /// Multi-line property declarations (type wraps to the next line) are not
 /// supported — each property must fit on a single line.
-/// TODO(review): Add multi-line property support if generated TS ever wraps types.
+/// TODO(#125): Add multi-line property support if generated TS ever wraps types.
 fn parse_parameters(content: &str) -> Vec<ParsedParameter> {
     let mut parameters = Vec::new();
 


### PR DESCRIPTION
## Summary

- Adds a `Clock` trait (`SystemClock` in production, `TestClock` in tests) in `crates/mcp-server/src/clock.rs`, replacing direct `Utc::now()` calls in `PendingGeneration::new`/`is_expired`.
- Threads `Arc<dyn Clock>` through `StateManager` and `GeneratorService` via new `with_clock` constructors, so tests can inject a fake "now" instead of rewinding `expires_at` post-construction.
- Adds boundary tests exercising the exact 30-minute TTL (T+30m, ±1s) and manager-level tests proving `StateManager`/`GeneratorService` actually consult the injected clock rather than a hardcoded `SystemClock`.
- Files follow-up issues #124, #125, #126 for the three previously untracked TODO markers in `crates/mcp-skill/src/parser.rs` and `crates/mcp-cli/src/main.rs`, and updates the comments to reference them (`TODO(#N): ...`) without resolving the underlying concerns.

This is a behavior-preserving refactor: `SystemClock::now()` is a pure passthrough to `Utc::now()`, and production expiry semantics are unchanged.

Closes #121

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (664/664 passed)
- [x] `cargo test --doc --all-features --workspace` (182/182 passed)