### PR TITLE
fix: introspector lifecycle robustness (child-process kill, eviction TOCTOU)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. a `#[tokio::test]`), that background task could be starved before it ever ran, leaking the
   child process; `cargo nextest run` reported both timeout-firing tests as `LEAK` on every run
   (#132).
+- **`mcp-execution-server`**: `GeneratorService::evict_introspector` now removes a per-server-id
+  introspector entry only if it is still the exact handle the caller obtained from
+  `introspector_for` (`Arc::ptr_eq` compare-and-remove), instead of removing by `server_id` alone.
+  Previously a finishing call could evict a different, still in-flight caller's live entry for the
+  same server id, letting concurrent callers bypass the per-id serialization the lock exists to
+  provide (#130).
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   numeric-suffix strategy already used for name collisions. Previously a tool named `delete` or
   `typeof` produced `export async function delete(...)`, a hard TypeScript/JavaScript syntax
   error that also broke the generated `index.ts` re-export (#133).
+- **`mcp-execution-introspector`**: `Introspector::discover_server` now spawns its MCP server child
+  process directly and kills it synchronously once the discovery round-trip finishes, instead of
+  relying on rmcp's `TokioChildProcess` `Drop`-spawned kill task. Under a short-lived tokio runtime
+  (e.g. a `#[tokio::test]`), that background task could be starved before it ever ran, leaking the
+  child process; `cargo nextest run` reported both timeout-firing tests as `LEAK` on every run
+  (#132).
 
 ### Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -39,4 +39,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -44,9 +44,11 @@
 
 use mcp_execution_core::{Error, Result, ServerConfig, ServerId, ToolName, validate_server_config};
 use rmcp::ServiceExt;
-use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
+use rmcp::transport::ConfigureCommandExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::process::Stdio;
+use tokio::process::Child;
 
 /// Information about an MCP server.
 ///
@@ -271,83 +273,39 @@ impl Introspector {
         // Validate server config for security (prevents command injection)
         validate_server_config(config)?;
 
-        // Connect via stdio using rmcp with full configuration
-        let transport = TokioChildProcess::new(
-            tokio::process::Command::new(&config.command).configure(|cmd| {
-                cmd.args(&config.args);
-                cmd.envs(&config.env);
-                if let Some(cwd) = &config.cwd {
-                    cmd.current_dir(cwd);
-                }
-            }),
-        )
-        .map_err(|e| Error::ConnectionFailed {
+        let mut child = spawn_introspection_child(&server_id, config)?;
+        let stdout = child.stdout.take().ok_or_else(|| Error::ConnectionFailed {
             server: server_id.to_string(),
-            source: Box::new(e),
+            source: Box::new(std::io::Error::other("child stdout was not captured")),
+        })?;
+        let stdin = child.stdin.take().ok_or_else(|| Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(std::io::Error::other("child stdin was not captured")),
         })?;
 
-        // Create client using serve pattern, bounded by the connect timeout
-        let client = tokio::time::timeout(config.connect_timeout(), ().serve(transport))
-            .await
-            .map_err(|_elapsed| Error::Timeout {
-                operation: format!("connect to {server_id}"),
-                duration_secs: config.connect_timeout().as_secs(),
-            })?
-            .map_err(|e| Error::ConnectionFailed {
-                server: server_id.to_string(),
-                source: Box::new(e),
-            })?;
+        let discovery = discover_via_stdio(&server_id, config, (stdout, stdin)).await;
 
-        // List all tools from server, bounded by the discover timeout
-        let tool_list = tokio::time::timeout(config.discover_timeout(), client.list_all_tools())
-            .await
-            .map_err(|_elapsed| Error::Timeout {
-                operation: format!("list_all_tools for {server_id}"),
-                duration_secs: config.discover_timeout().as_secs(),
-            })?
-            .map_err(|e| Error::ConnectionFailed {
-                server: server_id.to_string(),
-                source: Box::new(e),
-            })?;
+        // The child process is spawned solely for this discovery round-trip, so it
+        // must be reaped here regardless of outcome. We deliberately kill it
+        // ourselves rather than relying on rmcp's `TokioChildProcess`, whose cleanup
+        // is a `tokio::spawn`-ed background task in `Drop`: under a short-lived
+        // runtime (e.g. `#[tokio::test]`) that task can be starved before it ever
+        // runs, leaking the process (issue #132).
+        if let Err(kill_err) = child.kill().await {
+            tracing::warn!(
+                "failed to terminate introspection child process for {server_id}: {kill_err}"
+            );
+        }
 
-        tracing::debug!(
-            "Server {} responded with {} tools",
-            server_id,
-            tool_list.len()
+        let (tool_list, server_name, server_version, has_resources, has_prompts) = discovery?;
+        let info = build_server_info(
+            &server_id,
+            server_name,
+            server_version,
+            has_resources,
+            has_prompts,
+            tool_list,
         );
-
-        // Extract tools
-        let tools = tool_list
-            .into_iter()
-            .map(|tool| {
-                tracing::trace!("Found tool: {}", tool.name);
-                ToolInfo {
-                    name: ToolName::new(tool.name),
-                    description: tool.description.unwrap_or_default().to_string(),
-                    input_schema: serde_json::Value::Object((*tool.input_schema).clone()),
-                    output_schema: None, // rmcp doesn't provide output schema
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // Extract name, version, and capabilities from the MCP handshake result.
-        // Falls back to the command string / "unknown" if the server did not send peer info.
-        let (server_name, server_version, has_resources, has_prompts) =
-            extract_peer_meta(config, client.peer_info().as_deref());
-
-        let capabilities = ServerCapabilities {
-            supports_tools: !tools.is_empty(),
-            supports_resources: has_resources,
-            supports_prompts: has_prompts,
-        };
-
-        let info = ServerInfo {
-            id: server_id.clone(),
-            name: server_name,
-            version: server_version,
-            tools,
-            capabilities,
-        };
 
         self.servers.insert(server_id, info.clone());
 
@@ -484,6 +442,134 @@ impl Introspector {
 impl Default for Introspector {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Spawns the MCP server subprocess used for a single introspection
+/// round-trip, with piped stdin/stdout so it can be driven over stdio.
+///
+/// The caller owns the returned [`Child`] for its full lifetime and is
+/// responsible for terminating it (e.g. via [`Child::kill`]) once
+/// introspection completes; this crate does not keep the process alive for
+/// later tool invocation.
+///
+/// # Errors
+///
+/// Returns [`Error::ConnectionFailed`] if the process cannot be spawned
+/// (e.g. the command does not exist or is not executable).
+fn spawn_introspection_child(server_id: &ServerId, config: &ServerConfig) -> Result<Child> {
+    tokio::process::Command::new(&config.command)
+        .configure(|cmd| {
+            cmd.args(&config.args);
+            cmd.envs(&config.env);
+            if let Some(cwd) = &config.cwd {
+                cmd.current_dir(cwd);
+            }
+            cmd.stdin(Stdio::piped());
+            cmd.stdout(Stdio::piped());
+        })
+        .spawn()
+        .map_err(|e| Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(e),
+        })
+}
+
+/// Connects to an already-spawned MCP server over `transport` and lists its
+/// tools, with each step bounded by `config`'s configured timeouts.
+///
+/// Returns the discovered tools alongside the handshake-derived server name,
+/// version, and capability flags (resources / prompts support).
+///
+/// # Errors
+///
+/// Returns [`Error::Timeout`] if the connect or discovery step exceeds its
+/// configured timeout, or [`Error::ConnectionFailed`] if the underlying rmcp
+/// connection or request fails.
+async fn discover_via_stdio(
+    server_id: &ServerId,
+    config: &ServerConfig,
+    transport: (tokio::process::ChildStdout, tokio::process::ChildStdin),
+) -> Result<(Vec<rmcp::model::Tool>, String, String, bool, bool)> {
+    // Create client using serve pattern, bounded by the connect timeout
+    let client = tokio::time::timeout(config.connect_timeout(), ().serve(transport))
+        .await
+        .map_err(|_elapsed| Error::Timeout {
+            operation: format!("connect to {server_id}"),
+            duration_secs: config.connect_timeout().as_secs(),
+        })?
+        .map_err(|e| Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(e),
+        })?;
+
+    // List all tools from server, bounded by the discover timeout
+    let tool_list = tokio::time::timeout(config.discover_timeout(), client.list_all_tools())
+        .await
+        .map_err(|_elapsed| Error::Timeout {
+            operation: format!("list_all_tools for {server_id}"),
+            duration_secs: config.discover_timeout().as_secs(),
+        })?
+        .map_err(|e| Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(e),
+        })?;
+
+    // Extract name, version, and capabilities from the MCP handshake result.
+    // Falls back to the command string / "unknown" if the server did not send peer info.
+    let (server_name, server_version, has_resources, has_prompts) =
+        extract_peer_meta(config, client.peer_info().as_deref());
+
+    Ok((
+        tool_list,
+        server_name,
+        server_version,
+        has_resources,
+        has_prompts,
+    ))
+}
+
+/// Assembles a [`ServerInfo`] from the raw tool list and handshake metadata
+/// returned by [`discover_via_stdio`].
+fn build_server_info(
+    server_id: &ServerId,
+    server_name: String,
+    server_version: String,
+    has_resources: bool,
+    has_prompts: bool,
+    tool_list: Vec<rmcp::model::Tool>,
+) -> ServerInfo {
+    tracing::debug!(
+        "Server {} responded with {} tools",
+        server_id,
+        tool_list.len()
+    );
+
+    let tools = tool_list
+        .into_iter()
+        .map(|tool| {
+            tracing::trace!("Found tool: {}", tool.name);
+            ToolInfo {
+                name: ToolName::new(tool.name),
+                description: tool.description.unwrap_or_default().to_string(),
+                input_schema: serde_json::Value::Object((*tool.input_schema).clone()),
+                output_schema: None, // rmcp doesn't provide output schema
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let capabilities = ServerCapabilities {
+        supports_tools: !tools.is_empty(),
+        supports_resources: has_resources,
+        supports_prompts: has_prompts,
+    };
+
+    ServerInfo {
+        id: server_id.clone(),
+        name: server_name,
+        version: server_version,
+        tools,
+        capabilities,
     }
 }
 

--- a/crates/mcp-introspector/tests/fixtures/slow_mcp_server.rs
+++ b/crates/mcp-introspector/tests/fixtures/slow_mcp_server.rs
@@ -14,6 +14,12 @@
 //!
 //! Both delays default to 0 (respond immediately) so the fixture can also
 //! serve as a fast, successful server for sanity-check tests.
+//!
+//! An optional third CLI arg gives a file path; if present, the fixture
+//! writes its own OS process id to that file immediately on startup (before
+//! the connect delay), letting tests confirm - via the written pid - that
+//! the process was actually terminated after a timeout, rather than merely
+//! asserting on the returned error.
 
 use rmcp::model::{ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo};
 use rmcp::service::RequestContext;
@@ -51,6 +57,10 @@ fn arg_millis(index: usize) -> u64 {
 async fn main() {
     let connect_delay = Duration::from_millis(arg_millis(1));
     let list_tools_delay = Duration::from_millis(arg_millis(2));
+
+    if let Some(pid_file) = std::env::args().nth(3) {
+        std::fs::write(pid_file, std::process::id().to_string()).expect("failed to write pid file");
+    }
 
     // Delay before even starting the handshake, so the client's `serve()`
     // call blocks waiting for a response - simulating a hung connect phase

--- a/crates/mcp-introspector/tests/timeout_test.rs
+++ b/crates/mcp-introspector/tests/timeout_test.rs
@@ -3,6 +3,10 @@
 //! per-server-id locking in `mcp-execution-server` does not serialize
 //! introspection across unrelated server ids.
 //!
+//! Also proves (issue #132) that when a timeout fires, the spawned MCP
+//! server child process is actually terminated - not merely that
+//! `discover_server` returns a timeout error while the process leaks.
+//!
 //! Requires the `test-fixtures` feature (implied by `--all-features`, which
 //! is how CI and the project's preferred `cargo nextest` invocation run
 //! tests) so that `fixture-slow-mcp-server` is built.
@@ -11,7 +15,61 @@
 
 use mcp_execution_core::{Error, ServerConfig, ServerId};
 use mcp_execution_introspector::Introspector;
+use std::path::Path;
 use std::time::{Duration, Instant};
+
+/// Checks whether a process with the given OS pid still exists.
+///
+/// Implemented per-platform without extra dependencies: `kill -0` on Unix
+/// (arguments only, no shell involved) and `tasklist` filtering on Windows.
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .is_ok_and(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+}
+
+/// Polls [`process_is_alive`] until it reports the process gone or `timeout`
+/// elapses. Returns `true` once the process is confirmed gone.
+async fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !process_is_alive(pid) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    !process_is_alive(pid)
+}
+
+/// Polls a file until it has non-empty contents or `timeout` elapses, then
+/// returns those contents. Used to read the fixture's self-reported pid,
+/// which it writes at startup before the configured connect delay.
+async fn wait_for_file_contents(path: &Path, timeout: Duration) -> String {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(path)
+            && !contents.trim().is_empty()
+        {
+            return contents;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "pid file {} was not written within {timeout:?}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
 
 /// Absolute path to the `fixture-slow-mcp-server` binary built alongside this
 /// test target. The fixture speaks real MCP over stdio and takes two
@@ -91,6 +149,83 @@ async fn test_discover_server_discover_timeout_fires() {
     );
 }
 
+/// #132 — when the connect handshake times out, the spawned child process
+/// must be terminated, not merely have its rmcp transport dropped. Before
+/// the fix, cleanup was delegated to a `tokio::spawn`-ed background task in
+/// rmcp's `Drop` impl, which a short-lived test runtime could tear down
+/// before ever running - leaking the process.
+#[tokio::test]
+async fn test_discover_server_connect_timeout_kills_child_process() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-connect-timeout-kills-child");
+
+    let pid_file = tempfile::NamedTempFile::new().expect("create temp pid file");
+    let pid_path = pid_file.path().to_path_buf();
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("30000".to_string()) // fixture delays the handshake by 30s
+        .arg("0".to_string())
+        .arg(pid_path.display().to_string())
+        .connect_timeout(Duration::from_millis(150))
+        .build();
+
+    let result = introspector.discover_server(server_id, &config).await;
+    assert!(
+        matches!(result, Err(Error::Timeout { .. })),
+        "expected Error::Timeout, got {result:?}"
+    );
+
+    let pid_contents = wait_for_file_contents(&pid_path, Duration::from_secs(2)).await;
+    let pid: u32 = pid_contents
+        .trim()
+        .parse()
+        .expect("fixture wrote a valid pid");
+
+    assert!(
+        wait_for_process_exit(pid, Duration::from_secs(2)).await,
+        "expected introspection child process (pid {pid}) to be terminated after \
+         the connect timeout, but it is still running"
+    );
+}
+
+/// #132 — same guarantee as `test_discover_server_connect_timeout_kills_child_process`,
+/// but for a `discover_timeout` (i.e. `tools/list` hangs after a successful handshake).
+#[tokio::test]
+async fn test_discover_server_discover_timeout_kills_child_process() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-discover-timeout-kills-child");
+
+    let pid_file = tempfile::NamedTempFile::new().expect("create temp pid file");
+    let pid_path = pid_file.path().to_path_buf();
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("0".to_string()) // no handshake delay
+        .arg("30000".to_string()) // fixture delays tools/list by 30s
+        .arg(pid_path.display().to_string())
+        .discover_timeout(Duration::from_millis(150))
+        .build();
+
+    let result = introspector.discover_server(server_id, &config).await;
+    assert!(
+        matches!(result, Err(Error::Timeout { .. })),
+        "expected Error::Timeout, got {result:?}"
+    );
+
+    let pid_contents = wait_for_file_contents(&pid_path, Duration::from_secs(2)).await;
+    let pid: u32 = pid_contents
+        .trim()
+        .parse()
+        .expect("fixture wrote a valid pid");
+
+    assert!(
+        wait_for_process_exit(pid, Duration::from_secs(2)).await,
+        "expected introspection child process (pid {pid}) to be terminated after \
+         the discover timeout, but it is still running"
+    );
+}
+
 /// Sanity check: when the fixture responds promptly (no artificial delays),
 /// `discover_server` succeeds and does not spuriously time out.
 #[tokio::test]
@@ -109,4 +244,42 @@ async fn test_discover_server_succeeds_when_within_timeouts() {
     let result = introspector.discover_server(server_id, &config).await;
 
     assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+/// #132 — `discover_server` kills its spawned child process unconditionally
+/// after discovery completes, including on the success path (the process is
+/// only ever needed for a single introspection round-trip). This proves the
+/// child is actually gone shortly after `discover_server` returns `Ok(..)`,
+/// not merely that the call itself succeeded.
+#[tokio::test]
+async fn test_discover_server_success_kills_child_process() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-success-kills-child");
+
+    let pid_file = tempfile::NamedTempFile::new().expect("create temp pid file");
+    let pid_path = pid_file.path().to_path_buf();
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("0".to_string()) // no handshake delay
+        .arg("0".to_string()) // no tools/list delay
+        .arg(pid_path.display().to_string())
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build();
+
+    let result = introspector.discover_server(server_id, &config).await;
+    assert!(result.is_ok(), "expected success, got {result:?}");
+
+    let pid_contents = wait_for_file_contents(&pid_path, Duration::from_secs(2)).await;
+    let pid: u32 = pid_contents
+        .trim()
+        .parse()
+        .expect("fixture wrote a valid pid");
+
+    assert!(
+        wait_for_process_exit(pid, Duration::from_secs(2)).await,
+        "expected introspection child process (pid {pid}) to be terminated after \
+         a successful discover_server call, but it is still running"
+    );
 }

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -113,13 +113,28 @@ impl GeneratorService {
             .clone()
     }
 
-    /// Evicts the per-server-id introspector handle after use.
+    /// Evicts the per-server-id introspector handle after use, but only if
+    /// the map still holds the exact handle the caller obtained.
     ///
     /// `server_id` values are caller-supplied, so without eviction the map
     /// grows without bound as new ids are introspected. Called after
     /// `discover_server` completes, regardless of outcome.
-    async fn evict_introspector(&self, server_id: &ServerId) {
-        self.introspectors.lock().await.remove(server_id);
+    ///
+    /// A caller must pass the same `Arc<Mutex<Introspector>>` it received
+    /// from [`Self::introspector_for`]. Removing by `server_id` alone is a
+    /// TOCTOU bug: if another in-flight call for the same id already evicted
+    /// and a third call inserted a fresh handle, an unconditional `remove`
+    /// would prune that live handle out from under the third call. Comparing
+    /// with [`Arc::ptr_eq`] ensures a caller can only ever evict the entry it
+    /// created.
+    async fn evict_introspector(&self, server_id: &ServerId, handle: &Arc<Mutex<Introspector>>) {
+        let mut introspectors = self.introspectors.lock().await;
+        if let std::collections::hash_map::Entry::Occupied(entry) =
+            introspectors.entry(server_id.clone())
+            && Arc::ptr_eq(entry.get(), handle)
+        {
+            entry.remove();
+        }
     }
 }
 
@@ -181,8 +196,8 @@ impl GeneratorService {
         let config = config_builder.build();
 
         // Connect and introspect, holding only the lock for this server_id
+        let introspector_handle = self.introspector_for(&server_id).await;
         let discover_result = {
-            let introspector_handle = self.introspector_for(&server_id).await;
             let mut introspector = introspector_handle.lock().await;
             introspector
                 .discover_server(server_id.clone(), &config)
@@ -190,8 +205,11 @@ impl GeneratorService {
         };
 
         // Evict the per-server-id handle regardless of outcome, so caller-supplied
-        // server_id values can't grow the introspectors map without bound.
-        self.evict_introspector(&server_id).await;
+        // server_id values can't grow the introspectors map without bound. Only
+        // removes the entry if it is still this exact handle (see
+        // `evict_introspector` docs for why identity matters here).
+        self.evict_introspector(&server_id, &introspector_handle)
+            .await;
 
         let server_info = discover_result.map_err(|e| {
             if e.is_validation_error() {
@@ -1142,6 +1160,75 @@ mod tests {
             "holders of different per-id locks should not serialize \
              (expected < {serialized_threshold:?}, i.e. close to a single {hold_time:?} hold); \
              took {elapsed:?}"
+        );
+    }
+
+    /// Regression test for the TOCTOU eviction bug (issue #130): eviction
+    /// must be identity-checked, not just keyed by `server_id`.
+    ///
+    /// Simulates three overlapping callers for the same `server_id`:
+    /// - A and B both call `introspector_for` while an entry already exists,
+    ///   so (per `test_introspector_for_same_id_shares_one_lock`) they share
+    ///   the exact same `Arc<Mutex<Introspector>>`.
+    /// - A finishes first and evicts, removing the shared entry, while B is
+    ///   still "in flight" (still holding its clone of that same `Arc`).
+    /// - C then arrives, finds the map empty, and gets a brand-new `Arc` -
+    ///   distinct from A/B's.
+    /// - B finally finishes and attempts to evict using its (now stale)
+    ///   handle. Because eviction is identity-checked via `Arc::ptr_eq`, this
+    ///   must be a no-op: C's live entry must survive. Only C's own eviction
+    ///   should remove it.
+    #[tokio::test]
+    async fn test_stale_eviction_does_not_remove_unrelated_entry() {
+        let service = GeneratorService::new();
+        let server_id = ServerId::new("toctou-abc-test");
+
+        // A and B both fetch the handle for the same id before either
+        // evicts, so they end up sharing one Arc (mirrors the "shares one
+        // lock" behavior already covered by
+        // `test_introspector_for_same_id_shares_one_lock`).
+        let handle_a = service.introspector_for(&server_id).await;
+        let handle_b = service.introspector_for(&server_id).await;
+        assert!(
+            Arc::ptr_eq(&handle_a, &handle_b),
+            "A and B must share one introspector handle for the same server_id"
+        );
+
+        // A finishes first and evicts. B is still "in flight", holding its
+        // clone of the now-removed shared Arc.
+        service.evict_introspector(&server_id, &handle_a).await;
+        assert!(
+            service.introspectors.lock().await.is_empty(),
+            "map should be empty right after A's eviction"
+        );
+
+        // C arrives after A's eviction, finds the map empty, and gets a
+        // fresh, distinct handle.
+        let handle_c = service.introspector_for(&server_id).await;
+        assert!(
+            !Arc::ptr_eq(&handle_b, &handle_c),
+            "C must get a handle distinct from A/B's stale one"
+        );
+
+        // B finally finishes and tries to evict using its stale (A/B
+        // shared) handle. This must be a no-op: C's live entry, keyed by
+        // the same server_id, must survive because it is a different Arc.
+        service.evict_introspector(&server_id, &handle_b).await;
+        let introspectors = service.introspectors.lock().await;
+        let current = introspectors
+            .get(&server_id)
+            .expect("C's entry must survive B's stale eviction attempt");
+        assert!(
+            Arc::ptr_eq(current, &handle_c),
+            "the surviving entry must be C's handle, unaffected by B's stale eviction"
+        );
+        drop(introspectors);
+
+        // Only C's own eviction removes its entry.
+        service.evict_introspector(&server_id, &handle_c).await;
+        assert!(
+            service.introspectors.lock().await.is_empty(),
+            "map should be empty after C's own eviction"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fixes #132: `discover_server` now spawns its MCP server child process directly and kills it synchronously once the discovery round-trip finishes, instead of relying on rmcp's `TokioChildProcess` `Drop`-spawned kill task, which a short-lived tokio runtime could starve before it ran. `nextest` no longer reports the two timeout-firing tests as `LEAK`.
- Fixes #130: `GeneratorService::evict_introspector` is now identity-checked via `Arc::ptr_eq` compare-and-remove instead of removing by `server_id` alone, so a finishing caller can no longer evict a different in-flight caller's live entry for the same server id.

Both issues were found in the same CI-007 live-testing/architecture-review cycle and share the `area: bridge` label; bundled into one PR since they're small, independent, related fixes to introspector lifecycle robustness.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (720/720 passed, 0 leaked)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests: `test_discover_server_connect_timeout_kills_child_process`, `test_discover_server_discover_timeout_kills_child_process`, `test_discover_server_success_kills_child_process` (poll for actual OS process exit), `test_stale_eviction_does_not_remove_unrelated_entry` (A/B/C interleaving from #130)
- [x] CHANGELOG.md updated under `[Unreleased]`