### PR TITLE
fix(codegen): stop nested block comment from truncating index.ts JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-codegen`**: the header JSDoc block emitted at the top of every generated
+  `index.ts` no longer contains a nested `/* params */` block comment inside its usage example.
+  JS/TS block comments do not nest, so the inner comment's `*/` prematurely closed the outer
+  `/** ... */` doc comment, turning the rest of the file (including `@packageDocumentation`) into
+  top-level code and producing a syntax error in every generated `index.ts`. The placeholder is
+  now the non-comment `{ ...params }` (#139).
 - **`mcp-execution-codegen`**: two tools reported with an identical raw name (invalid per the MCP
   spec but not currently rejected upstream) no longer collapse to a single collision-map entry and
   silently overwrite one tool's generated file; each now resolves to a distinct, deterministically

--- a/crates/mcp-codegen/templates/progressive/index.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/index.ts.hbs
@@ -28,7 +28,7 @@
  * ```typescript
  * import { {{#if tools}}{{tools.[0].typescript_name}}{{/if}} } from './{{#if tools}}{{tools.[0].typescript_name}}{{/if}}.js';
  *
- * const result = await {{#if tools}}{{tools.[0].typescript_name}}{{/if}}({ /* params */ });
+ * const result = await {{#if tools}}{{tools.[0].typescript_name}}{{/if}}({ ...params });
  * ```
  *
  * @packageDocumentation

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -269,6 +269,36 @@ fn test_progressive_index_structure() {
 }
 
 #[test]
+fn test_progressive_index_doc_comment_not_prematurely_closed() {
+    let generator = ProgressiveGenerator::new().expect("Failed to create generator");
+    let server_info = create_test_server_info();
+
+    let code = generator
+        .generate(&server_info)
+        .expect("Failed to generate code");
+
+    let index_file = code
+        .files
+        .iter()
+        .find(|f| f.path == "index.ts")
+        .expect("index.ts not found");
+
+    let content = &index_file.content;
+
+    let doc_start = content.find("/**").expect("Missing opening JSDoc block");
+    let doc_end = content[doc_start..]
+        .find("*/")
+        .map(|i| doc_start + i)
+        .expect("Missing JSDoc close");
+
+    assert!(
+        content[doc_start..doc_end].contains("@packageDocumentation"),
+        "Top-level JSDoc block closed prematurely before @packageDocumentation \
+         — likely a nested /* ... */ inside the doc comment (regression for #139)"
+    );
+}
+
+#[test]
 fn test_progressive_runtime_bridge_structure() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();


### PR DESCRIPTION
## Summary
- The header JSDoc block emitted at the top of every generated `index.ts` contained a nested `/* params */` block comment inside its usage example. JS/TS block comments do not nest, so the inner comment's `*/` prematurely closed the outer `/** ... */` doc comment, turning the rest of the file (including `@packageDocumentation`) into top-level code and producing a syntax error in every generated `index.ts`.
- Replace the placeholder with the non-comment `{ ...params }`.
- Add a regression test (`test_progressive_index_doc_comment_not_prematurely_closed`) that asserts the doc block is not closed before `@packageDocumentation`; verified it fails against the pre-fix template and passes against the fix.
- Confirmed no other Handlebars template contains the same nested-comment-in-JSDoc pattern; confirmed all server-controlled fields interpolated into JSDoc blocks already pass through `sanitize_jsdoc`.

Closes #139

## Test plan
- [x] `cargo nextest run -p mcp-execution-codegen --all-features --no-fail-fast` (75/75 pass)
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (717/717 pass, 2 pre-existing unrelated leaky timeout tests)
- [x] `cargo test --doc --all-features --workspace`
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] Regenerated live output for `mcpls` and `chrome-devtools` servers; confirmed `tsc --noEmit` reports zero syntax errors on the generated `index.ts`