### PR TITLE
fix(skill): detect _meta.json sidecar drift against .ts tool files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously a finishing call could evict a different, still in-flight caller's live entry for the
   same server id, letting concurrent callers bypass the per-id serialization the lock exists to
   provide (#130).
+- **`mcp-execution-skill`**: `scan_tools_directory` now cross-checks each `_meta.json` sidecar entry
+  against the `.ts` file it should have produced. A tool listed in the sidecar whose `.ts` file is
+  missing (e.g. deleted manually, or an interrupted `generate` run) now fails with
+  `ScanError::StaleMetadata` instead of silently being included in `SKILL.md` for a tool that no
+  longer exists. A `.ts` file present on disk but not referenced by the sidecar (e.g. added
+  manually) is not fatal but is now logged via `tracing::warn!` instead of being silently dropped.
+  The `skill` CLI command's log line also no longer implies a raw file count; it reports the number
+  of tools verified against the sidecar (#154, #155).
 
 ### Testing
 

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -259,6 +259,9 @@ pub async fn run(
     info!("Exporting files to: {}", output_path.display());
 
     std::fs::create_dir_all(&output_path).context("failed to create output directory")?;
+    // TODO(#159): export is not atomic across the whole directory; an interrupted run
+    // can leave index.ts referencing a tool file that was never written, undetected by
+    // any consumer that reads .ts files directly instead of going through `skill`.
     vfs.export_to_filesystem(&output_path)
         .context("failed to export files to filesystem")?;
 

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -144,7 +144,10 @@ pub async fn run(
         );
     }
 
-    info!("Found {} tool files", tools.len());
+    // `tools.len()` reflects sidecar entries that were cross-checked against an
+    // actual `.ts` file on disk by `scan_tools_directory` (issue #154) — not a
+    // raw sidecar entry count.
+    info!("Verified {} tool files against sidecar", tools.len());
 
     // Step 6: Build skill context
     let hints_ref: Option<Vec<String>> = if hints.is_empty() { None } else { Some(hints) };
@@ -350,6 +353,9 @@ mod tests {
 
     /// Writes a minimal `_meta.json` sidecar with a single tool into `server_dir`,
     /// matching what `mcp-execution-codegen` would emit for a generated server.
+    ///
+    /// Also writes a matching stub `{typescript_name}.ts` file, since
+    /// `scan_tools_directory` cross-checks the sidecar against files on disk.
     fn write_meta_sidecar(server_dir: &Path, server_id: &str, tool_name: &str) {
         let meta = ServerMetadata {
             schema_version: METADATA_SCHEMA_VERSION,
@@ -373,6 +379,7 @@ mod tests {
 
         let content = serde_json::to_string_pretty(&meta).unwrap();
         std::fs::write(server_dir.join(METADATA_FILE_NAME), content).unwrap();
+        std::fs::write(server_dir.join(format!("{tool_name}.ts")), "export {}").unwrap();
     }
 
     #[test]
@@ -749,6 +756,87 @@ mod tests {
                 result.err()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_run_stale_metadata_fails_instead_of_silently_succeeding() {
+        // Issue #154 repro: a `_meta.json` sidecar that has drifted from the
+        // `.ts` files on disk (one entry's file was deleted, an unrelated file
+        // was added) must now make `skill` fail loudly instead of silently
+        // generating a SKILL.md with stale/missing tool references.
+        let temp = TempDir::new().unwrap();
+        let server_dir = temp.path().join("github");
+        std::fs::create_dir(&server_dir).unwrap();
+
+        let meta = ServerMetadata {
+            schema_version: METADATA_SCHEMA_VERSION,
+            server_id: "github".to_string(),
+            server_name: "GitHub".to_string(),
+            server_version: "1.0.0".to_string(),
+            tools: vec![
+                ToolMetadata {
+                    name: "create_issue".to_string(),
+                    typescript_name: "createIssue".to_string(),
+                    category: Some("issues".to_string()),
+                    keywords: vec!["create".to_string()],
+                    description: Some("Create an issue".to_string()),
+                    parameters: vec![ParameterMetadata {
+                        name: "title".to_string(),
+                        typescript_type: "string".to_string(),
+                        required: true,
+                        description: Some("Issue title".to_string()),
+                    }],
+                },
+                ToolMetadata {
+                    name: "list_repos".to_string(),
+                    typescript_name: "listRepos".to_string(),
+                    category: Some("repos".to_string()),
+                    keywords: vec!["list".to_string()],
+                    description: Some("List repos".to_string()),
+                    parameters: vec![],
+                },
+            ],
+        };
+        let content = serde_json::to_string_pretty(&meta).unwrap();
+        std::fs::write(server_dir.join(METADATA_FILE_NAME), content).unwrap();
+
+        // Generate as normal for `list_repos`, but simulate a `.ts` file that
+        // was deleted (or never written, e.g. an interrupted `generate`) for
+        // `create_issue` — this is the drift the sidecar must now catch.
+        std::fs::write(server_dir.join("listRepos.ts"), "export {}").unwrap();
+        // An unrelated `.ts` file left over on disk, not referenced by the
+        // sidecar at all — must not mask the missing-file error above.
+        std::fs::write(server_dir.join("orphanTool.ts"), "export {}").unwrap();
+
+        let output_path = temp.path().join("SKILL.md");
+
+        let result = run(
+            "github".to_string(),
+            Some(temp.path().to_path_buf()),
+            Some(output_path.clone()),
+            None,
+            vec![],
+            false,
+            OutputFormat::Json,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "drifted sidecar must fail instead of silently succeeding"
+        );
+        let err = result.unwrap_err();
+        // `anyhow::Error`'s `Display` only shows the outer context; the full
+        // chain (including the `ScanError::StaleMetadata` source) is in `{err:?}`.
+        let message = format!("{err:?}");
+        assert!(
+            message.contains("create_issue") || message.contains("createIssue.ts"),
+            "error must identify the tool/file with the missing .ts: {message}"
+        );
+        assert!(
+            !output_path.exists(),
+            "SKILL.md must not be written when the sidecar is stale"
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -484,7 +484,9 @@ impl GeneratorService {
         let tools = scan_tools_directory(&server_dir)
             .await
             .map_err(|e| match e {
-                ScanError::MissingMetadata { .. } | ScanError::UnsupportedSchema { .. } => {
+                ScanError::MissingMetadata { .. }
+                | ScanError::UnsupportedSchema { .. }
+                | ScanError::StaleMetadata { .. } => {
                     McpError::invalid_params(format!("Failed to scan tools directory: {e}"), None)
                 }
                 ScanError::Io(_)
@@ -1547,6 +1549,69 @@ mod tests {
              server directory, and must be reported the same way"
         );
         assert!(err.message.contains("Failed to scan tools directory"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_skill_stale_metadata_missing_ts_file() {
+        use mcp_execution_core::metadata::{
+            METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata,
+            ToolMetadata as SidecarToolMetadata,
+        };
+        use tempfile::TempDir;
+
+        let service = GeneratorService::new();
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        // Sidecar references a tool whose `.ts` file was never written (or was
+        // deleted) — the drift `StaleMetadata` (issues #154/#155) exists to
+        // catch, routed through the `generate_skill` MCP tool this time.
+        let target_dir = base_dir.join("test-server");
+        tokio::fs::create_dir_all(&target_dir).await.unwrap();
+        let meta = ServerMetadata {
+            schema_version: METADATA_SCHEMA_VERSION,
+            server_id: "test-server".to_string(),
+            server_name: "Test Server".to_string(),
+            server_version: "1.0.0".to_string(),
+            tools: vec![SidecarToolMetadata {
+                name: "create_issue".to_string(),
+                typescript_name: "createIssue".to_string(),
+                category: None,
+                keywords: vec![],
+                description: None,
+                parameters: vec![ParameterMetadata {
+                    name: "title".to_string(),
+                    typescript_type: "string".to_string(),
+                    required: true,
+                    description: None,
+                }],
+            }],
+        };
+        let content = serde_json::to_string_pretty(&meta).unwrap();
+        tokio::fs::write(target_dir.join(METADATA_FILE_NAME), content)
+            .await
+            .unwrap();
+        // Deliberately do not write `createIssue.ts`.
+
+        let params = GenerateSkillParams {
+            server_id: "test-server".to_string(),
+            skill_name: None,
+            use_case_hints: None,
+            servers_dir: Some(base_dir),
+        };
+
+        let result = service.generate_skill(Parameters(params)).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.code,
+            ErrorCode::INVALID_PARAMS,
+            "stale metadata is the same 'not generated / drifted directory' caller situation \
+             as a missing sidecar, and must be reported the same way"
+        );
+        assert!(err.message.contains("Failed to scan tools directory"));
+        assert!(err.message.contains("create_issue"));
     }
 
     // ========================================================================

--- a/crates/mcp-server/tests/skill_tests.rs
+++ b/crates/mcp-server/tests/skill_tests.rs
@@ -9,6 +9,9 @@ use tokio::fs;
 
 /// Build a `ServerMetadata` sidecar with `count` simple test tools, each with one
 /// required string parameter, and write it as `_meta.json` into `dir`.
+///
+/// Also writes a matching stub `{typescript_name}.ts` file for each tool, since
+/// `scan_tools_directory` now cross-checks the sidecar against files on disk.
 async fn write_metadata_sidecar(dir: &std::path::Path, tool_names: &[&str]) {
     let meta = ServerMetadata {
         schema_version: METADATA_SCHEMA_VERSION,
@@ -45,6 +48,15 @@ async fn write_metadata_sidecar(dir: &std::path::Path, tool_names: &[&str]) {
     fs::write(dir.join(METADATA_FILE_NAME), content)
         .await
         .unwrap();
+
+    for tool in &meta.tools {
+        fs::write(
+            dir.join(format!("{}.ts", tool.typescript_name)),
+            "export {}",
+        )
+        .await
+        .unwrap();
+    }
 }
 
 fn to_camel_case(s: &str) -> String {
@@ -218,8 +230,9 @@ async fn test_scan_directory_with_many_tools() {
 
 #[tokio::test]
 async fn test_scan_directory_ignores_stray_files() {
-    // Only `_meta.json` is read; stray `.ts` files, an `index.ts`, or a `_runtime`
-    // directory left over in a server directory must not affect the scan.
+    // Tool metadata itself only ever comes from `_meta.json`; an `index.ts`, a
+    // `_runtime` directory, or an unrelated stray file must not affect the scan
+    // (they are not sidecar-referenced tool files, so at most they are logged).
     let temp_dir = TempDir::new().unwrap();
     let dir = temp_dir.path();
 

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -80,6 +80,22 @@ pub enum ScanError {
     /// Sidecar file too large to process.
     #[error("file too large: {path} ({size} bytes exceeds {limit} limit)")]
     FileTooLarge { path: String, size: u64, limit: u64 },
+
+    /// A tool listed in the `_meta.json` sidecar has no corresponding `.ts`
+    /// file on disk.
+    ///
+    /// This indicates the sidecar and the generated TypeScript files have
+    /// drifted apart — e.g. the file was deleted manually, or a `generate`
+    /// run was interrupted before writing it.
+    #[error(
+        "stale metadata: tool '{tool}' is listed in {sidecar_path} but its file '{expected_file}' \
+         is missing (re-run 'generate' to regenerate this server)"
+    )]
+    StaleMetadata {
+        tool: String,
+        expected_file: String,
+        sidecar_path: String,
+    },
 }
 
 /// Parsed metadata from a server's generated tool set.
@@ -152,8 +168,13 @@ impl From<mcp_execution_core::metadata::ToolMetadata> for ParsedToolFile {
 ///
 /// Reads the structured metadata sidecar written by `mcp-execution-codegen`
 /// and maps each tool entry into a [`ParsedToolFile`]. Unlike the former
-/// regex-based `.ts` scanner, this does not enumerate or read any generated
-/// TypeScript source — the sidecar is the single source of truth.
+/// regex-based `.ts` scanner, tool metadata (name, category, keywords,
+/// parameters) is never re-parsed from generated TypeScript source — the
+/// sidecar remains the single source of truth for that. However, each
+/// sidecar entry's `.ts` file is cross-checked for existence on disk to
+/// detect drift between the sidecar and the generated files (see issues
+/// #154, #155): a missing file is a hard error, while an unreferenced `.ts`
+/// file on disk is logged via `tracing::warn!` and omitted from the result.
 ///
 /// # Arguments
 ///
@@ -166,8 +187,9 @@ impl From<mcp_execution_core::metadata::ToolMetadata> for ParsedToolFile {
 /// # Errors
 ///
 /// Returns `ScanError` if the directory doesn't exist, the sidecar is
-/// missing or malformed, or the sidecar's tool count exceeds
-/// [`MAX_TOOL_FILES`].
+/// missing or malformed, the sidecar's tool count exceeds
+/// [`MAX_TOOL_FILES`], or a sidecar entry's `.ts` file is missing from disk
+/// ([`ScanError::StaleMetadata`]).
 ///
 /// # Examples
 ///
@@ -234,6 +256,8 @@ pub async fn scan_tools_directory(dir: &Path) -> Result<Vec<ParsedToolFile>, Sca
         });
     }
 
+    verify_tool_files_on_disk(&canonical_base, &meta.tools, &meta_path).await?;
+
     let server_id = meta.server_id.clone();
     let mut tools: Vec<ParsedToolFile> = meta
         .tools
@@ -249,6 +273,65 @@ pub async fn scan_tools_directory(dir: &Path) -> Result<Vec<ParsedToolFile>, Sca
     tools.sort_by(|a, b| a.name.cmp(&b.name));
 
     Ok(tools)
+}
+
+/// Cross-checks sidecar tool entries against the `.ts` files actually
+/// present in `dir`, guarding against drift between `_meta.json` and the
+/// generated TypeScript output (see issues #154, #155).
+///
+/// Every sidecar entry must have a matching `{typescript_name}.ts` file, or
+/// this returns [`ScanError::StaleMetadata`]. `.ts` files present on disk
+/// but not referenced by the sidecar are not fatal — regenerating tool
+/// files is a normal part of `generate` — but are logged via
+/// `tracing::warn!` so the drift isn't silently dropped from `SKILL.md`.
+///
+/// # Errors
+///
+/// Returns `ScanError::Io` if the directory cannot be read, or
+/// `ScanError::StaleMetadata` if a sidecar entry's `.ts` file is missing.
+async fn verify_tool_files_on_disk(
+    dir: &Path,
+    tools: &[mcp_execution_core::metadata::ToolMetadata],
+    meta_path: &Path,
+) -> Result<(), ScanError> {
+    // Generated aggregator file, not a per-tool file — never expected in the sidecar.
+    const INDEX_FILE_NAME: &str = "index.ts";
+
+    let mut expected_files: std::collections::HashSet<String> =
+        std::collections::HashSet::with_capacity(tools.len());
+
+    for tool in tools {
+        let file_name = format!("{}.ts", tool.typescript_name);
+        if !dir.join(&file_name).is_file() {
+            return Err(ScanError::StaleMetadata {
+                tool: tool.name.clone(),
+                expected_file: file_name,
+                sidecar_path: sanitize_path_for_error(meta_path),
+            });
+        }
+        expected_files.insert(file_name);
+    }
+
+    let mut entries = tokio::fs::read_dir(dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("ts") {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
+            continue;
+        };
+        if file_name == INDEX_FILE_NAME || expected_files.contains(file_name) {
+            continue;
+        }
+        tracing::warn!(
+            file = %file_name,
+            "found .ts tool file not referenced by _meta.json; it will be omitted from SKILL.md \
+             (re-run 'generate' to refresh the sidecar)"
+        );
+    }
+
+    Ok(())
 }
 
 /// Extract skill metadata from SKILL.md content.
@@ -357,11 +440,22 @@ mod tests {
         }
     }
 
+    /// Writes `_meta.json` plus a matching stub `.ts` file for each tool, since
+    /// `scan_tools_directory` cross-checks the sidecar against files on disk.
     async fn write_metadata(dir: &Path, meta: &ServerMetadata) {
         let content = serde_json::to_string_pretty(meta).unwrap();
         tokio::fs::write(dir.join(METADATA_FILE_NAME), content)
             .await
             .unwrap();
+
+        for tool in &meta.tools {
+            tokio::fs::write(
+                dir.join(format!("{}.ts", tool.typescript_name)),
+                "export {}",
+            )
+            .await
+            .unwrap();
+        }
     }
 
     #[tokio::test]
@@ -413,6 +507,132 @@ mod tests {
 
         assert_eq!(tools[0].name, "alpha");
         assert_eq!(tools[1].name, "zebra");
+    }
+
+    #[tokio::test]
+    async fn test_scan_tools_directory_stale_metadata_missing_ts_file() {
+        // Issue #154/#155 regression: a sidecar entry whose `.ts` file was
+        // deleted (or never written, e.g. an interrupted `generate`) must be
+        // reported instead of silently vanishing from `SKILL.md`.
+        let temp_dir = TempDir::new().unwrap();
+        let meta = sample_metadata(1);
+        // Write only the sidecar, not the tool's `.ts` file.
+        let content = serde_json::to_string_pretty(&meta).unwrap();
+        tokio::fs::write(temp_dir.path().join(METADATA_FILE_NAME), content)
+            .await
+            .unwrap();
+
+        let result = scan_tools_directory(temp_dir.path()).await;
+
+        match result {
+            Err(ScanError::StaleMetadata {
+                tool,
+                expected_file,
+                ..
+            }) => {
+                assert_eq!(tool, "tool_0");
+                assert_eq!(expected_file, "tool0.ts");
+            }
+            other => panic!("expected StaleMetadata, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_tools_directory_stale_metadata_reports_first_missing_in_sidecar_order() {
+        // With multiple tools in the sidecar, only some of which have a missing
+        // `.ts` file, the check short-circuits on the first missing entry in
+        // sidecar order rather than scanning every tool up front.
+        let temp_dir = TempDir::new().unwrap();
+        let meta = sample_metadata(3);
+        let content = serde_json::to_string_pretty(&meta).unwrap();
+        tokio::fs::write(temp_dir.path().join(METADATA_FILE_NAME), content)
+            .await
+            .unwrap();
+
+        // Only write the `.ts` file for the middle tool; `tool_0` and `tool_2`
+        // are both missing, but `tool_0` is first in sidecar order.
+        tokio::fs::write(temp_dir.path().join("tool1.ts"), "export {}")
+            .await
+            .unwrap();
+
+        let result = scan_tools_directory(temp_dir.path()).await;
+
+        match result {
+            Err(ScanError::StaleMetadata {
+                tool,
+                expected_file,
+                ..
+            }) => {
+                assert_eq!(tool, "tool_0");
+                assert_eq!(expected_file, "tool0.ts");
+            }
+            other => panic!("expected StaleMetadata for tool_0, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_tools_directory_extra_ts_file_excluded_from_result() {
+        // Issue #154/#155 regression: a `.ts` file on disk that the sidecar
+        // does not reference (e.g. left over from a renamed/removed tool) must
+        // not be fatal and must not leak into the scan result — it is logged
+        // via `tracing::warn!` instead.
+        let temp_dir = TempDir::new().unwrap();
+        let meta = sample_metadata(1);
+        write_metadata(temp_dir.path(), &meta).await;
+
+        tokio::fs::write(temp_dir.path().join("orphan.ts"), "export {}")
+            .await
+            .unwrap();
+
+        let tools = scan_tools_directory(temp_dir.path()).await.unwrap();
+
+        assert_eq!(
+            tools.len(),
+            1,
+            "the orphaned .ts file must not be reported as a tool"
+        );
+        assert_eq!(tools[0].name, "tool_0");
+    }
+
+    #[tokio::test]
+    async fn test_scan_tools_directory_index_ts_not_treated_as_extra() {
+        // `index.ts` is the generated aggregator file and is never listed in
+        // the sidecar; its presence alone must not affect the scan result.
+        let temp_dir = TempDir::new().unwrap();
+        let meta = sample_metadata(1);
+        write_metadata(temp_dir.path(), &meta).await;
+
+        tokio::fs::write(temp_dir.path().join("index.ts"), "export * from './tool0';")
+            .await
+            .unwrap();
+
+        let tools = scan_tools_directory(temp_dir.path()).await.unwrap();
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "tool_0");
+    }
+
+    #[test]
+    fn test_stale_metadata_error_message_tells_user_to_regenerate() {
+        let err = ScanError::StaleMetadata {
+            tool: "create_issue".to_string(),
+            expected_file: "createIssue.ts".to_string(),
+            sidecar_path: "~/.claude/servers/github/_meta.json".to_string(),
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("create_issue"),
+            "message must name the affected tool"
+        );
+        assert!(
+            message.contains("createIssue.ts"),
+            "message must name the missing file"
+        );
+        assert!(
+            message.contains("re-run 'generate'"),
+            "message must tell the user how to fix it: {message}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- `scan_tools_directory` (`crates/mcp-skill/src/parser.rs`) now cross-checks every `_meta.json` sidecar entry against the `.ts` file it should have produced.
- A tool listed in the sidecar whose `.ts` file is missing (deleted manually, or an interrupted `generate` run) now fails with `ScanError::StaleMetadata` instead of silently producing an incorrect `SKILL.md`. The error is surfaced through both call sites: the `skill` CLI command (non-zero exit) and `mcp-execution-server`'s `generate_skill` MCP tool (`StaleMetadata` routed to `invalid_params`, same bucket as `MissingMetadata`/`UnsupportedSchema`).
- A `.ts` file present on disk but not referenced by the sidecar (added manually) is not fatal — it's now logged via `tracing::warn!` instead of being silently dropped (`index.ts`, the generated aggregator, is excluded from this check).
- Fixed the misleading `"Found N tool files"` log line in the `skill` CLI command to accurately report the number of tools verified against the sidecar.
- #155's proposal for a fully atomic whole-directory export in `mcp-execution-files` was deliberately scoped out: a temp-dir-then-rename approach runs into rename-onto-nonempty-directory issues, and a copy-merge approach is a real semantic change interacting with `ExportOptions::overwrite` and existing non-generated directory content. The sidecar cross-check closes the user-visible symptom for both issues — an interrupted `generate` is now caught on the next `skill` run instead of silently producing wrong output.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (722 passed, 0 failed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] 7 new regression tests added across `mcp-skill`, `mcp-cli`, and `mcp-server`: missing-`.ts`-file error, multi-tool partial drift, extra-file warning path (with `index.ts` exclusion), `StaleMetadata` error message quality, full CLI-level repro of issue #154's reproduction steps, and the `StaleMetadata` → `invalid_params` MCP error mapping.
- [x] CHANGELOG.md updated under `[Unreleased] > Fixed`.

## Known follow-up (non-blocking)

Adversarial review (impl-critic) flagged that this fix only guards the `skill`/`scan_tools_directory` path. A consumer that reads generated `.ts` files directly via `index.ts` (bypassing `skill` entirely) after an interrupted `generate` would still be unguarded, since the sidecar is never consulted on that path. This is outside #154/#155's literal scope; a follow-up issue will be filed to track it.

Closes #154, Closes #155