### PR TITLE
fix(codegen): emit tsc-clean generated tool wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mcp-execution-codegen`**: generated tool wrappers now pass `tsc --noEmit`. The `Params`
+  declaration in `tool.ts.hbs` is emitted as a `type` alias instead of an `interface`, since
+  interfaces are never structurally assignable to `callMCPTool`'s `Record<string, unknown>`
+  parameter without an explicit index signature. The wrapper's return statement now casts
+  `callMCPTool`'s `unknown` result to the tool's `Result` type, since `unknown` is never
+  assignable to a concrete type without a cast regardless of declaration kind (#176).
+  Note: this cast satisfies the compiler but does not validate the runtime shape — the
+  `Result` type stays declared as `Record<string, unknown>` even though `callMCPTool` can
+  also return a bare `string` (text content) or an array (JSON-list payloads); widening
+  `Result` to match reality is tracked as a follow-up, out of scope for this fix.
+
 ## [0.8.0] - 2026-07-09
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,7 @@ dependencies = [
  "mcp-execution-introspector",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/mcp-codegen/Cargo.toml
+++ b/crates/mcp-codegen/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "code_generation"

--- a/crates/mcp-codegen/README.md
+++ b/crates/mcp-codegen/README.md
@@ -75,17 +75,17 @@ Each tool file includes full TypeScript interfaces:
 export async function createIssue(
   params: CreateIssueParams
 ): Promise<CreateIssueResult> {
-  return await callMCPTool('github', 'create_issue', params);
+  return (await callMCPTool('github', 'create_issue', params)) as CreateIssueResult;
 }
 
-export interface CreateIssueParams {
+export type CreateIssueParams = {
   /** Repository in format "owner/repo" */
   repo: string;
   /** Issue title */
   title: string;
   /** Issue body (optional) */
   body?: string;
-}
+};
 ```
 
 ## Features

--- a/crates/mcp-codegen/templates/progressive/tool.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/tool.ts.hbs
@@ -39,7 +39,7 @@ import { callMCPTool } from './_runtime/mcp-bridge.ts';
 export async function {{typescript_name}}(
   params: {{typescript_name}}Params
 ): Promise<{{typescript_name}}Result> {
-  return await callMCPTool('{{{server_id_literal}}}', '{{{name_literal}}}', params);
+  return (await callMCPTool('{{{server_id_literal}}}', '{{{name_literal}}}', params)) as {{typescript_name}}Result;
 }
 
 /**
@@ -49,7 +49,8 @@ export async function {{typescript_name}}(
  * {{input_schema.description}}
 {{/if}}
  */
