### PR TITLE
fix(introspector,core,cli): implement working http/sse transport for introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into `PathBuf::join`, and — for a URL with `user:token@host` userinfo — leaked the credential
   into a directory name and generated `tool.ts` source. `build_server_config` now derives the
   id from a sanitized slug (host + path only, via the `url` crate; userinfo is structurally
-  excluded) instead.
+  excluded) instead. On a URL that fails to parse entirely (e.g. a mistyped port such as
+  `https://user:pass@host:99999/x`), the raw input is discarded rather than sanitized-and-reused,
+  since the earlier version's fallback still leaked credential-shaped substrings into the id
+  logged before validation gets a chance to reject the URL.
 
 - **`mcp-execution-core`**: `validate_network_config` (Http/Sse validation) hardening —
   header names differing only by case (e.g. `Authorization` vs `authorization`) are now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-core`**, **`mcp-execution-introspector`**: `--http`/`--sse` transports
+  actually connect now, instead of failing validation with a misleading "command cannot be
+  empty" `SecurityViolation` before the transport type was ever consulted (#180).
+  `validate_server_config` now dispatches on `TransportType`: stdio configs keep today's
+  command/args/env checks, while Http/Sse configs are validated for a present `url` (checked
+  here rather than assumed enforced by the builder, since a hand-edited `mcp.json` can bypass
+  it via serde defaults), an `http://`/`https://` scheme, and control-character-free header
+  names/values — header *values* are never included in error messages, since they routinely
+  carry bearer tokens. `Introspector::discover_server` now branches on transport and connects
+  Http/Sse configs via rmcp's `StreamableHttpClientTransport`; `TransportType::Sse` is routed
+  through the same client as `TransportType::Http`, since rmcp 2.2 has no separate legacy SSE
+  client (the MCP spec unified HTTP+SSE into "Streamable HTTP" in 2025-03-26). Also fixes the
+  server-name fallback (used when a server sends no handshake `peer_info`) falling back to
+  `config.url()` instead of the always-empty `config.command` for Http/Sse configs.
+
+- **`mcp-execution-cli`**: `generate --http`/`--sse` no longer derives the server id from the
+  raw URL. Once Http/Sse configs can actually reach `generate` (see above), a raw-URL id broke
+  `mcp_execution_skill::validate_server_id`'s lowercase/digit/hyphen requirement (making the
+  generated directory unusable by `cli skill`/`mcp-server`), could carry a `..` path segment
+  into `PathBuf::join`, and — for a URL with `user:token@host` userinfo — leaked the credential
+  into a directory name and generated `tool.ts` source. `build_server_config` now derives the
+  id from a sanitized slug (host + path only, via the `url` crate; userinfo is structurally
+  excluded) instead.
+
+- **`mcp-execution-core`**: `validate_network_config` (Http/Sse validation) hardening —
+  header names differing only by case (e.g. `Authorization` vs `authorization`) are now
+  rejected as duplicates instead of silently collapsing into one nondeterministic entry once
+  converted to `http::HeaderName`; the `http://`/`https://` scheme check is now case-insensitive
+  per RFC 3986; and header names are now validated against the RFC 7230 `token` charset instead
+  of only rejecting control characters, so a space/`:`/`@` in a header name is caught here with
+  a clear message instead of failing later inside `http::HeaderName` construction with an
+  opaque error.
+
+### Added
+
+- **`mcp-execution-introspector`**: new `test-fixtures`-gated dependency on
+  `rmcp/transport-streamable-http-server` and dev-dependencies on `axum` and `tokio-util`,
+  backing an in-process Streamable HTTP test server used to exercise the new HTTP/SSE
+  discovery path end-to-end (tool listing, handshake metadata, header propagation, and
+  connect/discover timeouts).
+
+- **`mcp-execution-cli`**: new dependency on `url` (already resolved transitively via
+  `rmcp`→`reqwest`, so no new crate enters the dependency tree), used to parse Http/Sse URLs
+  into a safe server-id slug.
+
 - **`mcp-execution-codegen`**: generated tool wrappers now pass `tsc --noEmit`. The `Params`
   declaration in `tool.ts.hbs` is emitted as a `type` alias instead of an `interface`, since
   interfaces are never structurally assignable to `callMCPTool`'s `Record<string, unknown>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,10 +118,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -175,6 +256,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -183,6 +266,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -286,6 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,7 +395,17 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -309,7 +417,17 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -504,7 +622,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -540,8 +658,25 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -574,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -594,6 +729,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -690,8 +840,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -701,9 +853,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -752,6 +906,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,10 +1034,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -790,6 +1151,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -811,6 +1178,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -851,6 +1277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1311,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-execution-cli"
@@ -898,6 +1342,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "which",
 ]
 
