### PR TITLE
chore(mcp-introspector): drop unused rmcp transport-child-process feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`mcp-execution-skill`**, **`mcp-execution-server`**, **`mcp-execution-cli`**: existing
   item-level `#[allow(...)]` attributes now carry a comment explaining the suppression, per the
   `CLAUDE.md` justification requirement (#147).
+- **`mcp-execution-introspector`**: dropped the unused rmcp `transport-child-process` feature.
+  `spawn_introspection_child` now configures the child `tokio::process::Command` directly instead
+  of via `rmcp::transport::ConfigureCommandExt`, which was the last thing requiring the feature
+  after #142 replaced `TokioChildProcess` with a manually spawned stdio pair. Shrinks the dependency
+  tree by dropping `process-wrap`, `nix`, and several Windows-only transitive crates that were only
+  pulled in for that feature (#146).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,12 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,18 +1112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,20 +1313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "process-wrap"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
-dependencies = [
- "futures",
- "indexmap",
- "nix",
- "tokio",
- "tracing",
- "windows",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,7 +1445,6 @@ dependencies = [
  "futures",
  "pastey",
  "pin-project-lite",
- "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -2162,27 +2129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,17 +2139,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -2235,16 +2170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,15 +2192,6 @@ name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -31,7 +31,7 @@ test-fixtures = ["rmcp/server", "rmcp/transport-io"]
 
 [dependencies]
 mcp-execution-core.workspace = true
-rmcp = { workspace = true, features = ["client", "transport-child-process"] }
+rmcp = { workspace = true, features = ["client"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time"] }

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -44,7 +44,6 @@
 
 use mcp_execution_core::{Error, Result, ServerConfig, ServerId, ToolName, validate_server_config};
 use rmcp::ServiceExt;
-use rmcp::transport::ConfigureCommandExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -458,21 +457,19 @@ impl Default for Introspector {
 /// Returns [`Error::ConnectionFailed`] if the process cannot be spawned
 /// (e.g. the command does not exist or is not executable).
 fn spawn_introspection_child(server_id: &ServerId, config: &ServerConfig) -> Result<Child> {
-    tokio::process::Command::new(&config.command)
-        .configure(|cmd| {
-            cmd.args(&config.args);
-            cmd.envs(&config.env);
-            if let Some(cwd) = &config.cwd {
-                cmd.current_dir(cwd);
-            }
-            cmd.stdin(Stdio::piped());
-            cmd.stdout(Stdio::piped());
-        })
-        .spawn()
-        .map_err(|e| Error::ConnectionFailed {
-            server: server_id.to_string(),
-            source: Box::new(e),
-        })
+    let mut command = tokio::process::Command::new(&config.command);
+    command.args(&config.args);
+    command.envs(&config.env);
+    if let Some(cwd) = &config.cwd {
+        command.current_dir(cwd);
+    }
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+
+    command.spawn().map_err(|e| Error::ConnectionFailed {
+        server: server_id.to_string(),
+        source: Box::new(e),
+    })
 }
 
 /// Connects to an already-spawned MCP server over `transport` and lists its


### PR DESCRIPTION
## Summary
- Remove the unused rmcp `transport-child-process` feature from `crates/mcp-introspector/Cargo.toml`; `TokioChildProcess` was already replaced by a manually spawned stdio pair in #142, and the only remaining user of the feature was `ConfigureCommandExt`
- Rewrite `spawn_introspection_child` to mutate the `tokio::process::Command` directly (same args/envs/cwd/stdio sequence, verified behaviorally identical) instead of chaining `ConfigureCommandExt::configure(...)`
- Cargo.lock shrinks by ~84 lines, dropping `process-wrap`, `nix`, `cfg_aliases`, and several Windows-only transitive crates that were only pulled in by the removed feature

## Test plan
- [x] `cargo build --workspace --all-features`
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (696 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] Confirmed no other workspace code references `ConfigureCommandExt`, `TokioChildProcess`, or `transport-child-process`

Closes #146