### PR TITLE
feat(core): allow mcp.json to override connect/discover timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`mcp-execution-cli`**, **`mcp-execution-server`**: `mcp.json` server entries can now override
+  the connect/discover timeouts introduced in #120 on a per-server basis via
+  `connectTimeoutSecs`/`discoverTimeoutSecs`, instead of being locked to the 30-second defaults.
+  Values are bounds-checked (`0 < timeout <= 600s`) by `validate_server_config` (#128).
+
 ### Security
 
 - **`mcp-execution-codegen`**: tool names, server IDs, and JSON Schema property keys are now

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -8,6 +8,7 @@ use mcp_execution_core::{ServerConfig, ServerConfigBuilder, ServerId};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// MCP configuration file structure (`~/.claude/mcp.json`).
 ///
@@ -23,6 +24,7 @@ pub struct McpConfig {
 
 /// Individual MCP server configuration entry from `mcp.json`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct McpServerEntry {
     /// Command to execute (binary name or absolute path).
     pub command: String,
@@ -32,6 +34,14 @@ pub struct McpServerEntry {
     /// Environment variables for the server process.
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Connection (handshake) timeout in seconds, overriding the 30-second
+    /// default when set. JSON key: `connectTimeoutSecs`.
+    #[serde(default)]
+    pub connect_timeout_secs: Option<u64>,
+    /// Tool discovery timeout in seconds, overriding the 30-second default
+    /// when set. JSON key: `discoverTimeoutSecs`.
+    #[serde(default)]
+    pub discover_timeout_secs: Option<u64>,
 }
 
 /// Loads MCP configuration from the given path.
@@ -207,6 +217,14 @@ fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
         builder = builder.env(key.clone(), value.clone());
     }
 
+    if let Some(secs) = entry.connect_timeout_secs {
+        builder = builder.connect_timeout(Duration::from_secs(secs));
+    }
+
+    if let Some(secs) = entry.discover_timeout_secs {
+        builder = builder.discover_timeout(Duration::from_secs(secs));
+    }
+
     builder.build()
 }
 
@@ -252,6 +270,7 @@ fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
 /// assert_eq!(id.as_str(), "github-mcp-server");
 /// assert_eq!(config.args(), &["stdio"]);
 /// ```
