### PR TITLE
test(mcp-introspector): add end-to-end coverage for env/cwd propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `discoverTimeoutSecs`. Both flags conflict with `--from-config`, since that path already reads
   timeouts from the server's `mcp.json` entry (#144).
 
+### Testing
+
+- **`mcp-execution-introspector`**: added an end-to-end test proving `ServerConfig::env`/
+  `ServerConfig::cwd` actually reach the spawned child process, not merely the config object. The
+  `fixture-slow-mcp-server` test fixture gained an optional fourth CLI arg (a report-file path); at
+  startup, it writes the environment variable value and working directory it observed to that
+  file, closing a coverage gap flagged during review of #146 (#153).
+
 ### Documentation
 
 - **`mcp-execution-core`**: documented the decision to permanently reject a `0` connect/discover

--- a/crates/mcp-introspector/tests/fixtures/slow_mcp_server.rs
+++ b/crates/mcp-introspector/tests/fixtures/slow_mcp_server.rs
@@ -20,12 +20,25 @@
 //! the connect delay), letting tests confirm - via the written pid - that
 //! the process was actually terminated after a timeout, rather than merely
 //! asserting on the returned error.
+//!
+//! An optional fourth CLI arg gives another file path; if present, the
+//! fixture writes a two-line report to it immediately on startup (before the
+//! connect delay): the value of the [`ENV_MARKER_VAR`] environment variable
+//! (empty if unset) on the first line, and the process's current working
+//! directory on the second. This lets `tests/timeout_test.rs` assert
+//! that `ServerConfig::env`/`ServerConfig::cwd` actually reach the spawned
+//! child process, rather than only being covered at the config-object level.
 
 use rmcp::model::{ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo};
 use rmcp::service::RequestContext;
 use rmcp::transport::stdio;
 use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, ServiceExt};
 use std::time::Duration;
+
+/// Name of the environment variable the fixture echoes into the env/cwd
+/// report file (see the fourth CLI arg above). Must match the constant of
+/// the same name used by `tests/timeout_test.rs`.
+const ENV_MARKER_VAR: &str = "MCP_EXECUTION_TEST_ENV_MARKER";
 
 struct SlowServer {
     list_tools_delay: Duration,
@@ -60,6 +73,16 @@ async fn main() {
 
     if let Some(pid_file) = std::env::args().nth(3) {
         std::fs::write(pid_file, std::process::id().to_string()).expect("failed to write pid file");
+    }
+
+    if let Some(report_file) = std::env::args().nth(4) {
+        let observed_env = std::env::var(ENV_MARKER_VAR).unwrap_or_default();
+        let observed_cwd = std::env::current_dir().expect("failed to read current directory");
+        std::fs::write(
+            report_file,
+            format!("{observed_env}\n{}", observed_cwd.display()),
+        )
+        .expect("failed to write env/cwd report file");
     }
 
     // Delay before even starting the handshake, so the client's `serve()`

--- a/crates/mcp-introspector/tests/timeout_test.rs
+++ b/crates/mcp-introspector/tests/timeout_test.rs
@@ -52,8 +52,9 @@ async fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
 }
 
 /// Polls a file until it has non-empty contents or `timeout` elapses, then
-/// returns those contents. Used to read the fixture's self-reported pid,
-/// which it writes at startup before the configured connect delay.
+/// returns those contents. Used to read the fixture's self-reported startup
+/// data (pid, or observed env/cwd), which it writes at startup before the
+/// configured connect delay.
 async fn wait_for_file_contents(path: &Path, timeout: Duration) -> String {
     let deadline = Instant::now() + timeout;
     loop {
@@ -64,7 +65,7 @@ async fn wait_for_file_contents(path: &Path, timeout: Duration) -> String {
         }
         assert!(
             Instant::now() < deadline,
-            "pid file {} was not written within {timeout:?}",
+            "file {} was not written within {timeout:?}",
             path.display()
         );
         tokio::time::sleep(Duration::from_millis(20)).await;
@@ -281,5 +282,58 @@ async fn test_discover_server_success_kills_child_process() {
         wait_for_process_exit(pid, Duration::from_secs(2)).await,
         "expected introspection child process (pid {pid}) to be terminated after \
          a successful discover_server call, but it is still running"
+    );
+}
+
+/// Name of the environment variable the fixture echoes into its env/cwd
+/// report file. Must match the `ENV_MARKER_VAR` constant in
+/// `tests/fixtures/slow_mcp_server.rs`.
+const ENV_MARKER_VAR: &str = "MCP_EXECUTION_TEST_ENV_MARKER";
+
+/// #153 — `ServerConfig::env`/`ServerConfig::cwd` must actually reach the
+/// spawned child process, not merely be stored on the config object. The
+/// fixture's fourth CLI arg is a report-file path it writes, at startup, the
+/// value it observed for [`ENV_MARKER_VAR`] and its own working directory
+/// to - so this test can confirm the child process itself observed the
+/// configured values, rather than only asserting on the `ServerConfig`
+/// struct.
+#[tokio::test]
+async fn test_discover_server_passes_env_and_cwd_to_child_process() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("test-env-cwd");
+
+    let pid_file = tempfile::NamedTempFile::new().expect("create temp pid file");
+    let report_file = tempfile::NamedTempFile::new().expect("create temp report file");
+    let report_path = report_file.path().to_path_buf();
+    let configured_cwd = tempfile::tempdir().expect("create temp cwd");
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .arg("0".to_string()) // no handshake delay
+        .arg("0".to_string()) // no tools/list delay
+        .arg(pid_file.path().display().to_string())
+        .arg(report_path.display().to_string())
+        .env(ENV_MARKER_VAR.to_string(), "issue-153-marker".to_string())
+        .cwd(configured_cwd.path().to_path_buf())
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build();
+
+    let result = introspector.discover_server(server_id, &config).await;
+    assert!(result.is_ok(), "expected success, got {result:?}");
+
+    let report = wait_for_file_contents(&report_path, Duration::from_secs(2)).await;
+    let mut lines = report.lines();
+    let observed_env = lines.next().unwrap_or_default();
+    let observed_cwd = lines.next().unwrap_or_default();
+
+    assert_eq!(
+        observed_env, "issue-153-marker",
+        "child process did not observe the configured env var"
+    );
+    assert_eq!(
+        std::fs::canonicalize(observed_cwd).expect("observed cwd should exist"),
+        std::fs::canonicalize(configured_cwd.path()).expect("configured cwd should exist"),
+        "child process did not run in the configured working directory"
     );
 }


### PR DESCRIPTION
## Summary
- Extends the `slow_mcp_server` integration-test fixture with an optional report-file argument that records the env var value and working directory it observed at startup.
- Adds `test_discover_server_passes_env_and_cwd_to_child_process`, which configures `ServerConfig::env`/`ServerConfig::cwd` and asserts the spawned child actually observed them (closing a previously indirect-only coverage gap).
- No production source changed — test files and CHANGELOG.md only.

Closes #153

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (715 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`