### PR TITLE
fix(cli): stop leaking secrets and route CLI errors to semantic exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `generate::run` keep their existing flat parameter lists and build `TransportArgs`
   internally.
 
+### Security
+
+- **`mcp-execution-cli`**: a malformed `--header`/`--env` value (missing the `=` separator, or
+  with an empty key) no longer echoes the raw, unvalidated argument into the CLI error message.
+  Since both flags routinely carry secrets (bearer tokens, API keys) with no reliable KEY=VALUE
+  structure to fall back on, `build_server_config`'s `parse_key_value` never echoes the value
+  portion when the key is empty or absent — mirroring the existing discipline in
+  `mcp_execution_core::command::validate_header_value_string`. Also closes a second leak on the
+  same path: a header written with the conventional `Name: Value` syntax (colon) instead of
+  `Name=Value`, where the value itself contains `=` (e.g. base64 padding, a JWT), previously put
+  the entire secret into the *key* slot — which then reached
+  `validate_header_name_string`'s error message, which assumes header names are never secret and
+  echoes them verbatim. `parse_key_value` now rejects a key containing whitespace, `:`, or
+  control characters (never legitimate in a header/env name) before it can reach that assumption
+  (#190).
+
 ### Fixed
+
+- **`mcp-execution-cli`**: `introspect`, `generate`, `skill`, and `setup` now exit with the
+  semantic `ExitCode` (`TIMEOUT`, `SERVER_ERROR`, `INVALID_INPUT`) documented on
+  `mcp_execution_core::cli::ExitCode`, instead of always collapsing to exit code 1 via anyhow's
+  default `main`-error handling. `runner::execute_command` now classifies a failing command's
+  underlying `mcp_execution_core::Error` (found by walking the `anyhow::Error` cause chain) into
+  the matching exit code before returning, so `main` can always turn the result into a process
+  exit code. `main` routes an invalid `--format` value through the same classification (it
+  previously bypassed `execute_command` entirely and always exited 1). Malformed `--header`/
+  `--env` values, an invalid `--server` id passed to `skill`, and path-traversal attempts in
+  `skill`'s output/server paths now carry a `CoreError` (`InvalidArgument`/`SecurityViolation`)
+  so they classify as `ExitCode::INVALID_INPUT` (2) instead of the generic `ExitCode::ERROR` (1)
+  (#195).
 
 - **`mcp-execution-cli`**: a `~/.claude/mcp.json` mixing stdio entries with http/sse entries
   (`{"type": "http", "url": "...", ...}`, no `command` key) failed to deserialize the *entire*

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -4,7 +4,7 @@
 //! and loading MCP server definitions from `~/.claude/mcp.json`.
 
 use anyhow::{Context, Result, bail};
-use mcp_execution_core::{ServerConfig, ServerConfigBuilder, ServerId};
+use mcp_execution_core::{Error as CoreError, ServerConfig, ServerConfigBuilder, ServerId};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -448,15 +448,47 @@ fn build_core_config(entry: &McpServerEntry) -> ServerConfig {
 }
 
 /// Parses a single `KEY=VALUE` CLI argument (used for `--env` and `--header`).
+///
+/// Security: `s` routinely carries secrets (tokens, API keys) in the value
+/// portion, so it must never be echoed into an error message verbatim —
+/// mirrors the discipline in `mcp_execution_core::command::validate_header_value_string`.
+/// Every error here is a `CoreError::InvalidArgument` (rather than a bare
+/// anyhow string) so it classifies as `ExitCode::INVALID_INPUT` downstream
+/// in `runner::classify_exit_code`.
 fn parse_key_value(s: &str, kind: &str) -> Result<(String, String)> {
-    let parts: Vec<&str> = s.splitn(2, '=').collect();
-    if parts.len() != 2 {
-        bail!("invalid {kind} format: '{s}' (expected KEY=VALUE)");
+    // No `=` at all: the whole string could itself be the secret with no
+    // discernible key, so it is never echoed, not even its length (which
+    // would narrow the secret's type/format for free in CI logs).
+    let Some((key, value)) = s.split_once('=') else {
+        return Err(CoreError::InvalidArgument(format!(
+            "invalid {kind} format: no '=' separator found (expected KEY=VALUE)"
+        ))
+        .into());
+    };
+    if key.is_empty() {
+        return Err(CoreError::InvalidArgument(format!(
+            "invalid {kind} format: key cannot be empty (expected KEY=VALUE)"
+        ))
+        .into());
     }
-    if parts[0].is_empty() {
-        bail!("invalid {kind} format: '{s}' (key cannot be empty)");
+    // A real header/env key never legitimately contains whitespace, `:`, or
+    // control characters. Their presence is the signature of the `=` having
+    // matched somewhere inside the value instead of acting as the separator
+    // — e.g. a header written `Name: Value` by mistake, where the value
+    // happens to contain `=` (base64 padding, a JWT). Reject without echoing
+    // `key`, since in that scenario it *is* the secret.
+    if key
+        .chars()
+        .any(|c| c.is_whitespace() || c == ':' || c.is_control())
+    {
+        return Err(CoreError::InvalidArgument(format!(
+            "invalid {kind} format: text before '=' contains characters that are never valid \
+             in a key, suggesting '=' matched inside a value rather than as the separator; \
+             refusing to echo it since it may contain a secret (expected KEY=VALUE)"
+        ))
+        .into());
     }
-    Ok((parts[0].to_string(), parts[1].to_string()))
+    Ok((key.to_string(), value.to_string()))
 }
 
 /// CLI-flag mirror of [`McpTransport`], holding the raw, unvalidated
@@ -1042,36 +1074,93 @@ mod tests {
 
     #[test]
     fn test_build_server_config_invalid_env() {
+        // Regression test for #190: a malformed `--env` value with no `=` is
+        // itself indistinguishable from a raw secret and must never be
+        // echoed — checked against the `{:?}` chain, since that's what
+        // `runner::execute_command` actually prints to stderr.
+        let secret = "ghp_verySECRETtoken1234567890abcdef";
+        let result = build_server_config(
+            stdio_transport("server", vec![], vec![secret], None),
+            None,
+            None,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(format!("{err:?}").contains("expected KEY=VALUE"));
+        assert!(
+            !format!("{err:?}").contains(secret),
+            "error chain leaked the raw secret: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_server_config_invalid_header() {
+        // Regression test for #190: same guarantee for `--header` values,
+        // which routinely carry bearer tokens / API keys.
+        let secret = "Bearer sk-live-supersecretvalue1234567890";
+        let result = build_server_config(
+            http_transport("https://example.com", vec![secret]),
+            None,
+            None,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(format!("{err:?}").contains("expected KEY=VALUE"));
+        assert!(
+            !format!("{err:?}").contains(secret),
+            "error chain leaked the raw secret: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_server_config_header_name_value_typo_does_not_leak_secret() {
+        // Regression test for #190/S1: a header written with the conventional
+        // `Name: Value` syntax (colon) instead of `Name=Value`, where the
+        // value contains `=` (e.g. base64 padding), previously put the whole
+        // secret into the "key" slot. That key then reached
+        // `mcp_execution_core::command::validate_header_name_string`, whose
+        // error message assumes header names are never secret and echoes
+        // them verbatim — leaking the credential one function downstream of
+        // the original fix.
+        let secret = "c2VjcmV0dG9rZW4=";
+        let header = format!("Authorization: Bearer {secret}");
+        let result = build_server_config(
+            http_transport("https://example.com", vec![&header]),
+            None,
+            None,
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            !format!("{err:?}").contains(secret),
+            "error chain leaked the raw secret: {err:?}"
+        );
+        assert!(
+            !format!("{err:?}").contains(&header),
+            "error chain leaked the raw header argument: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_server_config_invalid_env_classifies_as_invalid_argument() {
+        // Regression test for #195/S3: malformed `--env`/`--header` values are
+        // the most common invalid-input path for `introspect`/`generate`. The
+        // error must carry a `CoreError::InvalidArgument` so
+        // `runner::classify_exit_code` maps it to `ExitCode::INVALID_INPUT`
+        // instead of silently falling through to the generic `ExitCode::ERROR`.
         let result = build_server_config(
             stdio_transport("server", vec![], vec!["INVALID_FORMAT"], None),
             None,
             None,
         );
 
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("expected KEY=VALUE")
-        );
-    }
-
-    #[test]
-    fn test_build_server_config_invalid_header() {
-        let result = build_server_config(
-            http_transport("https://example.com", vec!["InvalidHeader"]),
-            None,
-            None,
-        );
-
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("expected KEY=VALUE")
-        );
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<CoreError>(),
+            Some(CoreError::InvalidArgument(_))
+        ));
     }
 
     #[test]
@@ -1266,35 +1355,42 @@ mod tests {
 
     #[test]
     fn test_build_server_config_empty_key_in_env() {
+        // Regression test for #190: the pre-fix message echoed the raw `s`
+        // (e.g. "=secretvalue"), leaking the value even though the key was
+        // reported empty.
+        let secret = "topsecretvalue";
+        let env_arg = format!("={secret}");
         let result = build_server_config(
-            stdio_transport("server", vec![], vec!["=value"], None),
+            stdio_transport("server", vec![], vec![&env_arg], None),
             None,
             None,
         );
 
         assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(format!("{err:?}").contains("key cannot be empty"));
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("key cannot be empty")
+            !format!("{err:?}").contains(secret),
+            "error chain leaked the raw secret: {err:?}"
         );
     }
 
     #[test]
     fn test_build_server_config_empty_key_in_header() {
+        let secret = "topsecretheadervalue";
+        let header_arg = format!("={secret}");
         let result = build_server_config(
-            http_transport("https://example.com", vec!["=value"]),
+            http_transport("https://example.com", vec![&header_arg]),
             None,
             None,
         );
 
         assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(format!("{err:?}").contains("key cannot be empty"));
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("key cannot be empty")
+            !format!("{err:?}").contains(secret),
+            "error chain leaked the raw secret: {err:?}"
         );
     }
 

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -8,6 +8,7 @@
 //! 4. Returns a prompt for Claude to generate optimal SKILL.md content
 
 use anyhow::{Context, Result, bail};
+use mcp_execution_core::Error as CoreError;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use mcp_execution_skill::{
     build_skill_context, render_skill_md, scan_tools_directory, validate_server_id,
@@ -110,7 +111,11 @@ pub async fn run(
     debug!("Output format: {}", output_format);
 
     // Step 1: Validate server ID
-    validate_server_id(&server).map_err(|e| anyhow::anyhow!("Invalid server ID: {e}"))?;
+    // A malformed `server` id is a CLI-argument mistake, so this is wrapped
+    // as `CoreError::InvalidArgument` (rather than a bare anyhow string) to
+    // classify as `ExitCode::INVALID_INPUT` in `runner::classify_exit_code`.
+    validate_server_id(&server)
+        .map_err(|e| CoreError::InvalidArgument(format!("Invalid server ID: {e}")))?;
     info!("Server ID validated: {}", server);
 
     // Step 2: Resolve servers directory
@@ -287,9 +292,15 @@ fn resolve_skills_dir() -> Result<PathBuf> {
 /// - Path cannot be canonicalized
 /// - Path is outside the base directory (symlink escape)
 fn validate_path_security(path: &Path, base: &Path) -> Result<PathBuf> {
-    // Check for path traversal in components (more robust than string check)
+    // Check for path traversal in components (more robust than string check).
+    // A traversal attempt is a malicious/invalid argument, so it is wrapped
+    // as `CoreError::SecurityViolation` to classify as
+    // `ExitCode::INVALID_INPUT` in `runner::classify_exit_code`.
     if has_path_traversal(path) {
-        bail!("Path traversal detected: {}", path.display());
+        return Err(CoreError::SecurityViolation {
+            reason: format!("path traversal detected: {}", path.display()),
+        }
+        .into());
     }
 
     // If the path doesn't exist yet, validation passed
@@ -312,11 +323,14 @@ fn validate_path_security(path: &Path, base: &Path) -> Result<PathBuf> {
 
     // Verify path is within base directory
     if !canonical_path.starts_with(&canonical_base) {
-        bail!(
-            "Security error: path {} is outside base directory {}",
-            canonical_path.display(),
-            canonical_base.display()
-        );
+        return Err(CoreError::SecurityViolation {
+            reason: format!(
+                "path {} is outside base directory {}",
+                canonical_path.display(),
+                canonical_base.display()
+            ),
+        }
+        .into());
     }
 
     Ok(canonical_path)
@@ -333,10 +347,13 @@ fn validate_path_security(path: &Path, base: &Path) -> Result<PathBuf> {
 /// Returns error if path contains traversal components (`..`).
 fn validate_output_path(path: &Path) -> Result<()> {
     if has_path_traversal(path) {
-        bail!(
-            "Invalid output path (path traversal detected): {}",
-            path.display()
-        );
+        return Err(CoreError::SecurityViolation {
+            reason: format!(
+                "invalid output path (path traversal detected): {}",
+                path.display()
+            ),
+        }
+        .into());
     }
     Ok(())
 }
@@ -435,7 +452,15 @@ mod tests {
 
         let result = validate_path_security(&evil_path, base);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("traversal"));
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("traversal"));
+        // Regression test for #195/S3: a path traversal attempt is a
+        // malicious/invalid argument, so it must carry a `CoreError` that
+        // `runner::classify_exit_code` maps to `ExitCode::INVALID_INPUT`.
+        assert!(matches!(
+            err.downcast_ref::<CoreError>(),
+            Some(CoreError::SecurityViolation { .. })
+        ));
     }
 
     #[test]
@@ -533,12 +558,15 @@ mod tests {
         .await;
 
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Invalid server ID")
-        );
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Invalid server ID"));
+        // Regression test for #195/S3: an invalid `server` id is a
+        // CLI-argument mistake, so it must carry a `CoreError` that
+        // `runner::classify_exit_code` maps to `ExitCode::INVALID_INPUT`.
+        assert!(matches!(
+            err.downcast_ref::<CoreError>(),
+            Some(CoreError::InvalidArgument(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/mcp-cli/src/main.rs
+++ b/crates/mcp-cli/src/main.rs
@@ -48,12 +48,14 @@ async fn main() -> Result<()> {
 
     runner::init_logging(cli.verbose)?;
 
-    let output_format = cli
-        .format
-        .parse::<OutputFormat>()
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    let exit_code = runner::execute_command(cli.command, output_format).await?;
+    // `OutputFormat::from_str`'s `Err` is a `mcp_execution_core::Error`
+    // (e.g. `--format xml`) — routed through the same
+    // `report_and_classify` used for command-handler failures so an invalid
+    // CLI argument here also exits `ExitCode::INVALID_INPUT`, not a bare 1.
+    let exit_code = match cli.format.parse::<OutputFormat>() {
+        Ok(output_format) => runner::execute_command(cli.command, output_format).await?,
+        Err(err) => runner::report_and_classify(&anyhow::Error::from(err)),
+    };
 
     std::process::exit(exit_code.as_i32());
 }

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -3,6 +3,7 @@
 //! Contains the main command execution loop and logging initialization.
 
 use anyhow::Result;
+use mcp_execution_core::Error as CoreError;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -41,7 +42,12 @@ pub fn init_logging(verbose: bool) -> Result<()> {
 
 /// Executes the specified CLI command.
 ///
-/// Routes commands to their respective handlers and returns an exit code.
+/// Routes commands to their respective handlers. On success, returns the exit
+/// code reported by the handler. If the handler fails, the error is printed
+/// to stderr and classified into a semantic [`ExitCode`] via
+/// [`classify_exit_code`] rather than propagated — this lets `main` always
+/// turn the result into a process exit code without falling back to anyhow's
+/// default behavior of collapsing every `Err` to exit code 1.
 ///
 /// # Arguments
 ///
@@ -50,14 +56,11 @@ pub fn init_logging(verbose: bool) -> Result<()> {
 ///
 /// # Errors
 ///
-/// Returns an error from the specific command handler if:
-/// - Server configuration is invalid (bad args, env vars, or headers)
-/// - Server connection or introspection fails
-/// - Configuration file is missing or malformed
-/// - File I/O or export operations fail
-/// - Output formatting fails (e.g., serialization errors)
+/// This function does not propagate command execution failures as `Err` —
+/// see above. It is fallible in signature to match this crate's convention
+/// of using `Result` consistently across command handlers.
 pub async fn execute_command(command: Commands, output_format: OutputFormat) -> Result<ExitCode> {
-    match command {
+    let result = match command {
         Commands::Introspect {
             from_config,
             server,
@@ -147,5 +150,169 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
             let mut cmd = Cli::command();
             commands::completions::run(shell, &mut cmd).await
         }
+    };
+
+    Ok(match result {
+        Ok(code) => code,
+        Err(err) => report_and_classify(&err),
+    })
+}
+
+/// Prints `err` to stderr (matching anyhow's default `main`-error format) and
+/// classifies it into a semantic [`ExitCode`] via [`classify_exit_code`].
+///
+/// Shared by [`execute_command`] (command-handler failures) and `main`
+/// (pre-dispatch failures, e.g. an invalid `--format` value), so every
+/// failure this CLI can produce is reported and exits the same way.
+pub fn report_and_classify(err: &anyhow::Error) -> ExitCode {
+    eprintln!("Error: {err:?}");
+    classify_exit_code(err)
+}
+
+/// Classifies an [`anyhow::Error`] returned by a command handler into a
+/// semantic [`ExitCode`].
+///
+/// Walks the error's cause chain looking for a [`CoreError`] — the concrete
+/// type every command handler ultimately produces via `?` — and maps its
+/// variant to the exit code that best communicates the failure category to
+/// scripts consuming this CLI. Errors that never wrap a [`CoreError`] (e.g.
+/// CLI argument parsing, serialization) fall back to [`ExitCode::ERROR`].
+fn classify_exit_code(error: &anyhow::Error) -> ExitCode {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<CoreError>())
+        .map_or(ExitCode::ERROR, |core_error| match core_error {
+            CoreError::Timeout { .. } => ExitCode::TIMEOUT,
+            CoreError::ConnectionFailed { .. } => ExitCode::SERVER_ERROR,
+            CoreError::ValidationError { .. }
+            | CoreError::SecurityViolation { .. }
+            | CoreError::InvalidArgument(_) => ExitCode::INVALID_INPUT,
+            CoreError::ResourceNotFound { .. }
+            | CoreError::ConfigError { .. }
+            | CoreError::SerializationError { .. }
+            | CoreError::ScriptGenerationError { .. } => ExitCode::ERROR,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wrap(core_error: CoreError) -> anyhow::Error {
+        anyhow::Error::new(core_error)
+    }
+
+    #[test]
+    fn test_classify_exit_code_timeout() {
+        let err = wrap(CoreError::Timeout {
+            operation: "discover".to_string(),
+            duration_secs: 30,
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::TIMEOUT);
+    }
+
+    #[test]
+    fn test_classify_exit_code_connection_failed() {
+        let err = wrap(CoreError::ConnectionFailed {
+            server: "test".to_string(),
+            source: "refused".into(),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_classify_exit_code_validation_error() {
+        let err = wrap(CoreError::ValidationError {
+            field: "connect_timeout".to_string(),
+            reason: "must be greater than zero".to_string(),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::INVALID_INPUT);
+    }
+
+    #[test]
+    fn test_classify_exit_code_security_violation() {
+        let err = wrap(CoreError::SecurityViolation {
+            reason: "forbidden env var".to_string(),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::INVALID_INPUT);
+    }
+
+    #[test]
+    fn test_classify_exit_code_invalid_argument() {
+        let err = wrap(CoreError::InvalidArgument("bad flag".to_string()));
+        assert_eq!(classify_exit_code(&err), ExitCode::INVALID_INPUT);
+    }
+
+    #[test]
+    fn test_classify_exit_code_other_core_errors_fall_back_to_error() {
+        let err = wrap(CoreError::ResourceNotFound {
+            resource: "server:missing".to_string(),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
+
+        let err = wrap(CoreError::ConfigError {
+            message: "bad config".to_string(),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
+    }
+
+    #[test]
+    fn test_classify_exit_code_non_core_error_falls_back_to_error() {
+        let err = anyhow::anyhow!("plain CLI-layer failure");
+        assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
+    }
+
+    #[test]
+    fn test_classify_exit_code_finds_core_error_through_context_chain() {
+        // The command handlers wrap `mcp_execution_core::Error` with
+        // `.with_context(...)` before it reaches `execute_command` — the
+        // classifier must find it through that wrapping, not just at the top.
+        let err = wrap(CoreError::Timeout {
+            operation: "connect".to_string(),
+            duration_secs: 5,
+        })
+        .context("failed to connect to server 'test' - ensure the server is installed");
+        assert_eq!(classify_exit_code(&err), ExitCode::TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_converts_failure_into_classified_exit_code_not_err() {
+        // Regression test for #195: a failing command must surface as
+        // `Ok(non_success_exit_code)`, never as `Err`, so `main` can always
+        // reach `std::process::exit` with the classified code instead of
+        // falling back to anyhow's default exit-code-1 handling. Asserting
+        // the exact `SERVER_ERROR` value (not just `!is_success()`) so a
+        // regression to the generic `ExitCode::ERROR` fallback is caught.
+        let result = execute_command(
+            Commands::Introspect {
+                from_config: None,
+                server: Some("nonexistent-server-for-exit-code-test".to_string()),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+                http: None,
+                sse: None,
+                headers: vec![],
+                detailed: false,
+                connect_timeout_secs: None,
+                discover_timeout_secs: None,
+            },
+            OutputFormat::Json,
+        )
+        .await;
+
+        let exit_code = result.expect("execute_command must not propagate Err");
+        assert_eq!(exit_code, ExitCode::SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_report_and_classify_prints_and_classifies() {
+        // Regression test for #195/S2: `main` routes pre-dispatch failures
+        // (e.g. an invalid `--format` value) through this same function, not
+        // just command-handler failures via `execute_command`.
+        let err = anyhow::Error::from(CoreError::InvalidArgument(
+            "invalid output format: 'xml' (expected: json, text, or pretty)".to_string(),
+        ));
+        assert_eq!(report_and_classify(&err), ExitCode::INVALID_INPUT);
     }
 }


### PR DESCRIPTION
## Summary

- `build_server_config`'s `parse_key_value` no longer echoes the raw `--header`/`--env` value into error messages when it is missing the `=` separator or has an empty key. Also rejects a key containing whitespace, `:`, or control characters, closing a second leak where a `Name: Value`-style typo with a `=`-containing value (base64, JWT) previously put the whole secret into the key slot and leaked it through `validate_header_name_string`'s error message.
- `runner::execute_command` now classifies a failing command's underlying `mcp_execution_core::Error` into the semantic `ExitCode` (`TIMEOUT`, `SERVER_ERROR`, `INVALID_INPUT`) documented on that type, instead of always collapsing to exit code 1. `main` routes an invalid `--format` value through the same classification. Malformed `--header`/`--env` values, an invalid `skill` server id, and path traversal attempts now carry a `CoreError` so they classify as `INVALID_INPUT` (2) rather than the generic `ERROR` (1).

Closes #190
Closes #195

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (840 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- [x] Live-verified `--header "Authorization: Bearer <secret>"` no longer leaks the secret and exits 2
- [x] Live-verified `--format xml` now exits 2 (was 1)
- [x] CHANGELOG.md updated under `[Unreleased]`