+// TODO(critic): expose connect/discover timeout flags for manual introspect
 pub fn build_server_config(
     server: Option<String>,
     args: Vec<String>,
@@ -855,6 +874,40 @@ mod tests {
 
         let servers = list_mcp_servers_from(file.path()).unwrap();
         assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn test_load_mcp_config_without_timeout_keys_uses_defaults() {
+        let json = r#"{"mcpServers": {"github": {"command": "node"}}}"#;
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        let entry = &config.mcp_servers["github"];
+        assert_eq!(entry.connect_timeout_secs, None);
+        assert_eq!(entry.discover_timeout_secs, None);
+
+        let server_config = build_core_config(entry);
+        assert_eq!(server_config.connect_timeout(), Duration::from_secs(30));
+        assert_eq!(server_config.discover_timeout(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_load_mcp_config_with_timeout_keys_reaches_server_config() {
+        let json = r#"{"mcpServers": {"github": {
+            "command": "node",
+            "connectTimeoutSecs": 5,
+            "discoverTimeoutSecs": 90
+        }}}"#;
+        let file = create_test_config(json);
+
+        let config = load_mcp_config_from(file.path()).unwrap();
+        let entry = &config.mcp_servers["github"];
+        assert_eq!(entry.connect_timeout_secs, Some(5));
+        assert_eq!(entry.discover_timeout_secs, Some(90));
+
+        let server_config = build_core_config(entry);
+        assert_eq!(server_config.connect_timeout(), Duration::from_secs(5));
+        assert_eq!(server_config.discover_timeout(), Duration::from_secs(90));
     }
 
     #[test]

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -338,6 +338,8 @@ mod tests {
             command: "node".to_string(),
             args: Vec::new(),
             env: HashMap::default(),
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
         assert_eq!(build_command_string(&entry), "node");
     }
@@ -348,6 +350,8 @@ mod tests {
             command: "node".to_string(),
             args: vec!["/path/to/server.js".to_string(), "--verbose".to_string()],
             env: HashMap::default(),
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
         assert_eq!(
             build_command_string(&entry),

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -33,6 +33,7 @@
 
 use crate::{Error, Result, ServerConfig};
 use std::path::Path;
+use std::time::Duration;
 
 /// Shell metacharacters that indicate potential command injection.
 const FORBIDDEN_CHARS: &[char] = &[';', '|', '&', '>', '<', '`', '$', '(', ')', '\n', '\r'];
@@ -47,6 +48,11 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
     "PATH", // Block PATH override to prevent binary substitution
 ];
 
+/// Upper bound for `connect_timeout`/`discover_timeout`, matching the
+/// 30-second defaults declared in `server_config.rs` with headroom for
+/// slow-starting servers configured via `mcp.json`.
+const MAX_TIMEOUT: Duration = Duration::from_mins(10);
+
 /// Validates a `ServerConfig` for safe subprocess execution.
 ///
 /// This function performs comprehensive security validation to prevent
@@ -55,6 +61,7 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
 /// 1. **Command**: Can be absolute path (with existence/permission checks) or binary name
 /// 2. **Arguments**: Each arg checked for shell metacharacters
 /// 3. **Environment**: Variables checked for dangerous names
+/// 4. **Timeouts**: `connect_timeout`/`discover_timeout` checked against bounds
 ///
 /// # Security Rules
 ///
@@ -62,6 +69,8 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
 /// - **Forbidden env names**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*`, `PATH`
 /// - **Absolute paths**: Must exist and be executable
 /// - **Binary names**: Allowed (resolved via PATH at runtime)
+/// - **Timeout bounds**: `connect_timeout`/`discover_timeout` must be greater than zero and at
+///   most `MAX_TIMEOUT` (600s)
 ///
 /// # Errors
 ///
@@ -70,6 +79,10 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
 /// - Command/args contain shell metacharacters
 /// - Absolute path does not exist or is not executable
 /// - Environment variable name is forbidden
+///
+/// Returns `Error::ValidationError` if:
+/// - `connect_timeout` or `discover_timeout` is zero
+/// - `connect_timeout` or `discover_timeout` exceeds `MAX_TIMEOUT` (600s)
 ///
 /// # Examples
 ///
@@ -117,6 +130,30 @@ pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
         validate_env_name(env_name)?;
     }
 
+    // Validate timeout bounds. Zero fires immediately and breaks all
+    // discovery; unbounded values re-open the DoS window these timeouts
+    // were introduced to close.
+    // TODO(critic): 0 is rejected; revisit if an infinite-timeout option is needed
+    validate_timeout(config.connect_timeout(), "connect_timeout")?;
+    validate_timeout(config.discover_timeout(), "discover_timeout")?;
+
+    Ok(())
+}
+
+/// Validates that a timeout is within `(0, MAX_TIMEOUT]`.
+fn validate_timeout(timeout: Duration, field: &str) -> Result<()> {
+    if timeout.is_zero() {
+        return Err(Error::ValidationError {
+            field: field.to_string(),
+            reason: "timeout must be greater than zero".to_string(),
+        });
+    }
+    if timeout > MAX_TIMEOUT {
+        return Err(Error::ValidationError {
+            field: field.to_string(),
+            reason: format!("timeout {timeout:?} exceeds maximum allowed {MAX_TIMEOUT:?}"),
+        });
+    }
     Ok(())
 }
 
@@ -505,6 +542,71 @@ mod tests {
             .env("LOG_LEVEL".to_string(), "info".to_string())
             .env("CACHE_DIR".to_string(), "/var/cache".to_string())
             .cwd(std::path::PathBuf::from("/opt/app"))
+            .build();
+        assert!(validate_server_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_default_timeouts_pass() {
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .build();
+        assert!(validate_server_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_zero_connect_timeout_rejected() {
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .connect_timeout(std::time::Duration::ZERO)
+            .build();
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::ValidationError { field, reason }) = result {
+            assert_eq!(field, "connect_timeout");
+            assert!(reason.contains("greater than zero"));
+        } else {
+            panic!("expected ValidationError");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_zero_discover_timeout_rejected() {
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .discover_timeout(std::time::Duration::ZERO)
+            .build();
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::ValidationError { field, .. }) = result {
+            assert_eq!(field, "discover_timeout");
+        } else {
+            panic!("expected ValidationError");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_above_max_timeout_rejected() {
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .connect_timeout(std::time::Duration::from_secs(601))
+            .build();
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::ValidationError { field, reason }) = result {
+            assert_eq!(field, "connect_timeout");
+            assert!(reason.contains("exceeds maximum"));
+        } else {
+            panic!("expected ValidationError");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_in_bounds_timeout_accepted() {
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .connect_timeout(std::time::Duration::from_mins(1))
+            .discover_timeout(std::time::Duration::from_mins(10))
             .build();
         assert!(validate_server_config(&config).is_ok());
     }

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -170,6 +170,14 @@ impl GeneratorService {
             config_builder = config_builder.env(key, value);
         }
 
+        if let Some(secs) = params.connect_timeout_secs {
+            config_builder = config_builder.connect_timeout(std::time::Duration::from_secs(secs));
+        }
+
+        if let Some(secs) = params.discover_timeout_secs {
+            config_builder = config_builder.discover_timeout(std::time::Duration::from_secs(secs));
+        }
+
         let config = config_builder.build();
 
         // Connect and introspect, holding only the lock for this server_id
@@ -186,7 +194,11 @@ impl GeneratorService {
         self.evict_introspector(&server_id).await;
 
         let server_info = discover_result.map_err(|e| {
-            McpError::internal_error(format!("Failed to introspect server: {e}"), None)
+            if e.is_validation_error() {
+                McpError::invalid_params(e.to_string(), None)
+            } else {
+                McpError::internal_error(format!("Failed to introspect server: {e}"), None)
+            }
         })?;
 
         // Extract tool metadata for Claude
@@ -852,6 +864,8 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
 
         let result = service.introspect_server(Parameters(params)).await;
@@ -871,6 +885,8 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
 
         let result = service.introspect_server(Parameters(params)).await;
@@ -890,6 +906,8 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
 
         let result = service.introspect_server(Parameters(params)).await;
@@ -907,6 +925,8 @@ mod tests {
             args: vec!["test".to_string()],
             env: HashMap::new(),
             output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
 
         // This will fail because echo is not an MCP server, but validation should pass
@@ -932,6 +952,8 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
 
         let result = service.introspect_server(Parameters(params)).await;
@@ -940,6 +962,33 @@ mod tests {
         if let Err(err) = result {
             assert_ne!(err.code, ErrorCode::INVALID_PARAMS);
         }
+    }
+
+    /// A zero timeout is a client input error, not a server-side connection
+    /// failure — it must surface as `INVALID_PARAMS`, matching the sibling
+    /// `validate_server_id` behavior, not `internal_error`.
+    #[tokio::test]
+    async fn test_introspect_server_zero_connect_timeout_is_invalid_params() {
+        let service = GeneratorService::new();
+
+        let params = IntrospectServerParams {
+            server_id: "zero-timeout-test".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            output_dir: None,
+            connect_timeout_secs: Some(0),
+            discover_timeout_secs: None,
+        };
+
+        let result = service.introspect_server(Parameters(params)).await;
+
+        let err = result.expect_err("zero connect_timeout must be rejected");
+        assert_eq!(
+            err.code,
+            ErrorCode::INVALID_PARAMS,
+            "zero timeout is a client input error, not an internal error"
+        );
     }
 
     // ========================================================================
@@ -970,6 +1019,8 @@ mod tests {
             args: vec![],
             env: HashMap::new(),
             output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
         };
 
         let result = service.introspect_server(Parameters(params)).await;

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -33,6 +33,8 @@ use uuid::Uuid;
 ///     args: vec!["-y".to_string(), "@anthropic/mcp-server-github".to_string()],
 ///     env: HashMap::new(),
 ///     output_dir: None,
+///     connect_timeout_secs: None,
+///     discover_timeout_secs: None,
 /// };
 /// ```
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -53,6 +55,16 @@ pub struct IntrospectServerParams {
 
     /// Custom output directory (default: `~/.claude/servers/{server_id}`)
     pub output_dir: Option<PathBuf>,
+
+    /// Connection (handshake) timeout in seconds, overriding the 30-second
+    /// default when set.
+    #[serde(default)]
+    pub connect_timeout_secs: Option<u64>,
+
+    /// Tool discovery timeout in seconds, overriding the 30-second default
+    /// when set.
+    #[serde(default)]
+    pub discover_timeout_secs: Option<u64>,
 }
 
 /// Result from introspecting an MCP server.


### PR DESCRIPTION
## Summary
- Adds optional `connectTimeoutSecs`/`discoverTimeoutSecs` fields to `McpServerEntry` (mcp.json, camelCase) and `IntrospectServerParams` (MCP tool params), wired into the existing `ServerConfigBuilder` setters only when present so omitting them preserves the current 30s defaults.
- Bounds (`0 < timeout <= 600s`) are enforced once inside `validate_server_config`, the single security gate both the CLI (`--from-config`) and `mcp-execution-server` paths already funnel through via `discover_server` — the check cannot be bypassed.
- Maps timeout validation failures on the MCP `introspect_server` path to `invalid_params` instead of `internal_error`, matching the existing `validate_server_id` error handling.
- Fully additive/backward compatible: existing `mcp.json` files without the new keys are unaffected.

## Context
`ServerConfig` gained `connect_timeout`/`discover_timeout` (30s defaults) in #120 to bound `Introspector::discover_server`'s awaits, but there was no path from `~/.claude/mcp.json` to those fields. This closes that gap per #128.

Developed via architect -> critic -> developer -> (tester, perf, security, impl-critic) -> reviewer pipeline; see `.local/handoff/` for the full design rationale, adversarial critique, and validation reports.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (707 passed, 2 pre-existing unrelated leaky tests)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- [x] New unit tests: backward-compat defaults, values reaching `ServerConfig`, zero/above-`MAX_TIMEOUT` rejection, in-bounds acceptance, S1 error-mapping end-to-end

Closes #128