### PR TITLE
refactor(cli,server): disambiguate ToolMetadata across mcp-server/mcp-cli/mcp-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after #142 replaced `TokioChildProcess` with a manually spawned stdio pair. Shrinks the dependency
   tree by dropping `process-wrap`, `nix`, and several Windows-only transitive crates that were only
   pulled in for that feature (#146).
+- **`mcp-execution-server`**, **`mcp-execution-cli`**: disambiguated the three unrelated
+  `ToolMetadata` structs that shared a name across the workspace. `mcp_execution_server::types::ToolMetadata`
+  (the `introspect_server` tool's response payload) is renamed to `IntrospectedToolSummary`, and
+  `mcp_execution_cli::commands::introspect::ToolMetadata` (CLI display formatting for `introspect`)
+  is renamed to `ToolDisplay`. `mcp_execution_core::metadata::ToolMetadata`, the canonical
+  `_meta.json` sidecar entry, is unchanged. Pure rename, no behavior change, and both renamed types
+  are wire/protocol-invisible (serde serializes by field name only). This is source-breaking for
+  any external library consumer of `mcp-execution-server` or `mcp-execution-cli` — neither crate
+  sets `publish = false` and both types are `pub`-reachable from their crate roots; treat as a
+  minor version bump at 0.7.x per pre-1.0 SemVer convention (#156).
 
 ### Fixed
 

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -38,7 +38,7 @@ pub struct IntrospectionResult {
     /// Server metadata
     pub server: ServerMetadata,
     /// List of available tools
-    pub tools: Vec<ToolMetadata>,
+    pub tools: Vec<ToolDisplay>,
 }
 
 /// Server metadata for display.
@@ -61,12 +61,12 @@ pub struct ServerMetadata {
     pub supports_prompts: bool,
 }
 
-/// Tool metadata for display.
+/// Tool information formatted for CLI display.
 ///
 /// Contains tool information with optional schema details
 /// when detailed output is requested.
 #[derive(Debug, Clone, Serialize)]
-pub struct ToolMetadata {
+pub struct ToolDisplay {
     /// Tool name
     pub name: String,
     /// Tool description
@@ -287,14 +287,14 @@ pub fn build_result(server_info: &ServerInfo, detailed: bool) -> IntrospectionRe
 
 /// Builds tool metadata from tool info.
 ///
-/// Transforms `ToolInfo` into `ToolMetadata` with optional schema details.
+/// Transforms `ToolInfo` into `ToolDisplay` with optional schema details.
 ///
 /// # Arguments
 ///
 /// * `tool_info` - Tool information from introspector
 /// * `detailed` - Whether to include input/output schemas
-fn build_tool_metadata(tool_info: &ToolInfo, detailed: bool) -> ToolMetadata {
-    ToolMetadata {
+fn build_tool_metadata(tool_info: &ToolInfo, detailed: bool) -> ToolDisplay {
+    ToolDisplay {
         name: tool_info.name.as_str().to_string(),
         description: tool_info.description.clone(),
         input_schema: if detailed {
@@ -490,7 +490,7 @@ mod tests {
                 supports_resources: false,
                 supports_prompts: false,
             },
-            tools: vec![ToolMetadata {
+            tools: vec![ToolDisplay {
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 input_schema: None,
@@ -518,7 +518,7 @@ mod tests {
                 supports_resources: false,
                 supports_prompts: false,
             },
-            tools: vec![ToolMetadata {
+            tools: vec![ToolDisplay {
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 input_schema: Some(json!({"type": "object"})),
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn test_tool_metadata_empty_description() {
-        let metadata = ToolMetadata {
+        let metadata = ToolDisplay {
             name: "tool".to_string(),
             description: String::new(),
             input_schema: None,
@@ -943,7 +943,7 @@ mod tests {
 
     #[test]
     fn test_tool_metadata_serialization_without_schemas() {
-        let metadata = ToolMetadata {
+        let metadata = ToolDisplay {
             name: "simple_tool".to_string(),
             description: "A simple tool".to_string(),
             input_schema: None,
@@ -962,7 +962,7 @@ mod tests {
     #[test]
     fn test_tool_metadata_long_description() {
         let long_description = "A".repeat(1000);
-        let metadata = ToolMetadata {
+        let metadata = ToolDisplay {
             name: "tool".to_string(),
             description: long_description.clone(),
             input_schema: None,

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -59,8 +59,8 @@ pub use service::GeneratorService;
 pub use state::StateManager;
 pub use types::{
     CategorizedTool, GeneratedServerInfo, IntrospectServerParams, IntrospectServerResult,
-    ListGeneratedServersParams, ListGeneratedServersResult, PendingGeneration,
-    SaveCategorizedToolsParams, SaveCategorizedToolsResult, ToolGenerationError, ToolMetadata,
+    IntrospectedToolSummary, ListGeneratedServersParams, ListGeneratedServersResult,
+    PendingGeneration, SaveCategorizedToolsParams, SaveCategorizedToolsResult, ToolGenerationError,
 };
 
 // Re-export skill types from mcp-skill crate

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -9,8 +9,8 @@ use crate::clock::{Clock, SystemClock};
 use crate::state::StateManager;
 use crate::types::{
     CategorizedTool, GeneratedServerInfo, IntrospectServerParams, IntrospectServerResult,
-    ListGeneratedServersParams, ListGeneratedServersResult, PendingGeneration,
-    SaveCategorizedToolsParams, SaveCategorizedToolsResult, ToolMetadata,
+    IntrospectedToolSummary, ListGeneratedServersParams, ListGeneratedServersResult,
+    PendingGeneration, SaveCategorizedToolsParams, SaveCategorizedToolsResult,
 };
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::{ServerConfig, ServerId};
@@ -222,13 +222,13 @@ impl GeneratorService {
         })?;
 
         // Extract tool metadata for Claude
-        let tools: Vec<ToolMetadata> = server_info
+        let tools: Vec<IntrospectedToolSummary> = server_info
             .tools
             .iter()
             .map(|tool| {
                 let parameters = extract_parameter_names(&tool.input_schema);
 
-                ToolMetadata {
+                IntrospectedToolSummary {
                     name: tool.name.as_str().to_string(),
                     description: tool.description.clone(),
                     parameters,

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -83,7 +83,7 @@ pub struct IntrospectServerResult {
     pub tools_found: usize,
 
     /// List of tools for categorization
-    pub tools: Vec<ToolMetadata>,
+    pub tools: Vec<IntrospectedToolSummary>,
 
     /// Session ID for `save_categorized_tools` call
     pub session_id: Uuid,
@@ -92,12 +92,12 @@ pub struct IntrospectServerResult {
     pub expires_at: DateTime<Utc>,
 }
 
-/// Metadata about a tool for categorization by Claude.
+/// Summary of an introspected tool, returned to Claude for categorization.
 ///
 /// Includes the tool name, description, and parameter names to help
 /// Claude understand the tool's purpose and assign appropriate categories.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
-pub struct ToolMetadata {
+pub struct IntrospectedToolSummary {
     /// Original tool name
     pub name: String,
 


### PR DESCRIPTION
## Summary
- Renames `mcp_execution_server::types::ToolMetadata` to `IntrospectedToolSummary` and `mcp_execution_cli::commands::introspect::ToolMetadata` to `ToolDisplay`, so the three unrelated `ToolMetadata` shapes in the workspace stop sharing a name.
- `mcp_execution_core::metadata::ToolMetadata`, the canonical `_meta.json` sidecar type, is unchanged.
- Pure rename, no behavior change; both renamed types are wire/protocol-invisible (serde serializes by field name only).
- Source-breaking for external library consumers of `mcp-execution-server`/`mcp-execution-cli` (neither crate sets `publish = false`, both types are `pub`-reachable) — documented in CHANGELOG.md and flagged via `BREAKING CHANGE:` footer; treat as a minor bump at 0.7.x per pre-1.0 SemVer convention.

Closes #156.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (714 passed)
- [x] `cargo test --doc --all-features --workspace`