### PR TITLE
feat(cli): add connect/discover timeout override flags for manual introspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the connect/discover timeouts introduced in #120 on a per-server basis via
   `connectTimeoutSecs`/`discoverTimeoutSecs`, instead of being locked to the 30-second defaults.
   Values are bounds-checked (`0 < timeout <= 600s`) by `validate_server_config` (#128).
+- **`mcp-execution-cli`**: `introspect` and `generate` now accept `--connect-timeout-secs` and
+  `--discover-timeout-secs` flags for manually-configured (non-`--from-config`) servers, matching
+  the field names, units, and validation bounds of `mcp.json`'s `connectTimeoutSecs`/
+  `discoverTimeoutSecs`. Both flags conflict with `--from-config`, since that path already reads
+  timeouts from the server's `mcp.json` entry (#144).
+
+### Documentation
+
+- **`mcp-execution-core`**: documented the decision to permanently reject a `0` connect/discover
+  timeout instead of treating it as "no timeout" — an infinite wait would let a hung or malicious
+  server block this tool's non-interactive CLI and MCP-server invocations forever, which is the
+  exact denial-of-service exposure these timeouts were introduced to close. No behavior change;
+  resolves the open question left by #136 (#145).
 
 ### Security
 

--- a/crates/mcp-cli/src/cli.rs
+++ b/crates/mcp-cli/src/cli.rs
@@ -93,7 +93,7 @@ pub enum Commands {
         ///   }
         /// }
         /// ```
-        #[arg(long = "from-config", conflicts_with_all = ["server", "args", "env", "cwd", "http", "sse"])]
+        #[arg(long = "from-config", conflicts_with_all = ["server", "args", "env", "cwd", "http", "sse", "connect_timeout_secs", "discover_timeout_secs"])]
         from_config: Option<String>,
 
         /// Server command (binary name or path)
@@ -130,6 +130,27 @@ pub enum Commands {
         /// Show detailed tool schemas
         #[arg(short, long)]
         detailed: bool,
+
+        /// Override the connection (handshake) timeout, in seconds.
+        ///
+        /// Same field/units as `mcp.json`'s `connectTimeoutSecs`. Must be
+        /// greater than zero and at most 600 seconds (10 minutes); there is
+        /// no infinite-timeout option, since an unbounded wait would let a
+        /// hung server block this command forever.
+        ///
+        /// Conflicts with `--from-config`: to override the timeout for a
+        /// server defined in `mcp.json`, either edit its `connectTimeoutSecs`
+        /// field, or re-run this command without `--from-config` using the
+        /// server's command/args/env directly.
+        #[arg(long = "connect-timeout-secs")]
+        connect_timeout_secs: Option<u64>,
+
+        /// Override the tool discovery timeout, in seconds.
+        ///
+        /// Same field/units as `mcp.json`'s `discoverTimeoutSecs`. Same
+        /// bounds and `--from-config` conflict as `--connect-timeout-secs`.
+        #[arg(long = "discover-timeout-secs")]
+        discover_timeout_secs: Option<u64>,
     },
 
     /// Generate Claude Code skill file from progressive loading tools.
@@ -247,7 +268,7 @@ pub enum Commands {
         ///   }
         /// }
         /// ```
-        #[arg(long = "from-config", conflicts_with_all = ["server", "server_args", "server_env", "server_cwd", "http_url", "sse_url"])]
+        #[arg(long = "from-config", conflicts_with_all = ["server", "server_args", "server_env", "server_cwd", "http_url", "sse_url", "connect_timeout_secs", "discover_timeout_secs"])]
         from_config: Option<String>,
 
         /// Server command (binary name or path)
@@ -294,6 +315,27 @@ pub enum Commands {
         /// Preview files that would be generated without writing to disk
         #[arg(long)]
         dry_run: bool,
+
+        /// Override the connection (handshake) timeout, in seconds.
+        ///
+        /// Same field/units as `mcp.json`'s `connectTimeoutSecs`. Must be
+        /// greater than zero and at most 600 seconds (10 minutes); there is
+        /// no infinite-timeout option, since an unbounded wait would let a
+        /// hung server block this command forever.
+        ///
+        /// Conflicts with `--from-config`: to override the timeout for a
+        /// server defined in `mcp.json`, either edit its `connectTimeoutSecs`
+        /// field, or re-run this command without `--from-config` using the
+        /// server's command/args/env directly.
+        #[arg(long = "connect-timeout-secs")]
+        connect_timeout_secs: Option<u64>,
+
+        /// Override the tool discovery timeout, in seconds.
+        ///
+        /// Same field/units as `mcp.json`'s `discoverTimeoutSecs`. Same
+        /// bounds and `--from-config` conflict as `--connect-timeout-secs`.
+        #[arg(long = "discover-timeout-secs")]
+        discover_timeout_secs: Option<u64>,
     },
 
     /// Manage MCP server connections.
@@ -422,6 +464,56 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_parsing_introspect_timeout_overrides() {
+        let cli = Cli::parse_from([
+            "mcp-cli",
+            "introspect",
+            "docker",
+            "--connect-timeout-secs",
+            "5",
+            "--discover-timeout-secs",
+            "90",
+        ]);
+        if let Commands::Introspect {
+            connect_timeout_secs,
+            discover_timeout_secs,
+            ..
+        } = cli.command
+        {
+            assert_eq!(connect_timeout_secs, Some(5));
+            assert_eq!(discover_timeout_secs, Some(90));
+        } else {
+            panic!("Expected Introspect command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parsing_introspect_timeout_conflicts_with_from_config() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "introspect",
+            "--from-config",
+            "github",
+            "--connect-timeout-secs",
+            "5",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_timeout_conflicts_with_from_config() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "generate",
+            "--from-config",
+            "github",
+            "--discover-timeout-secs",
+            "90",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_cli_parsing_generate() {
         let cli = Cli::parse_from(["mcp-cli", "generate", "server"]);
         assert!(matches!(cli.command, Commands::Generate { .. }));
@@ -438,6 +530,30 @@ mod tests {
         } = cli.command
         {
             assert_eq!(progressive_output, Some(PathBuf::from("/tmp/output")));
+        } else {
+            panic!("Expected Generate command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_timeout_overrides() {
+        let cli = Cli::parse_from([
+            "mcp-cli",
+            "generate",
+            "docker",
+            "--connect-timeout-secs",
+            "5",
+            "--discover-timeout-secs",
+            "90",
+        ]);
+        if let Commands::Generate {
+            connect_timeout_secs,
+            discover_timeout_secs,
+            ..
+        } = cli.command
+        {
+            assert_eq!(connect_timeout_secs, Some(5));
+            assert_eq!(discover_timeout_secs, Some(90));
         } else {
             panic!("Expected Generate command");
         }

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -241,6 +241,13 @@ fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
 /// * `http` - HTTP transport URL
 /// * `sse` - SSE transport URL
 /// * `headers` - HTTP headers in KEY=VALUE format
+/// * `connect_timeout_secs` - Connection (handshake) timeout override, in
+///   seconds. Same semantics as `mcp.json`'s `connectTimeoutSecs`: must be
+///   greater than zero and at most 600 seconds, enforced by
+///   [`validate_server_config`](mcp_execution_core::validate_server_config)
+///   at connect time.
+/// * `discover_timeout_secs` - Tool discovery timeout override, in seconds.
+///   Same semantics as `mcp.json`'s `discoverTimeoutSecs`.
 ///
 /// # Errors
 ///
@@ -265,12 +272,14 @@ fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
 ///     None,
 ///     None,
 ///     vec![],
+///     None,
+///     None,
 /// ).unwrap();
 ///
 /// assert_eq!(id.as_str(), "github-mcp-server");
 /// assert_eq!(config.args(), &["stdio"]);
 /// ```
-// TODO(#144): expose connect/discover timeout flags for manual introspect
+#[allow(clippy::too_many_arguments)] // mirrors the CLI's flat argument surface; grouping would add an abstraction for no behavioral benefit
 pub fn build_server_config(
     server: Option<String>,
     args: Vec<String>,
@@ -279,6 +288,8 @@ pub fn build_server_config(
     http: Option<String>,
     sse: Option<String>,
     headers: Vec<String>,
+    connect_timeout_secs: Option<u64>,
+    discover_timeout_secs: Option<u64>,
 ) -> Result<(ServerId, ServerConfig)> {
     // Parse environment variables / headers in KEY=VALUE format
     let parse_key_value = |s: &str, kind: &str| -> Result<(String, String)> {
@@ -293,7 +304,7 @@ pub fn build_server_config(
     };
 
     // Build config based on transport type
-    let (server_id, config) = if let Some(url) = http {
+    let (server_id, mut builder) = if let Some(url) = http {
         // HTTP transport
         let id = ServerId::new(&url);
         let mut builder = ServerConfig::builder().http_transport(url);
@@ -303,7 +314,7 @@ pub fn build_server_config(
             builder = builder.header(key, value);
         }
 
-        (id, builder.build())
+        (id, builder)
     } else if let Some(url) = sse {
         // SSE transport
         let id = ServerId::new(&url);
@@ -314,7 +325,7 @@ pub fn build_server_config(
             builder = builder.header(key, value);
         }
 
-        (id, builder.build())
+        (id, builder)
     } else {
         // Stdio transport (default)
         let command = server.expect("server is required for stdio transport");
@@ -334,10 +345,18 @@ pub fn build_server_config(
             builder = builder.cwd(PathBuf::from(dir));
         }
 
-        (id, builder.build())
+        (id, builder)
     };
 
-    Ok((server_id, config))
+    if let Some(secs) = connect_timeout_secs {
+        builder = builder.connect_timeout(Duration::from_secs(secs));
+    }
+
+    if let Some(secs) = discover_timeout_secs {
+        builder = builder.discover_timeout(Duration::from_secs(secs));
+    }
+
+    Ok((server_id, builder.build()))
 }
 
 #[cfg(test)]
@@ -427,6 +446,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -451,6 +472,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -476,6 +499,8 @@ mod tests {
             Some("https://api.githubcopilot.com/mcp/".to_string()),
             None,
             vec!["Authorization=Bearer token123".to_string()],
+            None,
+            None,
         )
         .unwrap();
 
@@ -497,6 +522,8 @@ mod tests {
             None,
             Some("https://example.com/sse".to_string()),
             vec!["X-API-Key=secret".to_string()],
+            None,
+            None,
         )
         .unwrap();
 
@@ -518,6 +545,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -534,6 +563,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         );
 
         assert!(result.is_err());
@@ -555,6 +586,8 @@ mod tests {
             Some("https://example.com".to_string()),
             None,
             vec!["InvalidHeader".to_string()],
+            None,
+            None,
         );
 
         assert!(result.is_err());
@@ -580,6 +613,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -604,6 +639,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -625,6 +662,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -648,6 +687,8 @@ mod tests {
                 "X-API-Key=secret".to_string(),
                 "Content-Type=application/json".to_string(),
             ],
+            None,
+            None,
         )
         .unwrap();
 
@@ -680,6 +721,8 @@ mod tests {
                 "X-Custom=value=with=equals".to_string(),
                 "X-Query=a=b&c=d".to_string(),
             ],
+            None,
+            None,
         )
         .unwrap();
 
@@ -703,6 +746,8 @@ mod tests {
             None,
             Some("https://sse.example.com/events".to_string()),
             vec!["Authorization=Bearer xyz".to_string()],
+            None,
+            None,
         )
         .unwrap();
 
@@ -725,6 +770,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -742,6 +789,8 @@ mod tests {
             Some("https://example.com".to_string()),
             None,
             vec!["X-Empty=".to_string()],
+            None,
+            None,
         )
         .unwrap();
 
@@ -767,6 +816,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         )
         .unwrap();
 
@@ -794,6 +845,8 @@ mod tests {
             None,
             None,
             vec![],
+            None,
+            None,
         );
 
         assert!(result.is_err());
@@ -815,6 +868,8 @@ mod tests {
             Some("https://example.com".to_string()),
             None,
             vec!["=value".to_string()],
+            None,
+            None,
         );
 
         assert!(result.is_err());
@@ -824,6 +879,72 @@ mod tests {
                 .to_string()
                 .contains("key cannot be empty")
         );
+    }
+
+    #[test]
+    fn test_build_server_config_timeout_override_reaches_core_validation() {
+        // The manual CLI-flag path must fail identically to the mcp.json path:
+        // both end up calling the same `validate_server_config`, so a zero
+        // override must trip the same `connect_timeout` ValidationError.
+        let (_, config) = build_server_config(
+            Some("docker".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            Some(0),
+            None,
+        )
+        .unwrap();
+
+        let result = mcp_execution_core::validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(mcp_execution_core::Error::ValidationError { field, reason }) = result {
+            assert_eq!(field, "connect_timeout");
+            assert!(reason.contains("greater than zero"));
+        } else {
+            panic!("expected ValidationError for connect_timeout");
+        }
+    }
+
+    #[test]
+    fn test_build_server_config_timeout_overrides() {
+        let (_, config) = build_server_config(
+            Some("server".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            Some(5),
+            Some(90),
+        )
+        .unwrap();
+
+        assert_eq!(config.connect_timeout(), Duration::from_secs(5));
+        assert_eq!(config.discover_timeout(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn test_build_server_config_default_timeouts_without_overrides() {
+        let (_, config) = build_server_config(
+            Some("server".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(config.connect_timeout(), Duration::from_secs(30));
+        assert_eq!(config.discover_timeout(), Duration::from_secs(30));
     }
 
     #[test]

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -89,6 +89,12 @@ fn format_size(bytes: usize) -> String {
 /// * `name` - Custom server name for directory (default: `server_id`)
 /// * `output_dir` - Custom output directory (default: ~/.claude/servers/)
 /// * `dry_run` - When true, preview files without writing to disk
+/// * `connect_timeout_secs` - Connection (handshake) timeout override, in
+///   seconds. Ignored when `from_config` is set (the `mcp.json` entry's
+///   `connectTimeoutSecs` applies instead). Same bounds as `mcp.json`: must
+///   be greater than zero and at most 600 seconds.
+/// * `discover_timeout_secs` - Tool discovery timeout override, in seconds.
+///   Same rules as `connect_timeout_secs`.
 /// * `output_format` - Output format (json, text, pretty)
 ///
 /// # Errors
@@ -113,6 +119,8 @@ pub async fn run(
     name: Option<String>,
     output_dir: Option<PathBuf>,
     dry_run: bool,
+    connect_timeout_secs: Option<u64>,
+    discover_timeout_secs: Option<u64>,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
     let (server_id, server_config) = if let Some(config_name) = from_config {
@@ -122,7 +130,17 @@ pub async fn run(
         );
         load_server_from_config(&config_name)?
     } else {
-        build_server_config(server, args, env, cwd, http, sse, headers)?
+        build_server_config(
+            server,
+            args,
+            env,
+            cwd,
+            http,
+            sse,
+            headers,
+            connect_timeout_secs,
+            discover_timeout_secs,
+        )?
     };
 
     info!("Connecting to MCP server: {}", server_id);
@@ -441,5 +459,66 @@ mod tests {
             !output_path.exists(),
             "dry-run must not write files to disk"
         );
+    }
+
+    #[tokio::test]
+    async fn test_run_zero_connect_timeout_override_rejected_by_validation() {
+        // A zero override must surface the same connect_timeout validation
+        // error as the mcp.json path, not just a generic connection failure.
+        let result = run(
+            None,
+            Some("nonexistent-server-timeout-test".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            None,
+            None,
+            false,
+            Some(0),
+            None,
+            OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let chain_msg = err
+            .chain()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            chain_msg.contains("greater than zero"),
+            "expected connect_timeout validation error in the error chain, got: {chain_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_with_valid_timeout_overrides_reaches_connection_attempt() {
+        // Valid overrides must not be rejected before the connection attempt.
+        let result = run(
+            None,
+            Some("nonexistent-server-timeout-test-2".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            None,
+            None,
+            false,
+            Some(5),
+            Some(90),
+            OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("failed to introspect MCP server"));
     }
 }

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -103,6 +103,12 @@ pub struct ToolMetadata {
 /// * `sse` - SSE transport URL
 /// * `headers` - HTTP headers in KEY=VALUE format
 /// * `detailed` - Whether to show detailed tool schemas
+/// * `connect_timeout_secs` - Connection (handshake) timeout override, in
+///   seconds. Ignored when `from_config` is set (the `mcp.json` entry's
+///   `connectTimeoutSecs` applies instead). Same bounds as `mcp.json`: must
+///   be greater than zero and at most 600 seconds.
+/// * `discover_timeout_secs` - Tool discovery timeout override, in seconds.
+///   Same rules as `connect_timeout_secs`.
 /// * `output_format` - Output format (json, text, pretty)
 ///
 /// # Errors
@@ -131,10 +137,12 @@ pub struct ToolMetadata {
 ///     None,
 ///     vec![],
 ///     false,
+///     None,
+///     None,
 ///     OutputFormat::Json
 /// ).await?;
 ///
-/// // HTTP transport
+/// // HTTP transport with a shorter connect timeout
 /// let exit_code = introspect::run(
 ///     None,
 ///     None,
@@ -145,6 +153,8 @@ pub struct ToolMetadata {
 ///     None,
 ///     vec!["Authorization=Bearer token".to_string()],
 ///     false,
+///     Some(5),
+///     None,
 ///     OutputFormat::Json
 /// ).await?;
 /// # Ok(())
@@ -161,6 +171,8 @@ pub async fn run(
     sse: Option<String>,
     headers: Vec<String>,
     detailed: bool,
+    connect_timeout_secs: Option<u64>,
+    discover_timeout_secs: Option<u64>,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
     // Build server config: either from mcp.json or from CLI arguments
@@ -171,7 +183,17 @@ pub async fn run(
         );
         load_server_from_config(&config_name)?
     } else {
-        build_server_config(server, args, env, cwd, http, sse, headers)?
+        build_server_config(
+            server,
+            args,
+            env,
+            cwd,
+            http,
+            sse,
+            headers,
+            connect_timeout_secs,
+            discover_timeout_secs,
+        )?
     };
 
     info!("Introspecting server: {}", server_id);
@@ -521,6 +543,8 @@ mod tests {
             None,
             vec![],
             false,
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -630,6 +654,8 @@ mod tests {
             None,
             vec![],
             false,
+            None,
+            None,
             OutputFormat::Text,
         )
         .await;
@@ -651,6 +677,8 @@ mod tests {
             None,
             vec![],
             false,
+            None,
+            None,
             OutputFormat::Pretty,
         )
         .await;
@@ -672,6 +700,8 @@ mod tests {
             None,
             vec![],
             true, // detailed mode
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -692,6 +722,8 @@ mod tests {
             None,
             vec!["Authorization=Bearer test".to_string()],
             false,
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -714,6 +746,8 @@ mod tests {
             Some("https://localhost:99999/sse".to_string()),
             vec!["X-API-Key=test-key".to_string()],
             false,
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -737,6 +771,8 @@ mod tests {
                 None,
                 vec![],
                 false,
+                None,
+                None,
                 format,
             )
             .await;
@@ -759,6 +795,8 @@ mod tests {
                 None,
                 vec![],
                 true, // detailed
+                None,
+                None,
                 format,
             )
             .await;
@@ -973,6 +1011,8 @@ mod tests {
             None,
             vec![],
             false,
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -1001,6 +1041,8 @@ mod tests {
             None,
             vec![],
             false,
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -1028,6 +1070,8 @@ mod tests {
             None,
             vec![],
             false,
+            None,
+            None,
             OutputFormat::Json,
         )
         .await;
@@ -1039,5 +1083,62 @@ mod tests {
             err_msg.contains("failed to connect") || err_msg.contains("test-server-direct"),
             "Should try direct connection: {err_msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_run_zero_connect_timeout_override_rejected_by_validation() {
+        // A zero override must surface the same connect_timeout validation
+        // error as the mcp.json path, not just a generic connection failure.
+        let result = run(
+            None,
+            Some("nonexistent-server-timeout-test".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            false,
+            Some(0),
+            None,
+            OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let chain_msg = err
+            .chain()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            chain_msg.contains("greater than zero"),
+            "expected connect_timeout validation error in the error chain, got: {chain_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_with_valid_timeout_overrides_reaches_connection_attempt() {
+        // Valid overrides must not be rejected before the connection attempt.
+        let result = run(
+            None,
+            Some("nonexistent-server-timeout-test-2".to_string()),
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            vec![],
+            false,
+            Some(5),
+            Some(90),
+            OutputFormat::Json,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("failed to connect to server"));
     }
 }

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -68,6 +68,8 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
             sse,
             headers,
             detailed,
+            connect_timeout_secs,
+            discover_timeout_secs,
         } => {
             commands::introspect::run(
                 from_config,
@@ -79,6 +81,8 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
                 sse,
                 headers,
                 detailed,
+                connect_timeout_secs,
+                discover_timeout_secs,
                 output_format,
             )
             .await
@@ -114,6 +118,8 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
             name,
             progressive_output,
             dry_run,
+            connect_timeout_secs,
+            discover_timeout_secs,
         } => {
             commands::generate::run(
                 from_config,
@@ -127,6 +133,8 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
                 name,
                 progressive_output,
                 dry_run,
+                connect_timeout_secs,
+                discover_timeout_secs,
                 output_format,
             )
             .await

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -109,6 +109,9 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 /// - Absolute paths undergo strict validation (existence, permissions)
 /// - All arguments are validated separately to prevent injection
 /// - Environment variables are checked against forbidden names
+/// - There is no infinite-timeout option: `0` is always rejected, since an
+///   unbounded wait would let a hung server block this non-interactive tool
+///   forever (see the `validate_timeout` design note in this module)
 pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
     // Validate command
     validate_command_string(&config.command, "command")?;
@@ -131,9 +134,10 @@ pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
     }
 
     // Validate timeout bounds. Zero fires immediately and breaks all
-    // discovery; unbounded values re-open the DoS window these timeouts
-    // were introduced to close.
-    // TODO(#145): 0 is rejected; revisit if an infinite-timeout option is needed
+    // discovery; an infinite timeout is deliberately unsupported (see
+    // `validate_timeout` doc comment) because it would let a hung or
+    // malicious server block this non-interactive CLI tool forever,
+    // re-opening the DoS window these timeouts were introduced to close.
     validate_timeout(config.connect_timeout(), "connect_timeout")?;
     validate_timeout(config.discover_timeout(), "discover_timeout")?;
 
@@ -141,6 +145,16 @@ pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
 }
 
 /// Validates that a timeout is within `(0, MAX_TIMEOUT]`.
+///
+/// # Design Note: No Infinite Timeout
+///
+/// A timeout of zero is permanently rejected rather than treated as a
+/// sentinel for "no timeout". This tool spawns subprocesses and connects to
+/// servers non-interactively (CLI and MCP-server modes); an unbounded
+/// connect/discover wait would let a hung or malicious server block the
+/// caller indefinitely, which is exactly the denial-of-service exposure
+/// these timeouts were added to close. Callers that need a longer wait
+/// should raise the value up to `MAX_TIMEOUT` (10 minutes) instead.
 fn validate_timeout(timeout: Duration, field: &str) -> Result<()> {
     if timeout.is_zero() {
         return Err(Error::ValidationError {


### PR DESCRIPTION
## Summary
- Add `--connect-timeout-secs` / `--discover-timeout-secs` flags to the manual (non-`--from-config`) `introspect` and `generate` commands, routed through the same `validate_server_config` chokepoint used by the `mcp.json` (`--from-config`) path, so both paths accept/reject identical values. Flags conflict with `--from-config` via clap.
- Document the decision to permanently reject a `0` connect/discover timeout rather than treat it as "no timeout": an unbounded wait would let a hung or malicious server block this tool's non-interactive CLI/MCP-server invocations forever, reopening the DoS exposure these timeouts were introduced to close. No behavior change.
- Resolves the two `TODO(critic)` markers left by #136.

Closes #144, closes #145

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (739 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links -D warnings" cargo doc --no-deps --workspace`
- [x] Manual smoke test: `--connect-timeout-secs 0` rejected with the same error as the `mcp.json` path; `--connect-timeout-secs 5` accepted; `--from-config X --connect-timeout-secs 5` rejected by clap as conflicting args