@@ -948,13 +1393,16 @@ dependencies = [
 name = "mcp-execution-introspector"
 version = "0.8.0"
 dependencies = [
+ "axum",
  "criterion",
+ "http",
  "mcp-execution-core",
  "rmcp",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1007,6 +1455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +1483,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1038,7 +1492,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1093,6 +1547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1596,12 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1186,6 +1652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,12 +1686,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1253,6 +1791,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rayon"
@@ -1344,6 +1891,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rmcp"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,19 +1952,28 @@ checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand",
+ "reqwest",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1392,6 +2002,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,7 +2026,82 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1411,12 +2111,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1451,6 +2166,35 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1508,12 +2252,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1548,6 +2315,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,10 +2343,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1588,6 +2406,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,7 +2435,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1636,6 +2474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +2492,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1656,8 +2519,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1669,6 +2533,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1735,11 +2609,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1809,6 +2730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +2752,30 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1862,6 +2813,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +2838,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1913,6 +2883,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2903,25 @@ checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1953,7 +2955,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2023,6 +3025,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2031,10 +3042,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -2057,10 +3161,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ homepage = "https://github.com/bug-ops/mcp-execution"
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+axum = "0.8"
 chrono = "0.4"
 clap = "4.6"
 clap_complete = "4.6"
@@ -24,6 +25,7 @@ dhat = "0.3"
 dialoguer = "0.12"
 dirs = "6.0"
 handlebars = "6.4"
+http = "1"
 mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.8.0" }
 mcp-execution-core = { path = "crates/mcp-core", version = "0.8.0" }
 mcp-execution-files = { path = "crates/mcp-files", version = "0.8.0" }
@@ -40,9 +42,11 @@ static_assertions = "1.1"
 tempfile = "3.27"
 thiserror = "2.0"
 tokio = "1.52"
+tokio-util = "0.7"
 toml = "1.1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+url = "2"
 uuid = "1.23"
 which = "8.0"
 

--- a/crates/mcp-cli/Cargo.toml
+++ b/crates/mcp-cli/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "sync
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+url = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -9,6 +9,10 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use url::Url;
+
+/// Fallback slug used when a URL sanitizes down to nothing (e.g. no host).
+const FALLBACK_SERVER_ID_SLUG: &str = "http-server";
 
 /// MCP configuration file structure (`~/.claude/mcp.json`).
 ///
@@ -306,7 +310,7 @@ pub fn build_server_config(
     // Build config based on transport type
     let (server_id, mut builder) = if let Some(url) = http {
         // HTTP transport
-        let id = ServerId::new(&url);
+        let id = derive_server_id_from_url(&url);
         let mut builder = ServerConfig::builder().http_transport(url);
 
         for header in headers {
@@ -317,7 +321,7 @@ pub fn build_server_config(
         (id, builder)
     } else if let Some(url) = sse {
         // SSE transport
-        let id = ServerId::new(&url);
+        let id = derive_server_id_from_url(&url);
         let mut builder = ServerConfig::builder().sse_transport(url);
 
         for header in headers {
@@ -357,6 +361,64 @@ pub fn build_server_config(
     }
 
     Ok((server_id, builder.build()))
+}
+
+/// Derives a filesystem- and `validate_server_id`-safe [`ServerId`] slug from
+/// an Http/Sse transport URL.
+///
+/// Using the raw URL as the id (the previous behavior) is unsafe once Http/Sse
+/// configs can actually reach `generate`: the id flows into a directory name
+/// under `~/.claude/servers/{id}/` and into generated `tool.ts` literals, so a
+/// raw URL there breaks `mcp_execution_skill::validate_server_id`'s
+/// lowercase/digit/hyphen requirement, can smuggle `..` path segments through
+/// `PathBuf::join`, and — if the URL carries `user:token@host` userinfo —
+/// leaks the credential into a directory name and generated source.
+///
+/// Only `host` and `path` are used (never `userinfo`, so credentials are
+/// structurally excluded). The result is lowercased, every run of characters
+/// outside `[a-z0-9-]` collapses to a single `-`, and leading/trailing `-` are
+/// trimmed. Falls back to [`FALLBACK_SERVER_ID_SLUG`] if the URL fails to
+/// parse or the result would otherwise be empty (e.g. a bare `https://` URL
+/// with no host). The slug is truncated to fit `validate_server_id`'s length
+/// limit.
+fn derive_server_id_from_url(url: &str) -> ServerId {
+    // Mirrors the private `mcp_execution_skill::types::MAX_SERVER_ID_LENGTH`;
+    // duplicated here since that constant isn't exported, and enforced by
+    // this module's tests calling `mcp_execution_skill::validate_server_id`
+    // on the derived slug.
+    const MAX_SERVER_ID_LENGTH: usize = 64;
+
+    // On parse failure, fall through to the empty-slug case below rather than
+    // sanitizing the raw string: a URL that failed to parse is about to be
+    // rejected by `validate_url_scheme`/the connection attempt anyway, and
+    // preserving any part of it here would defeat the credential-exclusion
+    // guarantee above for inputs like `https://user:pass@evil.com:99999/x`
+    // (a mistyped port is a realistic `Url::parse` failure, not just an
+    // adversarial one).
+    let host_and_path = Url::parse(url)
+        .ok()
+        .map(|parsed| format!("{}{}", parsed.host_str().unwrap_or_default(), parsed.path()))
+        .unwrap_or_default();
+
+    let mut slug = String::with_capacity(host_and_path.len());
+    for ch in host_and_path.chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_lowercase() || lower.is_ascii_digit() {
+            slug.push(lower);
+        } else if slug.chars().next_back().is_some_and(|last| last != '-') {
+            slug.push('-');
+        }
+    }
+
+    let slug = slug.trim_matches('-');
+    let slug = &slug[..slug.len().min(MAX_SERVER_ID_LENGTH)];
+    let slug = slug.trim_end_matches('-');
+
+    ServerId::new(if slug.is_empty() {
+        FALLBACK_SERVER_ID_SLUG
+    } else {
+        slug
+    })
 }
 
 #[cfg(test)]
@@ -504,7 +566,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(id.as_str(), "https://api.githubcopilot.com/mcp/");
+        assert_eq!(id.as_str(), "api-githubcopilot-com-mcp");
         assert_eq!(config.url(), Some("https://api.githubcopilot.com/mcp/"));
         assert_eq!(
             config.headers().get("Authorization"),
@@ -527,7 +589,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(id.as_str(), "https://example.com/sse");
+        assert_eq!(id.as_str(), "example-com-sse");
         assert_eq!(config.url(), Some("https://example.com/sse"));
         assert_eq!(
             config.headers().get("X-API-Key"),
@@ -751,7 +813,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(id.as_str(), "https://sse.example.com/events");
+        assert_eq!(id.as_str(), "sse-example-com-events");
         assert_eq!(config.url(), Some("https://sse.example.com/events"));
         assert_eq!(
             config.headers().get("Authorization"),
@@ -1042,5 +1104,159 @@ mod tests {
             config.mcp_servers.is_empty(),
             "missing mcpServers key must produce empty map, not error"
         );
+    }
+
+    // ── derive_server_id_from_url (review S1: raw-URL server ids are unsafe) ──
+
+    #[test]
+    fn test_derive_server_id_from_url_basic() {
+        assert_eq!(
+            derive_server_id_from_url("https://api.githubcopilot.com/mcp/").as_str(),
+            "api-githubcopilot-com-mcp"
+        );
+        assert_eq!(
+            derive_server_id_from_url("https://example.com/sse").as_str(),
+            "example-com-sse"
+        );
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_strips_credentials() {
+        // Userinfo (credentials) must never end up in the derived id: it flows
+        // into a directory name and generated tool.ts source.
+        let id = derive_server_id_from_url("https://user:sekrit-token@api.example.com/mcp");
+        assert!(!id.as_str().contains("sekrit"));
+        assert!(!id.as_str().contains("user"));
+        assert_eq!(id.as_str(), "api-example-com-mcp");
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_rejects_path_traversal_chars() {
+        // `..` segments must not survive into the id (which is later joined
+        // into a filesystem path via PathBuf::join).
+        let id = derive_server_id_from_url("https://api.example.com/../../etc/passwd");
+        assert!(!id.as_str().contains(".."));
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_join_never_escapes_base_dir() {
+        // Literal reproduction of how `generate.rs` uses the id: joined onto
+        // a base directory. Since the sanitized slug can only ever contain
+        // `[a-z0-9-]`, `PathBuf::join` can never interpret a component of it
+        // as `..` or an absolute-path override, regardless of what path
+        // segments were present in the original URL.
+        let base_dir = PathBuf::from("/home/user/.claude/servers");
+        let malicious_urls = [
+            "https://api.example.com/../../../../etc/passwd",
+            "https://api.example.com/..%2f..%2fescape",
+            "https://api.example.com/./././escape",
+        ];
+
+        for url in malicious_urls {
+            let id = derive_server_id_from_url(url);
+            let joined = base_dir.join(id.as_str());
+            assert!(
+                joined.starts_with(&base_dir),
+                "joining derived id {:?} (from {url:?}) onto {base_dir:?} escaped it: {joined:?}",
+                id.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_normalizes_case() {
+        assert_eq!(
+            derive_server_id_from_url("https://API.Example.COM/MCP").as_str(),
+            "api-example-com-mcp"
+        );
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_truncates_to_length_limit() {
+        let long_path = "a".repeat(200);
+        let id = derive_server_id_from_url(&format!("https://example.com/{long_path}"));
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_falls_back_when_empty() {
+        // `Url::parse` accepts "..." as a (degenerate but valid) host, so
+        // this genuinely exercises the "parsed OK, but sanitizes to nothing"
+        // path, not the parse-failure path covered by the test below.
+        let id = derive_server_id_from_url("https://...");
+        assert_eq!(id.as_str(), FALLBACK_SERVER_ID_SLUG);
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_falls_back_on_unparseable_url() {
+        // On a `Url::parse` failure the raw input is discarded entirely
+        // (never sanitized-and-reused) — every unparseable URL maps to the
+        // same fixed fallback slug, regardless of its content.
+        for unparseable in ["not a url at all", "", "://", "!!!"] {
+            let id = derive_server_id_from_url(unparseable);
+            assert_eq!(
+                id.as_str(),
+                FALLBACK_SERVER_ID_SLUG,
+                "input {unparseable:?} should fall back to the default slug"
+            );
+        }
+    }
+
+    /// Regression test for the credential leak the second review round found:
+    /// a URL with a mistyped port (a realistic user typo, not an attack) is a
+    /// `Url::parse` failure. Before the fix, the fallback sanitized the raw
+    /// string instead of discarding it, so `user`/`pass` survived into the id
+    /// — which is logged via `info!("Introspecting server: {}", ..)` before
+    /// `validate_server_config` ever gets a chance to reject the URL.
+    #[test]
+    fn test_derive_server_id_from_url_unparseable_credential_bearing_url_leaks_nothing() {
+        let id = derive_server_id_from_url("https://user:pass@evil.com:99999/x");
+        assert_eq!(id.as_str(), FALLBACK_SERVER_ID_SLUG);
+        assert!(!id.as_str().contains("user"));
+        assert!(!id.as_str().contains("pass"));
+        assert!(!id.as_str().contains("evil"));
+    }
+
+    #[test]
+    fn test_derive_server_id_from_url_always_passes_validate_server_id() {
+        let urls = [
+            "https://api.githubcopilot.com/mcp/",
+            "https://example.com/sse",
+            "https://user:token@host.example.com/mcp?query=1#frag",
+            "https://HOST.EXAMPLE.COM/Path/With/Mixed_Case",
+            "https://127.0.0.1:8443/mcp",
+            "https://example.com/../../escape",
+            "https://",
+            "not-a-url",
+        ];
+        for url in urls {
+            let id = derive_server_id_from_url(url);
+            assert!(
+                mcp_execution_skill::validate_server_id(id.as_str()).is_ok(),
+                "derived id {:?} from url {url:?} must satisfy validate_server_id",
+                id.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_server_config_http_id_passes_validate_server_id() {
+        let (id, _config) = build_server_config(
+            None,
+            vec![],
+            vec![],
+            None,
+            Some("https://user:token@api.example.com/mcp/../secret".to_string()),
+            None,
+            vec![],
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+        assert!(!id.as_str().contains("token"));
     }
 }

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -711,9 +711,11 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Port 99999 exceeds `u16::MAX`, so this always fails at the transport
+    /// layer (`InvalidPort`) rather than actually reaching a network peer —
+    /// deterministic without a live server.
     #[tokio::test]
     async fn test_run_http_transport() {
-        // Test HTTP transport with invalid URL
         let result = run(
             None,
             None,
@@ -731,13 +733,30 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("failed to connect to server"));
+        let err = result.unwrap_err();
+        let chain_msg = err
+            .chain()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" | ");
+
+        // Regression guard for #180: before the fix, every Http/Sse config
+        // failed validation with this misleading message before the
+        // transport was ever consulted. Asserting its absence (not just that
+        // *some* error occurred) is what gives this test signal.
+        assert!(
+            !chain_msg.contains("command cannot be empty"),
+            "must not regress to the pre-#180 empty-command validation error: {chain_msg}"
+        );
+        assert!(
+            chain_msg.contains("MCP server connection failed"),
+            "expected a real connection-layer failure, got: {chain_msg}"
+        );
     }
 
+    /// See `test_run_http_transport` — same deterministic-failure rationale.
     #[tokio::test]
     async fn test_run_sse_transport() {
-        // Test SSE transport with invalid URL
         let result = run(
             None,
             None,
@@ -755,8 +774,21 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("failed to connect to server"));
+        let err = result.unwrap_err();
+        let chain_msg = err
+            .chain()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" | ");
+
+        assert!(
+            !chain_msg.contains("command cannot be empty"),
+            "must not regress to the pre-#180 empty-command validation error: {chain_msg}"
+        );
+        assert!(
+            chain_msg.contains("MCP server connection failed"),
+            "expected a real connection-layer failure, got: {chain_msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -31,7 +31,7 @@
 //! assert!(validate_server_config(&config).is_err());
 //! ```
 
-use crate::{Error, Result, ServerConfig};
+use crate::{Error, Result, ServerConfig, TransportType};
 use std::path::Path;
 use std::time::Duration;
 
@@ -53,15 +53,16 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
 /// slow-starting servers configured via `mcp.json`.
 const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 
-/// Validates a `ServerConfig` for safe subprocess execution.
+/// Validates a `ServerConfig` for safe execution, dispatching on transport type.
 ///
-/// This function performs comprehensive security validation to prevent
-/// command injection attacks. It validates:
+/// This function performs comprehensive security validation before a config is
+/// used to connect to a server. It validates:
 ///
-/// 1. **Command**: Can be absolute path (with existence/permission checks) or binary name
-/// 2. **Arguments**: Each arg checked for shell metacharacters
-/// 3. **Environment**: Variables checked for dangerous names
-/// 4. **Timeouts**: `connect_timeout`/`discover_timeout` checked against bounds
+/// 1. **Stdio transport**: command (absolute path or binary name), arguments, and
+///    environment variables.
+/// 2. **Http/Sse transport**: URL presence and scheme, and HTTP header names/values.
+/// 3. **Timeouts**: `connect_timeout`/`discover_timeout` checked against bounds,
+///    for all transports.
 ///
 /// # Security Rules
 ///
@@ -69,6 +70,8 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 /// - **Forbidden env names**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*`, `PATH`
 /// - **Absolute paths**: Must exist and be executable
 /// - **Binary names**: Allowed (resolved via PATH at runtime)
+/// - **URL scheme**: Must be `http://` or `https://`
+/// - **Header names/values**: Must not contain control characters
 /// - **Timeout bounds**: `connect_timeout`/`discover_timeout` must be greater than zero and at
 ///   most `MAX_TIMEOUT` (600s)
 ///
@@ -79,8 +82,10 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 /// - Command/args contain shell metacharacters
 /// - Absolute path does not exist or is not executable
 /// - Environment variable name is forbidden
+/// - URL scheme is not `http://`/`https://`, or a header name/value contains control characters
 ///
 /// Returns `Error::ValidationError` if:
+/// - URL is missing for Http/Sse transport
 /// - `connect_timeout` or `discover_timeout` is zero
 /// - `connect_timeout` or `discover_timeout` exceeds `MAX_TIMEOUT` (600s)
 ///
@@ -101,6 +106,12 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 ///     .env("LD_PRELOAD".to_string(), "/evil.so".to_string())
 ///     .build();
 /// assert!(validate_server_config(&config).is_err());
+///
+/// // Valid: HTTP transport
+/// let config = ServerConfig::builder()
+///     .http_transport("https://api.example.com/mcp".to_string())
+///     .build();
+/// assert!(validate_server_config(&config).is_ok());
 /// ```
 ///
 /// # Security Considerations
@@ -109,10 +120,33 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 /// - Absolute paths undergo strict validation (existence, permissions)
 /// - All arguments are validated separately to prevent injection
 /// - Environment variables are checked against forbidden names
+/// - Header values are never echoed into error messages, since they routinely
+///   carry secrets such as bearer tokens
 /// - There is no infinite-timeout option: `0` is always rejected, since an
 ///   unbounded wait would let a hung server block this non-interactive tool
 ///   forever (see the `validate_timeout` design note in this module)
 pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
+    match config.transport() {
+        TransportType::Stdio => validate_stdio_config(config)?,
+        TransportType::Http | TransportType::Sse => validate_network_config(config)?,
+    }
+
+    // Validate timeout bounds. Zero fires immediately and breaks all
+    // discovery; an infinite timeout is deliberately unsupported (see
+    // `validate_timeout` doc comment) because it would let a hung or
+    // malicious server block this non-interactive CLI tool forever,
+    // re-opening the DoS window these timeouts were introduced to close.
+    validate_timeout(config.connect_timeout(), "connect_timeout")?;
+    validate_timeout(config.discover_timeout(), "discover_timeout")?;
+
+    Ok(())
+}
+
+/// Validates the stdio-transport-specific fields of a `ServerConfig`.
+///
+/// Checks the command (absolute path or binary name), arguments, and
+/// environment variables for command-injection risks.
+fn validate_stdio_config(config: &ServerConfig) -> Result<()> {
     // Validate command
     validate_command_string(&config.command, "command")?;
 
@@ -133,14 +167,127 @@ pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
         validate_env_name(env_name)?;
     }
 
-    // Validate timeout bounds. Zero fires immediately and breaks all
-    // discovery; an infinite timeout is deliberately unsupported (see
-    // `validate_timeout` doc comment) because it would let a hung or
-    // malicious server block this non-interactive CLI tool forever,
-    // re-opening the DoS window these timeouts were introduced to close.
-    validate_timeout(config.connect_timeout(), "connect_timeout")?;
-    validate_timeout(config.discover_timeout(), "discover_timeout")?;
+    Ok(())
+}
 
+/// Validates the Http/Sse-transport-specific fields of a `ServerConfig`.
+///
+/// `url` is `Option` at the type level and `#[serde(default)]`, so a
+/// hand-edited `mcp.json` with `"transport": "http"` and no `url` key
+/// deserializes successfully, bypassing `ServerConfigBuilder::try_build`'s
+/// "url required" check. This function is the actual enforcement point.
+fn validate_network_config(config: &ServerConfig) -> Result<()> {
+    let url = config.url().ok_or_else(|| Error::ValidationError {
+        field: "url".to_string(),
+        reason: "url is required for http/sse transport".to_string(),
+    })?;
+
+    validate_url_scheme(url)?;
+
+    // `http::HeaderName` lowercases on parse, so two headers that differ only
+    // in case (e.g. "Authorization" and "authorization") collapse into a
+    // single entry with a nondeterministic winner once converted — reject
+    // that here rather than letting it silently drop a header downstream.
+    let mut seen_header_names = std::collections::HashSet::new();
+    for (name, value) in config.headers() {
+        validate_header_name_string(name)?;
+        validate_header_value_string(name, value)?;
+        if !seen_header_names.insert(name.to_ascii_lowercase()) {
+            return Err(Error::SecurityViolation {
+                reason: format!("duplicate header name (case-insensitive): '{name}'"),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates that a URL uses the `http://` or `https://` scheme.
+///
+/// This is defense in depth: rejects `file://`, `unix://`, and similar
+/// schemes at the `mcp-core` validation boundary rather than relying on the
+/// HTTP client to reject them. The scheme comparison is case-insensitive per
+/// RFC 3986 (`HTTP://host` is a valid URL, not a different scheme).
+fn validate_url_scheme(url: &str) -> Result<()> {
+    let is_valid = url.split_once("://").is_some_and(|(scheme, _)| {
+        scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+    });
+    if is_valid {
+        Ok(())
+    } else {
+        Err(Error::SecurityViolation {
+            reason: "url must use the http:// or https:// scheme".to_string(),
+        })
+    }
+}
+
+/// Returns `true` if `value` contains an ASCII or Unicode control character
+/// (including `\r`, `\n`, and NUL), which could otherwise be used to smuggle
+/// extra header lines into an HTTP request.
+fn contains_control_char(value: &str) -> bool {
+    value.chars().any(char::is_control)
+}
+
+/// Returns `true` if `c` is a valid RFC 7230 `tchar` (the charset allowed in
+/// an HTTP header field name).
+const fn is_header_name_tchar(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(
+            c,
+            '!' | '#'
+                | '$'
+                | '%'
+                | '&'
+                | '\''
+                | '*'
+                | '+'
+                | '-'
+                | '.'
+                | '^'
+                | '_'
+                | '`'
+                | '|'
+                | '~'
+        )
+}
+
+/// Validates an HTTP header name against the RFC 7230 `token` charset.
+///
+/// A plain control-character check is not tight enough: a space, `:`, or `@`
+/// is not a control character but is still an invalid header-name character
+/// that would otherwise pass here and fail later inside `http::HeaderName`
+/// construction with an opaque error that omits the offending name. The
+/// header name itself is not a secret, so it is safe to include in the error
+/// message.
+fn validate_header_name_string(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(Error::SecurityViolation {
+            reason: "header name cannot be empty".to_string(),
+        });
+    }
+    if !name.chars().all(is_header_name_tchar) {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "header name '{name}' contains characters outside the allowed HTTP token charset"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Validates an HTTP header value for control characters.
+///
+/// # Security
+///
+/// The header *value* routinely carries secrets (e.g. bearer tokens), so it
+/// must never appear in the returned error's reason string — only the header
+/// *name* is included.
+fn validate_header_value_string(name: &str, value: &str) -> Result<()> {
+    if contains_control_char(value) {
+        return Err(Error::SecurityViolation {
+            reason: format!("value for header '{name}' contains control characters"),
+        });
+    }
     Ok(())
 }
 
@@ -636,5 +783,208 @@ mod tests {
         assert!(validate_env_name("LD_DEBUG").is_ok()); // Not in list
         assert!(validate_env_name("MY_PATH").is_ok()); // Not exact match
         assert!(validate_env_name("DYLD").is_ok()); // No underscore, not prefix match
+    }
+
+    // ── Http/Sse transport validation ────────────────────────────────────────
+
+    #[test]
+    fn test_validate_server_config_http_valid() {
+        let config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+        assert!(validate_server_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_sse_valid() {
+        let config = ServerConfig::builder()
+            .sse_transport("https://api.example.com/sse".to_string())
+            .build();
+        assert!(validate_server_config(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_http_with_valid_headers() {
+        let config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("Authorization".to_string(), "Bearer token123".to_string())
+            .build();
+        assert!(validate_server_config(&config).is_ok());
+    }
+
+    /// Constructs an Http-transport config missing `url` via deserialization
+    /// rather than the builder, since `try_build()` already refuses this and
+    /// would mask the bug this test guards against: a hand-edited `mcp.json`
+    /// with `"transport": "http"` and no `url` key deserializes fine because
+    /// every field is `#[serde(default)]`.
+    fn deserialize_http_config_missing_url() -> ServerConfig {
+        serde_json::from_str(r#"{"transport": "http"}"#).expect("valid ServerConfig JSON")
+    }
+
+    #[test]
+    fn test_validate_server_config_http_missing_url_rejected() {
+        let config = deserialize_http_config_missing_url();
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::ValidationError { field, reason }) = result {
+            assert_eq!(field, "url");
+            assert!(reason.contains("required"));
+        } else {
+            panic!("expected ValidationError for missing url");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_sse_missing_url_rejected() {
+        let config: ServerConfig =
+            serde_json::from_str(r#"{"transport": "sse"}"#).expect("valid ServerConfig JSON");
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::ValidationError { field, .. }) = result {
+            assert_eq!(field, "url");
+        } else {
+            panic!("expected ValidationError for missing url");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_non_http_scheme() {
+        for url in [
+            "file:///etc/passwd",
+            "unix:///tmp/socket",
+            "ftp://host/path",
+        ] {
+            let config = ServerConfig::builder()
+                .http_transport(url.to_string())
+                .build();
+            let result = validate_server_config(&config);
+            assert!(result.is_err(), "should reject scheme: {url}");
+            if let Err(Error::SecurityViolation { reason }) = result {
+                assert!(reason.contains("http://") || reason.contains("https://"));
+            } else {
+                panic!("expected SecurityViolation for url: {url}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_accepts_case_insensitive_scheme() {
+        for url in ["HTTP://api.example.com/mcp", "HTTPS://api.example.com/mcp"] {
+            let config = ServerConfig::builder()
+                .http_transport(url.to_string())
+                .build();
+            assert!(
+                validate_server_config(&config).is_ok(),
+                "should accept case-insensitive scheme: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_scheme_lookalike() {
+        // "httpsomething" must not be accepted as a loose prefix match of "http".
+        let config = ServerConfig::builder()
+            .http_transport("httpsomething://api.example.com/mcp".to_string())
+            .build();
+        assert!(validate_server_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_duplicate_header_case_insensitive() {
+        let mut config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+        config
+            .headers
+            .insert("Authorization".to_string(), "Bearer one".to_string());
+        config
+            .headers
+            .insert("authorization".to_string(), "Bearer two".to_string());
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("duplicate header"));
+        } else {
+            panic!("expected SecurityViolation for duplicate header name");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_header_name_with_invalid_tchar() {
+        // Space, ':', and '@' are not control characters but are still
+        // invalid HTTP header-name characters (outside RFC 7230's `token`).
+        for bad_name in ["X Bad Header", "X:Bad", "X@Bad"] {
+            let mut config = ServerConfig::builder()
+                .http_transport("https://api.example.com/mcp".to_string())
+                .build();
+            config
+                .headers
+                .insert(bad_name.to_string(), "value".to_string());
+
+            let result = validate_server_config(&config);
+            assert!(result.is_err(), "should reject header name: {bad_name}");
+            if let Err(Error::SecurityViolation { reason }) = result {
+                assert!(reason.contains("header name"));
+            } else {
+                panic!("expected SecurityViolation for header name: {bad_name}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_control_char_in_header_name() {
+        let mut config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+        config
+            .headers
+            .insert("X-Bad\r\nHeader".to_string(), "value".to_string());
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("header name"));
+        } else {
+            panic!("expected SecurityViolation for header name");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_control_char_in_header_value() {
+        let config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header(
+                "Authorization".to_string(),
+                "Bearer sekrit\r\nX-Injected: evil".to_string(),
+            )
+            .build();
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("Authorization"));
+            // The header VALUE must never appear in the error message.
+            assert!(!reason.contains("sekrit"));
+            assert!(!reason.contains("X-Injected"));
+        } else {
+            panic!("expected SecurityViolation for header value");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_timeout_bounds_still_enforced() {
+        let config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .connect_timeout(std::time::Duration::ZERO)
+            .build();
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::ValidationError { field, .. }) = result {
+            assert_eq!(field, "connect_timeout");
+        } else {
+            panic!("expected ValidationError for connect_timeout");
+        }
     }
 }

--- a/crates/mcp-core/src/server_config.rs
+++ b/crates/mcp-core/src/server_config.rs
@@ -176,6 +176,11 @@ pub struct ServerConfig {
     /// **Only used for HTTP transport.**
     ///
     /// Example: `https://api.example.com/mcp`
+    ///
+    /// This crate does not apply SSRF allowlisting to this URL — it is
+    /// treated like a `curl` target, appropriate for a local CLI tool.
+    /// Embedders that expose this config in a multi-tenant or server context
+    /// should apply their own URL allowlisting before connecting.
     #[serde(default)]
     pub url: Option<String>,
 

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -25,19 +25,34 @@ doc = false
 required-features = ["test-fixtures"]
 
 [features]
-# Enables the server-side rmcp features needed by the slow-server test fixture,
-# without pulling them into the default build of this (client-only) crate.
-test-fixtures = ["rmcp/server", "rmcp/transport-io"]
+# Enables the server-side rmcp features needed by the slow-server (stdio) and
+# HTTP fixture servers used in tests, without pulling them into the default
+# build of this (client-only) crate.
+test-fixtures = [
+    "rmcp/server",
+    "rmcp/transport-io",
+    "rmcp/transport-streamable-http-server",
+]
 
 [dependencies]
+http.workspace = true
 mcp-execution-core.workspace = true
-rmcp = { workspace = true, features = ["client"] }
+rmcp = { workspace = true, features = [
+    "client",
+    # Selects reqwest's rustls TLS backend for https:// URLs; the
+    # `transport-streamable-http-client-reqwest` feature alone only pulls in
+    # the `reqwest` dependency without a TLS backend.
+    "reqwest",
+    "transport-streamable-http-client-reqwest",
+] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]
+axum.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 tempfile.workspace = true
-tokio = { workspace = true, features = ["test-util", "macros"] }
+tokio = { workspace = true, features = ["test-util", "macros", "net"] }
+tokio-util.workspace = true

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -6,9 +6,11 @@
 //!
 //! # Architecture
 //!
-//! The introspector connects to MCP servers via stdio transport and uses rmcp's
-//! `ServiceExt` trait to query server capabilities. Discovered information is
-//! stored locally for subsequent code generation phases.
+//! The introspector connects to MCP servers via stdio (subprocess) or
+//! Streamable HTTP transport (used for both `TransportType::Http` and
+//! `TransportType::Sse`) and uses rmcp's `ServiceExt` trait to query server
+//! capabilities. Discovered information is stored locally for subsequent
+//! code generation phases.
 //!
 //! # Examples
 //!
@@ -42,8 +44,13 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations)]
 
-use mcp_execution_core::{Error, Result, ServerConfig, ServerId, ToolName, validate_server_config};
+use http::{HeaderName, HeaderValue};
+use mcp_execution_core::{
+    Error, Result, ServerConfig, ServerId, ToolName, TransportType, validate_server_config,
+};
 use rmcp::ServiceExt;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -272,31 +279,14 @@ impl Introspector {
         // Validate server config for security (prevents command injection)
         validate_server_config(config)?;
 
-        let mut child = spawn_introspection_child(&server_id, config)?;
-        let stdout = child.stdout.take().ok_or_else(|| Error::ConnectionFailed {
-            server: server_id.to_string(),
-            source: Box::new(std::io::Error::other("child stdout was not captured")),
-        })?;
-        let stdin = child.stdin.take().ok_or_else(|| Error::ConnectionFailed {
-            server: server_id.to_string(),
-            source: Box::new(std::io::Error::other("child stdin was not captured")),
-        })?;
+        let (tool_list, server_name, server_version, has_resources, has_prompts) =
+            match config.transport() {
+                TransportType::Stdio => discover_via_stdio_process(&server_id, config).await?,
+                TransportType::Http | TransportType::Sse => {
+                    discover_via_http(&server_id, config).await?
+                }
+            };
 
-        let discovery = discover_via_stdio(&server_id, config, (stdout, stdin)).await;
-
-        // The child process is spawned solely for this discovery round-trip, so it
-        // must be reaped here regardless of outcome. We deliberately kill it
-        // ourselves rather than relying on rmcp's `TokioChildProcess`, whose cleanup
-        // is a `tokio::spawn`-ed background task in `Drop`: under a short-lived
-        // runtime (e.g. `#[tokio::test]`) that task can be starved before it ever
-        // runs, leaking the process (issue #132).
-        if let Err(kill_err) = child.kill().await {
-            tracing::warn!(
-                "failed to terminate introspection child process for {server_id}: {kill_err}"
-            );
-        }
-
-        let (tool_list, server_name, server_version, has_resources, has_prompts) = discovery?;
         let info = build_server_info(
             &server_id,
             server_name,
@@ -472,6 +462,44 @@ fn spawn_introspection_child(server_id: &ServerId, config: &ServerConfig) -> Res
     })
 }
 
+/// Spawns the stdio introspection child, drives discovery over it, and tears
+/// it down afterward.
+///
+/// # Errors
+///
+/// Returns [`Error::ConnectionFailed`] if the process cannot be spawned or its
+/// stdio pipes are unavailable, or propagates errors from [`discover_via_stdio`].
+async fn discover_via_stdio_process(
+    server_id: &ServerId,
+    config: &ServerConfig,
+) -> Result<(Vec<rmcp::model::Tool>, String, String, bool, bool)> {
+    let mut child = spawn_introspection_child(server_id, config)?;
+    let stdout = child.stdout.take().ok_or_else(|| Error::ConnectionFailed {
+        server: server_id.to_string(),
+        source: Box::new(std::io::Error::other("child stdout was not captured")),
+    })?;
+    let stdin = child.stdin.take().ok_or_else(|| Error::ConnectionFailed {
+        server: server_id.to_string(),
+        source: Box::new(std::io::Error::other("child stdin was not captured")),
+    })?;
+
+    let discovery = discover_via_stdio(server_id, config, (stdout, stdin)).await;
+
+    // The child process is spawned solely for this discovery round-trip, so it
+    // must be reaped here regardless of outcome. We deliberately kill it
+    // ourselves rather than relying on rmcp's `TokioChildProcess`, whose cleanup
+    // is a `tokio::spawn`-ed background task in `Drop`: under a short-lived
+    // runtime (e.g. `#[tokio::test]`) that task can be starved before it ever
+    // runs, leaking the process (issue #132).
+    if let Err(kill_err) = child.kill().await {
+        tracing::warn!(
+            "failed to terminate introspection child process for {server_id}: {kill_err}"
+        );
+    }
+
+    discovery
+}
+
 /// Connects to an already-spawned MCP server over `transport` and lists its
 /// tools, with each step bounded by `config`'s configured timeouts.
 ///
@@ -514,6 +542,93 @@ async fn discover_via_stdio(
 
     // Extract name, version, and capabilities from the MCP handshake result.
     // Falls back to the command string / "unknown" if the server did not send peer info.
+    let (server_name, server_version, has_resources, has_prompts) =
+        extract_peer_meta(config, client.peer_info().as_deref());
+
+    Ok((
+        tool_list,
+        server_name,
+        server_version,
+        has_resources,
+        has_prompts,
+    ))
+}
+
+/// Connects to an MCP server over Streamable HTTP and lists its tools, with
+/// each step bounded by `config`'s configured timeouts.
+///
+/// Used for both [`TransportType::Http`] and [`TransportType::Sse`]: rmcp 2.2
+/// has a single client transport for network MCP servers ("Streamable
+/// HTTP"), which superseded the standalone SSE transport in the 2025-03-26
+/// MCP spec revision. There is no legacy SSE-only client to fall back to.
+///
+/// # Errors
+///
+/// Returns [`Error::Timeout`] if the connect or discovery step exceeds its
+/// configured timeout, or [`Error::ConnectionFailed`] if a header cannot be
+/// constructed, or the underlying rmcp connection or request fails (this
+/// includes a reserved-header collision, e.g. a caller-supplied `Accept`
+/// header, which rmcp rejects as `StreamableHttpError::ReservedHeaderConflict`).
+async fn discover_via_http(
+    server_id: &ServerId,
+    config: &ServerConfig,
+) -> Result<(Vec<rmcp::model::Tool>, String, String, bool, bool)> {
+    // `validate_server_config` (called by the caller) already guarantees `url`
+    // is `Some` for Http/Sse transports.
+    let url = config
+        .url()
+        .expect("url validated as present by validate_server_config");
+
+    let mut custom_headers = HashMap::new();
+    for (name, value) in config.headers() {
+        let header_name =
+            HeaderName::try_from(name.as_str()).map_err(|e| Error::ConnectionFailed {
+                server: server_id.to_string(),
+                source: Box::new(e),
+            })?;
+        let header_value =
+            HeaderValue::try_from(value.as_str()).map_err(|e| Error::ConnectionFailed {
+                server: server_id.to_string(),
+                source: Box::new(e),
+            })?;
+        custom_headers.insert(header_name, header_value);
+    }
+
+    // Type parameter inferred as `reqwest::Client`: `StreamableHttpClientTransportConfig`'s
+    // `from_config` is an inherent method defined only on that one specialization of
+    // `StreamableHttpClientTransport<C>`, so this crate does not need to depend on `reqwest`
+    // directly or name `reqwest::Client` to select it.
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(url).custom_headers(custom_headers),
+    );
+
+    let client = tokio::time::timeout(config.connect_timeout(), ().serve(transport))
+        .await
+        .map_err(|_elapsed| Error::Timeout {
+            operation: format!("connect to {server_id}"),
+            duration_secs: config.connect_timeout().as_secs(),
+        })?
+        .map_err(|e| Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(e),
+        })?;
+
+    let tool_list = tokio::time::timeout(config.discover_timeout(), client.list_all_tools())
+        .await
+        .map_err(|_elapsed| Error::Timeout {
+            operation: format!("list_all_tools for {server_id}"),
+            duration_secs: config.discover_timeout().as_secs(),
+        })?
+        .map_err(|e| Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(e),
+        })?;
+
+    // Extract name, version, and capabilities from the MCP handshake result.
+    // Dropping `client` here triggers `WorkerTransport`'s drop guard, which
+    // cancels the worker task; a cancelled worker cannot itself issue a
+    // session-DELETE request, so no explicit disconnect happens on this path
+    // — the server-side session simply expires on its own timeout instead.
     let (server_name, server_version, has_resources, has_prompts) =
         extract_peer_meta(config, client.peer_info().as_deref());
 
@@ -573,14 +688,21 @@ fn build_server_info(
 /// Extracts server name, version, resource support, and prompt support from
 /// the MCP handshake result (`peer_info`).
 ///
-/// Falls back to `(config.command, "unknown", false, false)` when the server
-/// did not send peer information (i.e. `peer_info` is `None`).
+/// Falls back to `(fallback_server_name(config), "unknown", false, false)`
+/// when the server did not send peer information (i.e. `peer_info` is `None`).
 fn extract_peer_meta(
     config: &ServerConfig,
     peer_info: Option<&rmcp::model::InitializeResult>,
 ) -> (String, String, bool, bool) {
     peer_info.map_or_else(
-        || (config.command.clone(), "unknown".to_string(), false, false),
+        || {
+            (
+                fallback_server_name(config),
+                "unknown".to_string(),
+                false,
+                false,
+            )
+        },
         |info| {
             (
                 info.server_info.name.clone(),
@@ -590,6 +712,18 @@ fn extract_peer_meta(
             )
         },
     )
+}
+
+/// Picks a display name for a server that sent no `peer_info` on handshake.
+///
+/// Prefers `config.command` (stdio transport); falls back to `config.url()`
+/// since Http/Sse transports always leave `command` empty.
+fn fallback_server_name(config: &ServerConfig) -> String {
+    if config.command.is_empty() {
+        config.url().unwrap_or_default().to_string()
+    } else {
+        config.command.clone()
+    }
 }
 
 #[cfg(test)]
@@ -878,6 +1012,19 @@ mod tests {
         let (name, _, _, _) = extract_peer_meta(&config, None);
 
         assert_eq!(name, "fallback-binary");
+    }
+
+    /// Incidental fix: for Http/Sse configs `command` is always empty, so the
+    /// fallback name must come from `url`, not silently be `""`.
+    #[test]
+    fn test_extract_peer_meta_fallback_name_is_url_for_http_transport() {
+        let config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+
+        let (name, _, _, _) = extract_peer_meta(&config, None);
+
+        assert_eq!(name, "https://api.example.com/mcp");
     }
 
     /// Fallback: `peer_info` is `None` — version falls back to `"unknown"`

--- a/crates/mcp-introspector/tests/http_transport_test.rs
+++ b/crates/mcp-introspector/tests/http_transport_test.rs
@@ -1,0 +1,318 @@
+//! Integration tests proving `Introspector::discover_server` works end-to-end
+//! over Streamable HTTP (issue #180): connects to a real in-process rmcp
+//! Streamable HTTP server, discovers its tools and handshake metadata, proves
+//! `TransportType::Sse` uses the same client path as `TransportType::Http`,
+//! confirms a custom header set via `ServerConfig::header` actually reaches
+//! the server on the wire, and exercises the connect/discover timeout paths
+//! the same way `tests/timeout_test.rs` does for stdio.
+//!
+//! Requires the `test-fixtures` feature (implied by `--all-features`, which
+//! is how CI and the project's preferred `cargo nextest` invocation run
+//! tests) so that `rmcp/transport-streamable-http-server` is enabled.
+
+#![cfg(feature = "test-fixtures")]
+
+use axum::Router;
+use axum::extract::{Request, State};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use mcp_execution_core::{Error, ServerConfig, ServerId};
+use mcp_execution_introspector::Introspector;
+use rmcp::model::{
+    Implementation, InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+    Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+/// Header the fixture server watches for, to prove custom headers configured
+/// via `ServerConfig::header` reach the server over the wire.
+const TEST_HEADER_NAME: &str = "x-test-header";
+
+/// Minimal MCP server exposing a single `echo` tool, used to exercise the
+/// HTTP/SSE client path end-to-end. `list_tools_delay` lets discover-timeout
+/// tests hang the `tools/list` response independently of the connect phase.
+#[derive(Clone)]
+struct FixtureHandler {
+    list_tools_delay: Duration,
+}
+
+impl ServerHandler for FixtureHandler {
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("fixture-http-server", "9.9.9"))
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        if !self.list_tools_delay.is_zero() {
+            tokio::time::sleep(self.list_tools_delay).await;
+        }
+        Ok(ListToolsResult::with_all_items(vec![Tool::new(
+            "echo",
+            "Echoes input back",
+            serde_json::Map::new(),
+        )]))
+    }
+}
+
+/// Shared state for the header-capturing, optionally-delaying middleware
+/// wrapped around the fixture's Streamable HTTP service.
+#[derive(Clone)]
+struct MiddlewareState {
+    /// Delay applied to every request, simulating a hung connect phase.
+    connect_delay: Duration,
+    /// Records the last observed value of [`TEST_HEADER_NAME`].
+    captured_header: Arc<Mutex<Option<String>>>,
+}
+
+async fn instrument_request(
+    State(state): State<MiddlewareState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if let Some(value) = req.headers().get(TEST_HEADER_NAME) {
+        *state.captured_header.lock().unwrap() =
+            Some(value.to_str().unwrap_or_default().to_string());
+    }
+    if !state.connect_delay.is_zero() {
+        tokio::time::sleep(state.connect_delay).await;
+    }
+    next.run(req).await
+}
+
+/// Spawns the fixture server on a loopback TCP port.
+///
+/// Returns the base URL to connect to (`http://127.0.0.1:PORT/mcp`), a
+/// `CancellationToken` the caller must cancel to shut the server down, and
+/// the header-capture handle described in [`MiddlewareState`].
+async fn spawn_fixture_server(
+    connect_delay: Duration,
+    list_tools_delay: Duration,
+) -> (String, CancellationToken, Arc<Mutex<Option<String>>>) {
+    let ct = CancellationToken::new();
+    let server_config =
+        StreamableHttpServerConfig::default().with_cancellation_token(ct.child_token());
+
+    let handler = FixtureHandler { list_tools_delay };
+    let service: StreamableHttpService<FixtureHandler, LocalSessionManager> =
+        StreamableHttpService::new(
+            move || Ok(handler.clone()),
+            Arc::new(LocalSessionManager::default()),
+            server_config,
+        );
+
+    let captured_header = Arc::new(Mutex::new(None));
+    let middleware_state = MiddlewareState {
+        connect_delay,
+        captured_header: captured_header.clone(),
+    };
+
+    let router: Router =
+        Router::new()
+            .nest_service("/mcp", service)
+            .layer(middleware::from_fn_with_state(
+                middleware_state,
+                instrument_request,
+            ));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture listener");
+    let addr = listener
+        .local_addr()
+        .expect("fixture listener has a local addr");
+
+    let shutdown_ct = ct.clone();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled_owned().await })
+            .await;
+    });
+
+    (format!("http://{addr}/mcp"), ct, captured_header)
+}
+
+#[tokio::test]
+async fn test_discover_server_http_lists_tools_and_metadata() {
+    let (url, ct, captured_header) = spawn_fixture_server(Duration::ZERO, Duration::ZERO).await;
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .http_transport(url)
+        .header(TEST_HEADER_NAME.to_string(), "propagated-value".to_string())
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build();
+
+    let result = introspector
+        .discover_server(ServerId::new("http-fixture"), &config)
+        .await;
+
+    ct.cancel();
+
+    let info = result.expect("discover_server should succeed against the HTTP fixture");
+    assert_eq!(info.name, "fixture-http-server");
+    assert_eq!(info.version, "9.9.9");
+    assert_eq!(info.tools.len(), 1);
+    assert_eq!(info.tools[0].name.as_str(), "echo");
+    assert!(info.capabilities.supports_tools);
+
+    assert_eq!(
+        captured_header.lock().unwrap().as_deref(),
+        Some("propagated-value"),
+        "the custom header configured via ServerConfig::header must reach the server"
+    );
+}
+
+/// rmcp 2.2 has a single client transport for both `Http` and `Sse`
+/// (`TransportType::Sse` is documented as an alias) — this proves that
+/// end-to-end against a real server, not just at the type level.
+#[tokio::test]
+async fn test_discover_server_sse_transport_also_works() {
+    let (url, ct, _captured_header) = spawn_fixture_server(Duration::ZERO, Duration::ZERO).await;
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .sse_transport(url)
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build();
+
+    let result = introspector
+        .discover_server(ServerId::new("sse-fixture"), &config)
+        .await;
+
+    ct.cancel();
+
+    let info =
+        result.expect("discover_server should succeed against the HTTP fixture over Sse transport");
+    assert_eq!(info.tools.len(), 1);
+    assert_eq!(info.tools[0].name.as_str(), "echo");
+}
+
+/// The fixture delays `tools/list`, so with a short `discover_timeout`
+/// `discover_server` must fail with `Error::Timeout { operation: "list_all_tools" }`
+/// — mirroring `test_discover_server_discover_timeout_fires` in `timeout_test.rs`
+/// for the stdio path.
+#[tokio::test]
+async fn test_discover_server_http_discover_timeout_fires() {
+    let (url, ct, _captured_header) =
+        spawn_fixture_server(Duration::ZERO, Duration::from_secs(30)).await;
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .http_transport(url)
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_millis(150))
+        .build();
+
+    let started = Instant::now();
+    let result = introspector
+        .discover_server(ServerId::new("http-discover-timeout"), &config)
+        .await;
+    let elapsed = started.elapsed();
+
+    ct.cancel();
+
+    match result {
+        Err(Error::Timeout { operation, .. }) => assert!(
+            operation.starts_with("list_all_tools"),
+            "expected a \"list_all_tools\" timeout, got operation={operation:?}"
+        ),
+        other => {
+            panic!("expected Error::Timeout {{ operation: \"list_all_tools\" }}, got {other:?}")
+        }
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout should fire near the configured 150ms bound, not wait for the fixture's 30s delay; took {elapsed:?}"
+    );
+}
+
+/// The fixture delays every response (including the initial handshake), so
+/// with a short `connect_timeout` `discover_server` must fail with
+/// `Error::Timeout { operation: "connect" }` — mirroring
+/// `test_discover_server_connect_timeout_fires` in `timeout_test.rs` for the
+/// stdio path.
+#[tokio::test]
+async fn test_discover_server_http_connect_timeout_fires() {
+    let (url, ct, _captured_header) =
+        spawn_fixture_server(Duration::from_secs(30), Duration::ZERO).await;
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .http_transport(url)
+        .connect_timeout(Duration::from_millis(150))
+        .build();
+
+    let started = Instant::now();
+    let result = introspector
+        .discover_server(ServerId::new("http-connect-timeout"), &config)
+        .await;
+    let elapsed = started.elapsed();
+
+    ct.cancel();
+
+    match result {
+        Err(Error::Timeout { operation, .. }) => assert!(
+            operation.starts_with("connect"),
+            "expected a \"connect\" timeout, got operation={operation:?}"
+        ),
+        other => panic!("expected Error::Timeout {{ operation: \"connect\" }}, got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout should fire near the configured 150ms bound, not wait for the fixture's 30s delay; took {elapsed:?}"
+    );
+}
+
+/// rmcp rejects a handful of reserved headers (`Accept`, `Mcp-Session-Id`,
+/// `Last-Event-Id`) that its own transport already sets — `Authorization` is
+/// not among them, so the documented PAT use case is unaffected. This proves
+/// the resulting error is a legible message naming the header, not a raw
+/// Debug dump, by reaching through `Error::ConnectionFailed`'s `source`.
+///
+/// No fixture server needed: rmcp validates custom headers while building the
+/// request, before any socket I/O, so this is deterministic against an
+/// address nothing listens on.
+#[tokio::test]
+async fn test_discover_server_http_reserved_header_collision_is_legible() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind unused-port listener");
+    let addr = listener.local_addr().expect("listener has a local addr");
+    drop(listener); // nothing listens at `addr` from this point on
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .http_transport(format!("http://{addr}/mcp"))
+        .header("Accept".to_string(), "text/html".to_string())
+        .connect_timeout(Duration::from_secs(5))
+        .build();
+
+    let result = introspector
+        .discover_server(ServerId::new("reserved-header-fixture"), &config)
+        .await;
+
+    match result {
+        Err(Error::ConnectionFailed { source, .. }) => {
+            let msg = source.to_string();
+            assert!(
+                msg.to_ascii_lowercase().contains("reserved")
+                    && msg.to_ascii_lowercase().contains("accept"),
+                "expected a legible reserved-header-conflict message naming the header, got: {msg}"
+            );
+        }
+        other => panic!("expected Error::ConnectionFailed, got {other:?}"),
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception", # Used by some LLVM/Rust tooling
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "ISC",                            # Used by the aws-lc-rs TLS backend pulled in via rustls
+    "CDLA-Permissive-2.0",            # Mozilla root certificate data bundled by webpki-root-certs
     "Unicode-3.0",
     "Zlib",                           # Compression libraries
     "BSL-1.0",                        # Boost Software License


### PR DESCRIPTION
## Summary

- `Introspector::discover_server` previously ignored `config.transport()` entirely and always spawned a subprocess, so `--http`/`--sse` always failed validation with a misleading "command cannot be empty" `SecurityViolation` before the transport type was ever consulted. `validate_server_config` now dispatches on `TransportType`: stdio keeps its existing command/args/env checks, while Http/Sse configs are validated for a present `url`, an `http(s)` scheme, and control-character-free headers, with header values never surfacing in error text.
- `discover_server` now connects Http/Sse configs via rmcp's `StreamableHttpClientTransport`. `TransportType::Sse` routes through the same client, since rmcp 2.2 has no separate legacy SSE transport (the MCP spec unified HTTP+SSE into "Streamable HTTP" in 2025-03-26).
- `generate --http`/`--sse` no longer derives the server id from the raw URL. This path becomes reachable now that the transport actually works, and a raw-URL id broke `validate_server_id`'s charset requirement, could carry a path-traversal segment into a filesystem join, and could leak URL userinfo credentials into a directory name and generated source. `build_server_config` now derives a sanitized host+path slug instead (credentials are structurally excluded).
- Additional hardening in `validate_network_config`: case-insensitive duplicate header names are rejected instead of silently colliding after `HeaderName` lowercases them; the scheme check is case-insensitive per RFC 3986; header names are validated against the RFC 7230 token charset instead of only control characters.

Fixes #180.

## Dependencies

- `mcp-introspector` gains `http` as a direct dependency (already transitively present via rmcp) for `HeaderName`/`HeaderValue` construction. `reqwest` is deliberately **not** added as a direct dependency — `StreamableHttpClientTransport::from_config`'s type parameter infers from its only matching inherent impl.
- `mcp-cli` gains `url` as a direct dependency (already transitively resolved via rmcp→reqwest→url) for safe server-id slug derivation.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (794 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] New end-to-end test suite (`crates/mcp-introspector/tests/http_transport_test.rs`) against an in-process Streamable HTTP fixture: tool listing, handshake metadata, header propagation, `Sse` alias behavior, connect timeout, discover timeout
- [x] New unit tests for `validate_network_config` (url presence incl. serde-bypass case, scheme validation, header charset, duplicate-header rejection, secret-non-leak assertion) and `derive_server_id_from_url` (valid slug, credential exclusion, path-traversal containment, parse-failure fallback)
- [x] Manually verified via CLI: `--http` against an unreachable host now surfaces a real connection error instead of the old "command cannot be empty"; a `file://` URL is rejected with a clear scheme error