### PR TITLE
chore(core): link TODO(critic) markers to tracked issues

### DIFF
--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -270,7 +270,7 @@ fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
 /// assert_eq!(id.as_str(), "github-mcp-server");
 /// assert_eq!(config.args(), &["stdio"]);
 /// ```
-// TODO(critic): expose connect/discover timeout flags for manual introspect
+// TODO(#144): expose connect/discover timeout flags for manual introspect
 pub fn build_server_config(
     server: Option<String>,
     args: Vec<String>,

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -133,7 +133,7 @@ pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
     // Validate timeout bounds. Zero fires immediately and breaks all
     // discovery; unbounded values re-open the DoS window these timeouts
     // were introduced to close.
-    // TODO(critic): 0 is rejected; revisit if an infinite-timeout option is needed
+    // TODO(#145): 0 is rejected; revisit if an infinite-timeout option is needed
     validate_timeout(config.connect_timeout(), "connect_timeout")?;
     validate_timeout(config.discover_timeout(), "discover_timeout")?;
 


### PR DESCRIPTION
## Summary
- Replace the two untracked `TODO(critic)` markers left by #136 with `TODO(#N)` references, matching the project's convention of linking deferred design decisions to a tracked issue.
- `crates/mcp-cli/src/commands/common.rs:273` now references #144 (expose connect/discover timeout flags for manual introspect)
- `crates/mcp-core/src/command.rs:136` now references #145 (revisit whether an infinite-timeout option is needed)

Closes #138

## Test plan
- [x] `grep -rn "TODO(critic)"` across the repo returns zero matches
- [x] `cargo build --workspace`
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (721 tests pass)
- [x] `cargo test --doc --all-features --workspace` (187 doc-tests pass)