-export interface {{typescript_name}}Params {
+{{!-- type alias, not interface: only aliases get an implicit index signature for Record<string, unknown> --}}
+export type {{typescript_name}}Params = {
 {{#each properties}}
   {{#if description}}
   /**
@@ -62,7 +63,7 @@ export interface {{typescript_name}}Params {
   {{name}}?: {{{typescript_type}}};
 {{/if}}
 {{/each}}
-}
+};
 
 /**
  * Result type for {{typescript_name}} tool.
@@ -70,6 +71,7 @@ export interface {{typescript_name}}Params {
  * The structure of the result depends on the specific tool implementation.
  * Refer to the MCP server documentation for details.
  */
+{{!-- TODO(critic): Result is declared as Record<string, unknown> but callMCPTool returns string for text content and arrays for JSON lists — see #176 discussion --}}
 export interface {{typescript_name}}Result {
   [key: string]: unknown;
 }

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -7,6 +7,7 @@ use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::{ServerId, ToolName};
 use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
 use serde_json::json;
+use std::process::Command;
 
 /// Creates a mock server info for testing.
 fn create_test_server_info() -> ServerInfo {
@@ -155,10 +156,11 @@ fn test_progressive_tool_file_structure() {
         "Missing function export"
     );
 
-    // Should contain parameter interface
+    // Should contain parameter type alias (not an interface — interfaces are not
+    // structurally assignable to Record<string, unknown>, which callMCPTool requires)
     assert!(
-        content.contains("export interface createIssueParams"),
-        "Missing Params interface"
+        content.contains("export type createIssueParams = {"),
+        "Missing Params type alias"
     );
 
     // Should contain result interface
@@ -169,6 +171,13 @@ fn test_progressive_tool_file_structure() {
 
     // Should call callMCPTool
     assert!(content.contains("callMCPTool"), "Missing callMCPTool call");
+
+    // Should cast callMCPTool's `unknown` return to the Result type — `unknown` is never
+    // assignable to a concrete type without a cast, regardless of interface vs type alias
+    assert!(
+        content.contains(") as createIssueResult;"),
+        "Missing cast of callMCPTool's return value to createIssueResult"
+    );
 
     // Should include server_id and tool name
     assert!(
@@ -494,5 +503,115 @@ fn test_progressive_tool_with_complex_types() {
     assert!(
         content.contains("enabled?: boolean"),
         "Missing boolean type"
+    );
+}
+
+/// Regression guard for #176: generated tool wrappers must actually type-check under
+/// `tsc --strict --noEmit`, not merely contain the right substrings. Type-checks the real
+/// generated `createIssue.ts` against a minimal stub of `callMCPTool` (mirroring the
+/// signature declared in `runtime-bridge.ts.hbs`) rather than the full runtime bridge, so
+/// the test stays offline and doesn't depend on `@types/node` being installed.
+///
+/// Skips (does not fail) when `tsc` is not on `PATH`, since the TypeScript toolchain isn't
+/// guaranteed to be present in every environment this suite runs in.
+#[test]
+fn test_generated_tool_passes_tsc_noemit() {
+    if Command::new("tsc").arg("--version").output().is_err() {
+        eprintln!("skipping test_generated_tool_passes_tsc_noemit: `tsc` not found on PATH");
+        return;
+    }
+
+    // Guard against the stub below silently going stale if callMCPTool's signature changes.
+    let bridge_template = include_str!("../templates/progressive/runtime-bridge.ts.hbs");
+    assert!(
+        bridge_template.contains("params: Record<string, unknown>")
+            && bridge_template.contains("): Promise<unknown> {"),
+        "callMCPTool signature in runtime-bridge.ts.hbs changed — update the stub in \
+         test_generated_tool_passes_tsc_noemit to match"
+    );
+
+    let generator = ProgressiveGenerator::new().expect("Failed to create generator");
+    let server_info = create_test_server_info();
+    let code = generator
+        .generate(&server_info)
+        .expect("Failed to generate code");
+
+    let tool_file = code
+        .files
+        .iter()
+        .find(|f| f.path == "createIssue.ts")
+        .expect("createIssue.ts not found");
+    let package_json = code
+        .files
+        .iter()
+        .find(|f| f.path == "package.json")
+        .expect("package.json not found");
+
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    std::fs::write(dir.path().join("createIssue.ts"), &tool_file.content)
+        .expect("Failed to write createIssue.ts");
+    // Real package.json declares `"type": "module"`, which is what makes `import.meta.url`
+    // in the generated CLI-mode block legal under NodeNext module resolution.
+    std::fs::write(dir.path().join("package.json"), &package_json.content)
+        .expect("Failed to write package.json");
+    // Minimal ambient declaration for the subset of the Node `process` global the generated
+    // CLI-mode block references, so the test doesn't depend on `@types/node` being installed.
+    std::fs::write(
+        dir.path().join("globals.d.ts"),
+        "declare const process: {\n\
+         \x20\x20argv: string[];\n\
+         \x20\x20exit(code?: number): never;\n\
+         };\n",
+    )
+    .expect("Failed to write globals.d.ts");
+
+    let runtime_dir = dir.path().join("_runtime");
+    std::fs::create_dir_all(&runtime_dir).expect("Failed to create _runtime dir");
+    std::fs::write(
+        runtime_dir.join("mcp-bridge.ts"),
+        "export async function callMCPTool(\n\
+         \x20\x20serverId: string,\n\
+         \x20\x20toolName: string,\n\
+         \x20\x20params: Record<string, unknown>\n\
+         ): Promise<unknown> {\n\
+         \x20\x20void serverId;\n\
+         \x20\x20void toolName;\n\
+         \x20\x20void params;\n\
+         \x20\x20return undefined;\n\
+         }\n",
+    )
+    .expect("Failed to write mcp-bridge.ts stub");
+
+    std::fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}
+"#,
+    )
+    .expect("Failed to write tsconfig.json");
+
+    let output = Command::new("tsc")
+        .arg("--noEmit")
+        .arg("-p")
+        .arg(dir.path().join("tsconfig.json"))
+        .output()
+        .expect("Failed to run tsc");
+
+    assert!(
+        output.status.success(),
+        "tsc --noEmit failed on generated createIssue.ts:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
 }


### PR DESCRIPTION
## Summary
- Generated `Params` types are now emitted as `type` aliases instead of `interface`; interfaces are never structurally assignable to `callMCPTool`'s `Record<string, unknown>` parameter without an explicit index signature.
- The generated wrapper's return statement now casts `callMCPTool`'s `unknown` result to the tool's `Result` type, since `unknown` is never assignable to a concrete type without a cast.
- Added a `tsc --strict --noEmit` regression test against real generated output (skips gracefully if `tsc` is unavailable), plus assertions guarding both the `Params` and cast changes, so this error class (semantically invalid but syntactically valid TS, invisible to `node --check`) cannot silently regress.
- Updated `README.md` example output and `CHANGELOG.md` to match, including an explicit note that the cast satisfies the compiler but does not validate the runtime shape (`Result` can also be a bare `string` or array in practice — tracked as a follow-up).

Fixes #176.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (753/753)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New `test_generated_tool_passes_tsc_noemit` verified as a real regression guard (fails against the pre-fix template with the original TS2345/TS2322 errors, passes against the fix)