### PR TITLE
fix(codegen,core): stop escaping JSDoc output and re-validate mcp.json in the runtime bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,18 @@ jobs:
         with:
           tool: nextest
 
+      # mcp-execution-codegen's test suite compiles and executes generated TypeScript under
+      # `tsc`/`node` (e.g. the #201 runtime-bridge regression tests) to catch TypeScript-level
+      # regressions that a Rust-only check can't see. Those tests hard-fail (rather than
+      # silently skip) when the `CI` env var is set, so this toolchain must be present here.
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install TypeScript
+        run: npm install -g typescript
+
       - name: Build (all targets, all features)
         run: cargo build --all-targets --all-features --workspace
 
@@ -148,6 +160,16 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+
+      # See the `test` job for why this toolchain is required: mcp-execution-codegen's
+      # TypeScript-executing regression tests hard-fail under `CI` rather than skip.
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install TypeScript
+        run: npm install -g typescript
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directory is tracked as a follow-up, alongside a separate, larger unvalidated-path issue in
   `introspect_server`'s `output_dir` — neither is in scope here.
 
+- **`mcp-execution-codegen`**, **`mcp-execution-core`**: hardened, defense-in-depth mitigation
+  for the generated runtime bridge (`_runtime/mcp-bridge.ts`) re-reading `~/.claude/mcp.json`
+  unvalidated at every tool call. The bridge now re-validates each stdio server's command,
+  arguments, and environment variable names against the same forbidden-shell-metacharacter
+  and forbidden-env-var rules as `mcp_execution_core::validate_server_config` before every
+  `spawn()` call, failing closed (throwing) rather than silently stripping the offending
+  value. This is **not** a complete closure of the underlying injection primitive: an
+  attacker who can already edit `~/.claude/mcp.json` could equally edit the generated
+  `_runtime/mcp-bridge.ts` itself (e.g. delete the new validation call), and the forbidden
+  env-var list does not cover every RCE-relevant variable (e.g. arbitrary env vars honored by
+  the target subprocess's own runtime). Treat this as raising the bar, not as a sandbox
+  boundary. A tracking issue for the remaining gaps (broader env-var coverage, full parity
+  with `validate_server_config`'s absolute-path/transport/URL/header checks, and a
+  Rust/TypeScript validation-drift guard) will be filed as a follow-up.
+  - `FORBIDDEN_ENV_NAMES` (`mcp-core`'s `command.rs`, mirrored in the bridge) now additionally
+    blocks `NODE_OPTIONS` (can inject e.g. `--require /tmp/evil.js` into any Node subprocess)
+    and `BASH_ENV` (sourced by non-interactive `bash` before running a script).
+  - The bridge's validation error messages no longer echo the offending command/argument
+    value verbatim — MCP server arguments routinely carry secrets (e.g. `--token=...`), and
+    this error can surface into tool output visible to the calling model, not just an
+    operator's terminal.
+  - `{"transport":"http"/"sse",...}` server entries (valid `mcp.json` since #200) are now
+    rejected by the bridge with a clear, intentional error ("this runtime bridge only
+    supports stdio transport servers") instead of an opaque `TypeError` from validating an
+    `undefined` command/args.
+  - `sanitize_jsdoc` (used for tool/category/keyword text embedded in generated comments) now
+    also strips U+2028/U+2029 (ECMAScript line terminators not covered by `\r`/`\n`
+    stripping), closing a `//`-comment-termination gap in `index.ts`'s category header.
+
+  **BREAKING CHANGE:** the forbidden-env-var check (`PATH`, `LD_LIBRARY_PATH`, `DYLD_*`,
+  `LD_PRELOAD`, and now `NODE_OPTIONS`/`BASH_ENV`) now runs on *every* tool invocation via the
+  generated bridge, not just once at `generate` time. An `mcp.json` entry that legitimately
+  pins one of these names (e.g. `PATH` or `LD_LIBRARY_PATH` for an nvm/pyenv/Homebrew-wrapped
+  server) previously worked at call time and will now fail closed with a validation error.
+
+- **`mcp-execution-codegen`**: `TemplateEngine` no longer HTML-escapes Handlebars output.
+  Generated templates interpolate tool/server metadata into TypeScript JSDoc comments, not
+  HTML, so the default escaping of `&`, `<`, `>`, `"`, and `'` was corrupting benign
+  punctuation (apostrophes, comparison operators, ampersands) in generated source. JSDoc
+  comment-injection protection continues to come from `sanitize_jsdoc`'s `*/`-stripping and
+  newline-flattening, which run before rendering and are unaffected by this change.
+
 - **`mcp-execution-core`**, **`mcp-execution-introspector`**: `--http`/`--sse` transports
   actually connect now, instead of failing validation with a misleading "command cannot be
   empty" `SecurityViolation` before the transport type was ever consulted (#180).

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -649,9 +649,14 @@ impl<'a> ProgressiveGenerator<'a> {
 /// Sanitizes a server-controlled string for safe interpolation into JSDoc block comments.
 ///
 /// Prevents JSDoc comment terminator injection by replacing `*/` sequences,
-/// stripping newlines, and truncating to a safe maximum length.
+/// stripping newlines (including U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR,
+/// which ECMAScript treats as line terminators and which therefore also terminate a `//`
+/// line comment even though they aren't ASCII `\r`/`\n`), and truncating to a safe maximum
+/// length.
 fn sanitize_jsdoc(s: &str, max_len: usize) -> String {
-    let sanitized = s.replace("*/", "*\\/").replace(['\r', '\n'], " ");
+    let sanitized = s
+        .replace("*/", "*\\/")
+        .replace(['\r', '\n', '\u{2028}', '\u{2029}'], " ");
     if sanitized.chars().count() > max_len {
         sanitized.chars().take(max_len).collect()
     } else {
@@ -663,12 +668,16 @@ fn sanitize_jsdoc(s: &str, max_len: usize) -> String {
 ///
 /// Backslashes are escaped before quotes so the backslash introduced by quote-escaping
 /// is not itself re-escaped. Carriage returns and newlines are escaped so the value
-/// cannot terminate the literal by injecting a raw line break.
+/// cannot terminate the literal by injecting a raw line break. U+2028/U+2029 are also
+/// escaped: legal but unescaped inside a string literal only since ES2019, so a raw
+/// occurrence would be a syntax error for consumers targeting an older ECMAScript target.
 fn sanitize_ts_string_literal(s: &str) -> String {
     s.replace('\\', "\\\\")
         .replace('\'', "\\'")
         .replace('\r', "\\r")
         .replace('\n', "\\n")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029")
 }
 
 /// JavaScript/TypeScript reserved words that cannot be used as a function or export
@@ -1326,6 +1335,57 @@ mod tests {
     }
 
     #[test]
+    fn test_sanitize_jsdoc_replaces_unicode_line_terminators() {
+        // U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are treated as line
+        // terminators by ECMAScript, so they terminate a `//` line comment (e.g.
+        // `index.ts.hbs`'s `// --- {{name}} ---` category header) even though they are not
+        // ASCII `\r`/`\n` and were never covered by Handlebars' HTML-escaping either.
+        assert_eq!(
+            sanitize_jsdoc("line1\u{2028}line2\u{2029}line3", 256),
+            "line1 line2 line3"
+        );
+    }
+
+    #[test]
+    fn test_generate_with_categories_sanitizes_unicode_line_terminator_in_category() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = create_test_server_info();
+
+        let mut categorizations = HashMap::new();
+        categorizations.insert(
+            "create_issue".to_string(),
+            ToolCategorization {
+                category: "issues\u{2028}export const pwned = 1;".to_string(),
+                keywords: String::new(),
+                short_description: "Create a new issue".to_string(),
+            },
+        );
+
+        let code = generator
+            .generate_with_categories(&server_info, &categorizations)
+            .unwrap();
+        let index = code.files.iter().find(|f| f.path == "index.ts").unwrap();
+
+        // The sanitized category text (including the literal "export const pwned = 1;"
+        // substring) is expected to still appear, harmlessly, inside the `// --- ... ---`
+        // comment. What must NOT happen is U+2028 terminating that comment early and
+        // letting "export const pwned" start a fresh, live top-level statement.
+        assert!(
+            index
+                .content
+                .contains("// --- issues export const pwned = 1; ---"),
+            "sanitized category text should remain inert inside the comment: {}",
+            index.content
+        );
+        assert!(
+            !index.content.contains("\nexport const pwned"),
+            "U+2028 must not terminate the `// --- {{category}} ---` line comment and \
+             inject a live top-level statement: {}",
+            index.content
+        );
+    }
+
+    #[test]
     fn test_sanitize_jsdoc_truncates() {
         let long = "a".repeat(300);
         assert_eq!(sanitize_jsdoc(&long, 256).chars().count(), 256);
@@ -1359,6 +1419,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_sanitize_ts_string_literal_escapes_unicode_line_terminators() {
+        // U+2028/U+2029 are legal-but-unescaped inside a string literal only since ES2019;
+        // a raw occurrence is a syntax error for consumers targeting an older ES target.
+        assert_eq!(
+            sanitize_ts_string_literal("line1\u{2028}line2\u{2029}line3"),
+            "line1\\u2028line2\\u2029line3"
+        );
+    }
+
     // `sanitize_ts_identifier`'s core behavior (invalid-char replacement, leading-digit
     // and empty-string prefixing) is unit-tested in `common::typescript`, its canonical
     // home now that it's a shared `pub fn`; this test covers the passthrough case that's
@@ -1386,10 +1456,24 @@ mod tests {
             })
             .unwrap();
 
+        // Scoped to the `callMCPTool(...)` call site itself: the JSDoc header above it
+        // legitimately echoes the raw tool name inside a `/** */` block comment (quotes
+        // there are inert, not code), so a whole-file substring check would false-positive
+        // on that comment. The security property under test is that `name_literal`
+        // (escaped via `sanitize_ts_string_literal`) can't break out of the single-quoted
+        // string literal actually passed to `callMCPTool`.
+        // Matches the actual invocation (`return (await callMCPTool(...`) rather than any
+        // line merely containing "callMCPTool(" — a future `@example` line in the JSDoc
+        // above (which legitimately shows `callMCPTool(...)` usage in prose) would otherwise
+        // silently redirect this assertion to the wrong line.
+        let call_site_line = tool
+            .content
+            .lines()
+            .find(|line| line.contains("return (await callMCPTool("))
+            .expect("generated tool file must contain a callMCPTool(...) invocation");
         assert!(
-            !tool.content.contains("'); alert('pwned"),
-            "raw quote must not break out of the callMCPTool string literal: {}",
-            tool.content
+            !call_site_line.contains("'); alert('pwned"),
+            "raw quote must not break out of the callMCPTool string literal: {call_site_line}"
         );
     }
 
@@ -1721,6 +1805,81 @@ mod tests {
             "truncation must not re-open the JSDoc comment: {sanitized}"
         );
         assert_eq!(sanitized.chars().count(), max_len);
+    }
+
+    #[test]
+    fn test_generate_runtime_bridge_declares_forbidden_env_var_list() {
+        // Cheap, offline snapshot check that the rendered bridge's `FORBIDDEN_ENV_NAMES`
+        // literal contains the expected names. This is NOT a drift guard: the names below
+        // are hardcoded here a third time, independent of `mcp-core`'s `command.rs` — adding
+        // a name to `command.rs` alone would not fail this test, since nothing here reads
+        // that list. (A real Rust/TypeScript drift guard is tracked separately; the two
+        // copies are currently kept in sync by hand.) This also does NOT prove the validator
+        // is reachable or enforced at runtime — a `grep`-style assertion can pass even
+        // against dead code (e.g. an unreachable function, or one whose result is never
+        // checked). The actual behavioral regression guard for #201 — that a hostile
+        // `~/.claude/mcp.json` is rejected before any subprocess is spawned — lives in
+        // `crates/mcp-codegen/tests/progressive_generation.rs`
+        // (`test_runtime_bridge_rejects_forbidden_env_var_before_spawn`), which compiles and
+        // actually executes the rendered bridge under Node.
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = create_test_server_info();
+
+        let code = generator.generate(&server_info).unwrap();
+        let bridge = code
+            .files
+            .iter()
+            .find(|f| f.path == "_runtime/mcp-bridge.ts")
+            .unwrap();
+
+        for forbidden_env in [
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+            "DYLD_INSERT_LIBRARIES",
+            "DYLD_LIBRARY_PATH",
+            "DYLD_FRAMEWORK_PATH",
+            "PATH",
+            "NODE_OPTIONS",
+            "BASH_ENV",
+        ] {
+            assert!(
+                bridge.content.contains(&format!("'{forbidden_env}'")),
+                "runtime bridge must list forbidden env var {forbidden_env}: {}",
+                bridge.content
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_preserves_benign_punctuation() {
+        // Issue #204 regression: Handlebars' default HTML-escaping corrupted benign
+        // punctuation (apostrophes, ampersands, comparison operators) in JSDoc comments,
+        // turning e.g. `don't` into `don&#x27;t` or `a < b` into `a &lt; b`.
+        let generator = ProgressiveGenerator::new().unwrap();
+        let mut server_info = create_test_server_info();
+        server_info.tools[0].description =
+            "Compares values: a < b && b > c, or use \"quotes\" & don't forget 'em".to_string();
+
+        let code = generator.generate(&server_info).unwrap();
+        let tool = code
+            .files
+            .iter()
+            .find(|f| f.path == "createIssue.ts")
+            .unwrap();
+
+        assert!(
+            tool.content
+                .contains("a < b && b > c, or use \"quotes\" & don't forget 'em"),
+            "benign punctuation must survive verbatim, not be HTML-escaped: {}",
+            tool.content
+        );
+        for entity in ["&lt;", "&gt;", "&amp;", "&quot;", "&#x27;", "&#39;"] {
+            assert!(
+                !tool.content.contains(entity),
+                "output must not contain HTML entity {entity}: {}",
+                tool.content
+            );
+        }
     }
 
     #[test]

--- a/crates/mcp-codegen/src/template_engine.rs
+++ b/crates/mcp-codegen/src/template_engine.rs
@@ -55,6 +55,14 @@ impl<'a> TemplateEngine<'a> {
         // Strict mode: fail on missing variables
         handlebars.set_strict_mode(true);
 
+        // Handlebars HTML-escapes `{{var}}` by default (`&`, `<`, `>`, `"`, `'`),
+        // which corrupts the TypeScript/JSDoc source this engine generates. Injection
+        // safety is instead enforced upstream by `sanitize_jsdoc` and
+        // `sanitize_ts_string_literal` (see `progressive/generator.rs`), which run
+        // before rendering and strip the sequences that actually matter (`*/`,
+        // unescaped quotes, newlines).
+        handlebars.register_escape_fn(handlebars::no_escape);
+
         // Register progressive loading templates
         Self::register_progressive_templates(&mut handlebars)?;
 
@@ -228,5 +236,20 @@ mod tests {
     #[test]
     fn test_default_trait() {
         let _engine = TemplateEngine::default();
+    }
+
+    #[test]
+    fn test_render_does_not_html_escape() {
+        // Handlebars HTML-escapes `{{var}}` by default; this project's templates
+        // interpolate into TypeScript/JSDoc, not HTML, so that must be disabled.
+        let mut engine = TemplateEngine::new().unwrap();
+        engine
+            .register_template_string("test-no-escape", "{{value}}")
+            .unwrap();
+
+        let context = json!({"value": "a && b < c > d \"e\" 'f'"});
+        let result = engine.render("test-no-escape", &context).unwrap();
+
+        assert_eq!(result, "a && b < c > d \"e\" 'f'");
     }
 }

--- a/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
@@ -21,6 +21,9 @@ import { Readable } from 'stream';
  * Configuration for an MCP server
  */
 interface ServerConfig {
+  /** Transport type; "stdio" if omitted. Only "stdio" is validated/supported here — see
+   * {@link validateServerConfig}. */
+  transport?: string;
   /** Command to execute (e.g., "docker", "node", "npx") */
   command: string;
   /** Arguments to pass to the command */
@@ -110,13 +113,135 @@ function debug(...args: unknown[]): void {
 }
 
 /**
+ * Shell metacharacters that indicate potential command injection.
+ * Mirrors `FORBIDDEN_CHARS` in `mcp-execution-core`'s `command.rs`.
+ */
+const FORBIDDEN_CHARS = [';', '|', '&', '>', '<', '`', '$', '(', ')', '\n', '\r'];
+
+/**
+ * Forbidden environment variable names that pose security risks.
+ * Mirrors `FORBIDDEN_ENV_NAMES` in `mcp-execution-core`'s `command.rs`.
+ * `DYLD_*` is additionally rejected as a prefix match, not just these exact names.
+ */
+const FORBIDDEN_ENV_NAMES = [
+  'LD_PRELOAD',
+  'LD_LIBRARY_PATH',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  'DYLD_FRAMEWORK_PATH',
+  'PATH',
+  'NODE_OPTIONS',
+  'BASH_ENV',
+];
+
+/**
+ * Validates a command or argument string for forbidden shell metacharacters.
+ *
+ * Mirrors `validate_command_string` in `mcp-execution-core`'s `command.rs`. The offending
+ * value itself is never included in the thrown message: MCP server commands/arguments
+ * routinely carry secrets (e.g. `--token=...`), and this error can surface into tool output
+ * visible to the calling model, not just an operator's terminal — mirroring the header-value
+ * redaction rule in `mcp-execution-core`'s `command.rs`.
+ *
+ * @param value - The command or argument string to validate
+ * @param context - Human-readable description of the value, used in error messages
+ * @throws {Error} If the value is not a string, is empty/whitespace-only, or contains a
+ *   forbidden character
+ */
+function validateCommandString(value: unknown, context: string): void {
+  if (typeof value !== 'string') {
+    throw new Error(`${context} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${context} cannot be empty`);
+  }
+  for (const forbidden of FORBIDDEN_CHARS) {
+    if (trimmed.includes(forbidden)) {
+      throw new Error(
+        `${context} contains forbidden shell metacharacter '${forbidden}' (value redacted: ` +
+        `MCP server commands/arguments may carry secrets)`
+      );
+    }
+  }
+}
+
+/**
+ * Validates an environment variable name against the forbidden list.
+ *
+ * Mirrors `validate_env_name` in `mcp-execution-core`'s `command.rs`.
+ *
+ * @param name - The environment variable name to validate
+ * @throws {Error} If the name is forbidden (exact match or `DYLD_*` prefix)
+ */
+function validateEnvName(name: string): void {
+  if (FORBIDDEN_ENV_NAMES.includes(name)) {
+    throw new Error(`Forbidden environment variable name: ${name}`);
+  }
+  if (name.startsWith('DYLD_')) {
+    throw new Error(`Forbidden environment variable prefix DYLD_: ${name}`);
+  }
+}
+
+/**
+ * Validates a server configuration for safe subprocess execution.
+ *
+ * `~/.claude/mcp.json` is re-read from disk on every server (re)connection, so
+ * a config that passed validation at `generate` time can later be edited to
+ * add e.g. `LD_PRELOAD` and bypass that one-time check. This re-validates the
+ * command, arguments, and environment variable names on every load, mirroring
+ * `mcp_execution_core::validate_server_config`'s stdio-transport checks
+ * (`command.rs`) — full parity with that function's http/sse checks (URL
+ * scheme, headers, timeouts) is intentionally out of scope, since this bridge
+ * only ever spawns a subprocess and has no http/sse client of its own. Fails
+ * closed by throwing rather than silently stripping the offending value, so
+ * an invalid config surfaces as a clear error instead of an unexpectedly
+ * sanitized spawn.
+ *
+ * @param config - The server configuration to validate
+ * @param serverId - Server identifier, used in error messages
+ * @throws {Error} If the transport is not "stdio", or the command, an argument, or an
+ *   environment variable name is unsafe
+ */
+function validateServerConfig(config: ServerConfig, serverId: string): void {
+  // `{"transport":"http",...}` is a valid mcp.json entry (all ServerConfig fields are
+  // optional on the Rust side), but this bridge only ever spawns a subprocess — reject it
+  // here with a clear message rather than letting `command`/`args` being `undefined` throw
+  // an opaque TypeError out of validateCommandString or Node's own spawn().
+  const transport = config.transport ?? 'stdio';
+  if (transport !== 'stdio') {
+    throw new Error(
+      `Server '${serverId}' is configured for '${transport}' transport, but this generated ` +
+      `runtime bridge only supports stdio transport servers.`
+    );
+  }
+
+  validateCommandString(config.command, `command for server '${serverId}'`);
+
+  const args: unknown = config.args ?? [];
+  if (!Array.isArray(args)) {
+    throw new Error(`args for server '${serverId}' must be an array of strings`);
+  }
+  args.forEach((arg, idx) => {
+    validateCommandString(arg, `argument ${idx} for server '${serverId}'`);
+  });
+
+  for (const envName of Object.keys(config.env ?? {})) {
+    validateEnvName(envName);
+  }
+}
+
+/**
  * Load server configuration from filesystem
  *
- * Looks for config in ~/.claude/mcp.json under mcpServers.{serverId}
+ * Looks for config in ~/.claude/mcp.json under mcpServers.{serverId}. The
+ * resolved configuration is validated via {@link validateServerConfig} before
+ * being returned, since this file can be edited after code generation.
  *
  * @param serverId - Server identifier (e.g., "github", "gdrive")
  * @returns Server configuration
- * @throws {Error} If config file not found or serverId not in config
+ * @throws {Error} If config file not found, serverId not in config, or the
+ *   resolved configuration fails security validation
  */
 async function loadServerConfig(serverId: string): Promise<ServerConfig> {
   const configPath = join(homedir(), '.claude', 'mcp.json');
@@ -133,7 +258,9 @@ async function loadServerConfig(serverId: string): Promise<ServerConfig> {
       );
     }
 
-    return config.mcpServers[serverId];
+    const serverConfig: ServerConfig = config.mcpServers[serverId];
+    validateServerConfig(serverConfig, serverId);
+    return serverConfig;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new Error(

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -668,8 +668,8 @@ fn test_generated_tool_passes_tsc_noemit() {
 }
 
 /// Compiles `bridge_ts` (the rendered runtime bridge) alongside a harness that calls
-/// `callMCPTool(server_id, "noop", {})`, runs it under Node with `$HOME` pointed at a temp
-/// directory containing `mcp_json` as `~/.claude/mcp.json`, and returns
+/// `callMCPTool(server_id, "noop", {})`, runs it under Node with `$HOME`/`%USERPROFILE%`
+/// pointed at a temp directory containing `mcp_json` as `~/.claude/mcp.json`, and returns
 /// `(exit_success, stdout, stderr)`.
 ///
 /// Uses `tsc --noCheck` (type-erasure only, no type-checking) so this doesn't need
@@ -763,7 +763,12 @@ fn run_bridge_harness(
     std::thread::spawn(move || {
         let result = Command::new("node")
             .arg(&harness_path)
+            // Node's `os.homedir()` — which `loadServerConfig()` uses to find
+            // `~/.claude/mcp.json` — reads `$HOME` on POSIX but `%USERPROFILE%` on Windows;
+            // both must point at the fake home directory for the harness to isolate itself
+            // from the real runner's home on every platform.
             .env("HOME", &home_dir)
+            .env("USERPROFILE", &home_dir)
             .output();
         let _ = tx.send(result);
     });

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -506,6 +506,18 @@ fn test_progressive_tool_with_complex_types() {
     );
 }
 
+/// Name of the `tsc` executable to spawn directly via [`std::process::Command`].
+///
+/// `npm install -g typescript` installs `tsc` as a `.cmd`/`.ps1` shim script on Windows, not
+/// a `.exe`. Windows' `CreateProcess` (which `Command` calls into directly, bypassing a
+/// shell) only appends the `.exe` extension when none is given — it does not consult
+/// `PATHEXT` the way `cmd.exe` does — so `Command::new("tsc")` silently fails to find it even
+/// though `tsc` resolves fine when typed at a Windows shell prompt. Elsewhere, the real `tsc`
+/// binary (or symlink to one) is on `PATH` unqualified.
+const fn tsc_program() -> &'static str {
+    if cfg!(windows) { "tsc.cmd" } else { "tsc" }
+}
+
 /// Ensures `tsc` (and, if `require_node`, `node`) are available on `PATH` before a test that
 /// depends on the TypeScript/Node toolchain runs.
 ///
@@ -519,7 +531,10 @@ fn test_progressive_tool_with_complex_types() {
 ///
 /// Returns `true` if the required tools are present and the test should proceed.
 fn require_ts_toolchain(test_name: &str, require_node: bool) -> bool {
-    let tsc_missing = Command::new("tsc").arg("--version").output().is_err();
+    let tsc_missing = Command::new(tsc_program())
+        .arg("--version")
+        .output()
+        .is_err();
     let node_missing = require_node && Command::new("node").arg("--version").output().is_err();
 
     if !tsc_missing && !node_missing {
@@ -637,7 +652,7 @@ fn test_generated_tool_passes_tsc_noemit() {
     )
     .expect("Failed to write tsconfig.json");
 
-    let output = Command::new("tsc")
+    let output = Command::new(tsc_program())
         .arg("--noEmit")
         .arg("-p")
         .arg(dir.path().join("tsconfig.json"))
@@ -723,7 +738,7 @@ fn run_bridge_harness(
     .expect("Failed to write harness.ts");
 
     let dist_dir = dir.path().join("dist");
-    let tsc_output = Command::new("tsc")
+    let tsc_output = Command::new(tsc_program())
         .args(["--noCheck", "--module", "NodeNext", "--moduleResolution"])
         .arg("NodeNext")
         .arg("--target")

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -506,18 +506,54 @@ fn test_progressive_tool_with_complex_types() {
     );
 }
 
+/// Ensures `tsc` (and, if `require_node`, `node`) are available on `PATH` before a test that
+/// depends on the TypeScript/Node toolchain runs.
+///
+/// In CI (the `CI` env var is set — GitHub Actions sets it for every job) a missing
+/// toolchain is a hard test failure rather than a silent skip: these tests exist
+/// specifically to catch TypeScript-level regressions (e.g. #201's runtime-bridge
+/// validation, #176's generated-wrapper type errors) that no Rust-only check can see, and a
+/// CI runner missing Node/tsc would otherwise report green while running zero of that
+/// coverage. Locally (no `CI` env var), a missing toolchain just skips the test with a
+/// message, since not everyone running `cargo test` has Node installed.
+///
+/// Returns `true` if the required tools are present and the test should proceed.
+fn require_ts_toolchain(test_name: &str, require_node: bool) -> bool {
+    let tsc_missing = Command::new("tsc").arg("--version").output().is_err();
+    let node_missing = require_node && Command::new("node").arg("--version").output().is_err();
+
+    if !tsc_missing && !node_missing {
+        return true;
+    }
+
+    let missing = match (tsc_missing, node_missing) {
+        (true, true) => "`tsc` and `node`",
+        (true, false) => "`tsc`",
+        (false, true) => "`node`",
+        (false, false) => unreachable!("checked above"),
+    };
+
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{test_name}: {missing} not found on PATH in CI — this test exists to catch \
+         TypeScript-level regressions and must not silently skip in CI. Install Node.js and \
+         run `npm install -g typescript` in this CI job."
+    );
+
+    eprintln!("skipping {test_name}: {missing} not found on PATH");
+    false
+}
+
 /// Regression guard for #176: generated tool wrappers must actually type-check under
 /// `tsc --strict --noEmit`, not merely contain the right substrings. Type-checks the real
 /// generated `createIssue.ts` against a minimal stub of `callMCPTool` (mirroring the
 /// signature declared in `runtime-bridge.ts.hbs`) rather than the full runtime bridge, so
 /// the test stays offline and doesn't depend on `@types/node` being installed.
 ///
-/// Skips (does not fail) when `tsc` is not on `PATH`, since the TypeScript toolchain isn't
-/// guaranteed to be present in every environment this suite runs in.
+/// Skips locally (hard-fails in CI — see `require_ts_toolchain`) when `tsc` is not on `PATH`.
 #[test]
 fn test_generated_tool_passes_tsc_noemit() {
-    if Command::new("tsc").arg("--version").output().is_err() {
-        eprintln!("skipping test_generated_tool_passes_tsc_noemit: `tsc` not found on PATH");
+    if !require_ts_toolchain("test_generated_tool_passes_tsc_noemit", false) {
         return;
     }
 
@@ -613,5 +649,242 @@ fn test_generated_tool_passes_tsc_noemit() {
         "tsc --noEmit failed on generated createIssue.ts:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Compiles `bridge_ts` (the rendered runtime bridge) alongside a harness that calls
+/// `callMCPTool(server_id, "noop", {})`, runs it under Node with `$HOME` pointed at a temp
+/// directory containing `mcp_json` as `~/.claude/mcp.json`, and returns
+/// `(exit_success, stdout, stderr)`.
+///
+/// Uses `tsc --noCheck` (type-erasure only, no type-checking) so this doesn't need
+/// `@types/node` installed to resolve the bridge's Node builtin imports (`child_process`,
+/// `fs/promises`, `os`, `path`, `stream`).
+///
+/// A hostile/unvalidated config that reaches `spawn()` can hang forever here (the bridge
+/// waits on a JSON-RPC response from a subprocess that will never send one) — that's
+/// exactly the failure mode these tests exist to catch, so the harness itself races a 5s
+/// watchdog against `callMCPTool`'s promise, and this helper additionally bounds the whole
+/// Node run at 15s so a regression fails the test suite instead of hanging it.
+///
+/// Returns `None` if `tsc`/`node` are not on `PATH` and the caller should skip locally; hard
+/// fails (via `require_ts_toolchain`) instead of returning `None` when running in CI.
+fn run_bridge_harness(
+    test_name: &str,
+    bridge_ts: &str,
+    mcp_json: &serde_json::Value,
+    server_id: &str,
+) -> Option<(bool, String, String)> {
+    if !require_ts_toolchain(test_name, true) {
+        return None;
+    }
+
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let home_dir = dir.path().join("home");
+    let claude_dir = home_dir.join(".claude");
+    std::fs::create_dir_all(&claude_dir).expect("Failed to create fake $HOME/.claude");
+    std::fs::write(claude_dir.join("mcp.json"), mcp_json.to_string())
+        .expect("Failed to write mcp.json");
+
+    let src_dir = dir.path().join("src");
+    std::fs::create_dir_all(&src_dir).expect("Failed to create src dir");
+    // `--module NodeNext` picks CJS vs. ESM emit per-file based on the nearest
+    // `package.json`'s "type" field, resolved from the *source* file's location — not the
+    // `--outDir`. Without this, tsc silently emits CommonJS (`require`/`exports`), which
+    // then fails at runtime once Node sees `dist/package.json`'s `"type": "module"`.
+    std::fs::write(src_dir.join("package.json"), "{\"type\":\"module\"}\n")
+        .expect("Failed to write src/package.json");
+    std::fs::write(src_dir.join("mcp-bridge.ts"), bridge_ts)
+        .expect("Failed to write mcp-bridge.ts");
+    std::fs::write(
+        src_dir.join("harness.ts"),
+        format!(
+            "import {{ callMCPTool }} from './mcp-bridge.js';\n\
+             \n\
+             const watchdog = setTimeout(() => {{\n\
+             \x20\x20console.log('TIMEOUT: did not settle before spawning');\n\
+             \x20\x20process.exit(2);\n\
+             }}, 5000);\n\
+             \n\
+             callMCPTool('{server_id}', 'noop', {{}}).then(\n\
+             \x20\x20() => {{\n\
+             \x20\x20\x20\x20clearTimeout(watchdog);\n\
+             \x20\x20\x20\x20console.log('UNEXPECTED_SUCCESS');\n\
+             \x20\x20\x20\x20process.exit(1);\n\
+             \x20\x20}},\n\
+             \x20\x20(err: unknown) => {{\n\
+             \x20\x20\x20\x20clearTimeout(watchdog);\n\
+             \x20\x20\x20\x20console.log('REJECTED:', String(err));\n\
+             \x20\x20\x20\x20process.exit(0);\n\
+             \x20\x20}}\n\
+             );\n"
+        ),
+    )
+    .expect("Failed to write harness.ts");
+
+    let dist_dir = dir.path().join("dist");
+    let tsc_output = Command::new("tsc")
+        .args(["--noCheck", "--module", "NodeNext", "--moduleResolution"])
+        .arg("NodeNext")
+        .arg("--target")
+        .arg("ES2022")
+        .arg("--outDir")
+        .arg(&dist_dir)
+        .arg(src_dir.join("mcp-bridge.ts"))
+        .arg(src_dir.join("harness.ts"))
+        .output()
+        .expect("Failed to run tsc");
+    assert!(
+        tsc_output.status.success(),
+        "tsc failed to compile the rendered runtime bridge:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&tsc_output.stdout),
+        String::from_utf8_lossy(&tsc_output.stderr)
+    );
+    std::fs::write(dist_dir.join("package.json"), "{\"type\":\"module\"}\n")
+        .expect("Failed to write dist/package.json");
+
+    let harness_path = dist_dir.join("harness.js");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let result = Command::new("node")
+            .arg(&harness_path)
+            .env("HOME", &home_dir)
+            .output();
+        let _ = tx.send(result);
+    });
+
+    let output = rx
+        .recv_timeout(std::time::Duration::from_secs(15))
+        .unwrap_or_else(|_| {
+            panic!(
+                "node harness did not exit within 15s; the bridge may be hanging on an \
+                 unvalidated spawn instead of rejecting the hostile config"
+            )
+        })
+        .expect("Failed to run node");
+
+    Some((
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+/// Behavioral regression guard for #201: a hostile `~/.claude/mcp.json` entry (a forbidden
+/// `LD_PRELOAD` env var) must be rejected by the rendered `_runtime/mcp-bridge.ts` before it
+/// ever spawns the configured subprocess. Unlike a string-grep over the rendered source (see
+/// `test_generate_runtime_bridge_declares_forbidden_env_var_list` in
+/// `progressive/generator.rs`, which can pass even against dead/unreachable validation code),
+/// this actually compiles and executes the bridge under Node.
+///
+/// Skips (does not fail) when `tsc` or `node` is not on `PATH`.
+#[test]
+fn test_runtime_bridge_rejects_forbidden_env_var_before_spawn() {
+    let generator = ProgressiveGenerator::new().expect("Failed to create generator");
+    let server_info = create_test_server_info();
+    let code = generator
+        .generate(&server_info)
+        .expect("Failed to generate code");
+    let bridge = code
+        .files
+        .iter()
+        .find(|f| f.path == "_runtime/mcp-bridge.ts")
+        .expect("_runtime/mcp-bridge.ts not found");
+
+    // Benign command/args (no shell metacharacters) so the metacharacter check doesn't fire
+    // first and mask the env-var check under test.
+    let mcp_json = json!({
+        "mcpServers": {
+            "github": {
+                "command": "node",
+                "args": ["--version"],
+                "env": { "LD_PRELOAD": "/tmp/evil.so" }
+            }
+        }
+    });
+
+    // `require_ts_toolchain` (called inside `run_bridge_harness`) already prints the skip
+    // reason locally and hard-fails in CI, so a missing toolchain here just means "skip".
+    let Some((success, stdout, stderr)) = run_bridge_harness(
+        "test_runtime_bridge_rejects_forbidden_env_var_before_spawn",
+        &bridge.content,
+        &mcp_json,
+        "github",
+    ) else {
+        return;
+    };
+
+    assert!(
+        success,
+        "bridge did not reject the hostile LD_PRELOAD config before spawning:\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("REJECTED:"),
+        "expected the bridge to reject the config: stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("LD_PRELOAD"),
+        "rejection reason should name the forbidden env var: {stdout}"
+    );
+}
+
+/// Behavioral regression guard for #201's critic follow-up (S3): `{"transport":"http",...}`
+/// is a valid `mcp.json` entry since #200 (all `ServerConfig` fields are `#[serde(default)]`
+/// on the Rust side). Before this fix, the bridge's validator called `.trim()` on the
+/// `undefined` `command`/`args` an http-transport entry has, throwing an opaque
+/// `TypeError: Cannot read properties of undefined (reading 'trim')`. This runtime bridge
+/// only ever spawns a subprocess (stdio transport); a non-stdio config must be rejected with
+/// a clear, intentional error instead of that crash.
+///
+/// Skips (does not fail) when `tsc` or `node` is not on `PATH`.
+#[test]
+fn test_runtime_bridge_rejects_http_transport_with_clear_error_not_crash() {
+    let generator = ProgressiveGenerator::new().expect("Failed to create generator");
+    let server_info = create_test_server_info();
+    let code = generator
+        .generate(&server_info)
+        .expect("Failed to generate code");
+    let bridge = code
+        .files
+        .iter()
+        .find(|f| f.path == "_runtime/mcp-bridge.ts")
+        .expect("_runtime/mcp-bridge.ts not found");
+
+    let mcp_json = json!({
+        "mcpServers": {
+            "github": {
+                "transport": "http",
+                "url": "https://api.example.com/mcp"
+            }
+        }
+    });
+
+    // `require_ts_toolchain` (called inside `run_bridge_harness`) already prints the skip
+    // reason locally and hard-fails in CI, so a missing toolchain here just means "skip".
+    let Some((success, stdout, stderr)) = run_bridge_harness(
+        "test_runtime_bridge_rejects_http_transport_with_clear_error_not_crash",
+        &bridge.content,
+        &mcp_json,
+        "github",
+    ) else {
+        return;
+    };
+
+    assert!(
+        success,
+        "bridge did not reject the http-transport config cleanly:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("REJECTED:"),
+        "expected the bridge to reject the config: stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("Cannot read properties of undefined"),
+        "must fail with a clear, intentional error, not the pre-fix opaque TypeError: {stdout}"
+    );
+    assert!(
+        stdout.contains("http") || stdout.contains("transport"),
+        "rejection reason should mention the unsupported transport: {stdout}"
     );
 }

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -45,7 +45,9 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
     "DYLD_INSERT_LIBRARIES",
     "DYLD_LIBRARY_PATH",
     "DYLD_FRAMEWORK_PATH",
-    "PATH", // Block PATH override to prevent binary substitution
+    "PATH",         // Block PATH override to prevent binary substitution
+    "NODE_OPTIONS", // Lets a config inject e.g. `--require /tmp/evil.js` into any Node subprocess
+    "BASH_ENV",     // Sourced by non-interactive `bash` before running a script/command
 ];
 
 /// Upper bound for `connect_timeout`/`discover_timeout`, matching the
@@ -67,7 +69,8 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 /// # Security Rules
 ///
 /// - **Forbidden chars in command/args**: `;`, `|`, `&`, `>`, `<`, `` ` ``, `$`, `(`, `)`, `\n`, `\r`
-/// - **Forbidden env names**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*`, `PATH`
+/// - **Forbidden env names**: `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*`, `PATH`,
+///   `NODE_OPTIONS`, `BASH_ENV`
 /// - **Absolute paths**: Must exist and be executable
 /// - **Binary names**: Allowed (resolved via PATH at runtime)
 /// - **URL scheme**: Must be `http://` or `https://`
@@ -593,6 +596,38 @@ mod tests {
         assert!(result.is_err());
         if let Err(Error::SecurityViolation { reason }) = result {
             assert!(reason.contains("PATH"));
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_forbidden_env_node_options() {
+        // NODE_OPTIONS lets a config inject e.g. `--require /tmp/evil.js` into any Node
+        // subprocess the server itself spawns.
+        let config = ServerConfig::builder()
+            .command("node".to_string())
+            .env(
+                "NODE_OPTIONS".to_string(),
+                "--require /tmp/evil.js".to_string(),
+            )
+            .build();
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("NODE_OPTIONS"));
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_forbidden_env_bash_env() {
+        // BASH_ENV is sourced by non-interactive `bash` before running a script or command.
+        let config = ServerConfig::builder()
+            .command("bash".to_string())
+            .env("BASH_ENV".to_string(), "/tmp/evil.sh".to_string())
+            .build();
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("BASH_ENV"));
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes #204: `TemplateEngine` no longer HTML-escapes Handlebars output. Generated templates interpolate tool/server metadata into TypeScript JSDoc comments, not HTML, so the default escaping of `&`, `<`, `>`, `"`, `'` was corrupting benign punctuation in generated source. JSDoc injection protection continues to come from `sanitize_jsdoc`'s `*/`-stripping (now also covering U+2028/U+2029 line terminators), unaffected by this change.
- Fixes #201: the generated runtime bridge re-read `~/.claude/mcp.json` unvalidated at every tool call, bypassing the forbidden-env-var/shell-metacharacter checks `validate_server_config` only ever applied once, at `generate` time. The bridge now re-validates each stdio server's command, arguments, and environment variable names against the same rules before every `spawn()` call, failing closed. This is defense-in-depth, not full closure — see the CHANGELOG entry and the follow-up issue for residual gaps (non-exhaustive env-var list, no parity with http/sse validation, no Rust/TS drift guard).

**BREAKING CHANGE:** the forbidden-env-var check now runs on every tool invocation via the generated bridge, not just once at `generate` time. An `mcp.json` entry that legitimately pins `PATH` or `LD_LIBRARY_PATH` (e.g. for an nvm/pyenv/Homebrew-wrapped server) previously worked at call time and will now fail closed.

## Test plan

- [x] `cargo nextest run --all-features --workspace --no-fail-fast` — full suite passes, including two new Node-executed behavioral tests for the bridge validation
- [x] `cargo test --doc --all-features --workspace`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo +nightly fmt --check`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] CI workflow updated (`actions/setup-node` + global `tsc`) so the new bridge-validation tests actually execute in CI instead of silently skipping; verified locally both with and without the toolchain present
- [x] Manually mutation-tested the new regression tests (reverting each fix independently causes the corresponding test to fail)