### PR TITLE
fix(server): bound stdio JSON-RPC request line size before deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so they classify as `ExitCode::INVALID_INPUT` (2) instead of the generic `ExitCode::ERROR` (1)
   (#195).
 
+- **`mcp-execution-server`**: the stdio transport buffered incoming JSON-RPC request lines
+  without any size limit (`rmcp`'s `stdio()` reads via an unbounded `BufReader::read_until`,
+  bypassing its own codec's length check), so a single oversized line could grow memory use
+  without bound (#213). This closes the residual gap noted below in the `save_categorized_tools`
+  fix (#197), which bounded the processed array but not the raw wire payload. `main.rs` now
+  builds the transport from a `FramedRead`/`FramedWrite` pair using
+  `JsonRpcMessageCodec::new_with_max_length` (4 MiB cap) instead of `stdio()` directly; note the
+  cap bounds peak buffer growth to roughly 4x itself (~16 MiB), not 1:1, since `tokio_util`'s
+  internal buffer only checks the bound after doubling its capacity on a read — still strictly
+  bounded, just not as tight as the raw constant suggests. Because `tokio_util`'s `FramedImpl`
+  treats any decode error as terminal (the poll immediately following an `Err` unconditionally
+  yields `None`, ending the stream), a `bounded_request_stream` wrapper (now generic over
+  `AsyncRead` and unit-tested) swallows exactly that one sentinel `None` for a line-length or
+  parse error so an oversized or malformed line is dropped (logged via `tracing::warn!`) without
+  dropping the whole session — a genuine I/O error on the underlying reader still ends the
+  session, matching the prior transport's behavior.
+
 - **`mcp-execution-cli`**: a `~/.claude/mcp.json` mixing stdio entries with http/sse entries
   (`{"type": "http", "url": "...", ...}`, no `command` key) failed to deserialize the *entire*
   file with a misleading "missing field `command`" error, since `McpServerEntry` hardcoded a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs",
+ "futures-util",
  "mcp-execution-codegen",
  "mcp-execution-core",
  "mcp-execution-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ criterion = "0.8"
 dhat = "0.3"
 dialoguer = "0.12"
 dirs = "6.0"
+futures-util = "0.3"
 handlebars = "6.4"
 http = "1"
 mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.8.0" }

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
+futures-util = { workspace = true }
 mcp-execution-codegen = { workspace = true }
 mcp-execution-core = { workspace = true }
 mcp-execution-files = { workspace = true }
@@ -36,7 +37,7 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
     "sync",
 ] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4", "serde"] }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -25,10 +25,86 @@
 //! ```
 
 use anyhow::Result;
+use futures_util::StreamExt;
+use futures_util::stream::{self, Stream};
 use mcp_execution_server::service::GeneratorService;
+use rmcp::RoleServer;
 use rmcp::ServiceExt;
+use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::transport::async_rw::{JsonRpcMessageCodec, JsonRpcMessageCodecError};
 use rmcp::transport::stdio;
+use std::task::Poll;
+use tokio::io::AsyncRead;
+use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Maximum size, in bytes, of a single newline-delimited JSON-RPC request read from
+/// stdin. Requests exceeding this are discarded rather than buffered without bound.
+///
+/// `rmcp`'s [`stdio`] transport reads lines via an unbounded `BufReader::read_until`,
+/// so the cap is enforced here by wiring the stdin side through
+/// [`JsonRpcMessageCodec::new_with_max_length`] instead of using `stdio()` directly.
+/// 4 MiB leaves headroom over the largest legitimate payload (`save_categorized_tools`
+/// with `MAX_TOOL_FILES` entries, or a `MAX_SKILL_CONTENT_SIZE` skill body), both under
+/// 1 MiB — but this constant is *not* the peak resident buffer size: `tokio_util`'s
+/// internal read buffer grows by doubling and is only checked against this bound after
+/// each read fills whatever capacity it already reserved, so an attacker's oversized
+/// line can push peak buffer capacity to roughly 4x this value (measured ~16 MiB for a
+/// 4 MiB cap) before it is rejected. Still strictly bounded, just not 1:1 with the cap.
+const MAX_REQUEST_LINE_SIZE: usize = 4 * 1024 * 1024;
+
+/// Wraps a size-bounded [`FramedRead`] so one oversized or malformed line drops that
+/// request without ending the session, while a genuine I/O error still ends it.
+///
+/// `tokio_util`'s `FramedImpl` treats any `Decoder::decode` error as terminal: the poll
+/// immediately after an `Err` unconditionally returns `None`, which `Stream` consumers
+/// (including `rmcp`'s transport) read as end-of-stream. `JsonRpcMessageCodecError`
+/// carries both cases through that same `Err` channel, so they must be told apart:
+/// [`JsonRpcMessageCodecError::MaxLineLengthExceeded`] and `::Serde` mean "one bad line",
+/// and we swallow the mandatory sentinel `None` that follows to keep the connection
+/// alive; `::Io` means the underlying reader itself is broken (e.g. a closed or
+/// orphaned fd erroring on every poll), and re-swallowing it would spin the task at
+/// 100% CPU forever, so it is left fatal, matching the prior `stdio()` transport's
+/// behavior on a read error. The enum is `#[non_exhaustive]`; unknown future variants
+/// are treated as recoverable, consistent with the two known non-I/O cases.
+fn bounded_request_stream<R>(
+    reader: R,
+    max_length: usize,
+) -> impl Stream<Item = RxJsonRpcMessage<RoleServer>> + Send + Unpin + 'static
+where
+    R: AsyncRead + Send + Unpin + 'static,
+{
+    let mut framed = FramedRead::new(
+        reader,
+        JsonRpcMessageCodec::<RxJsonRpcMessage<RoleServer>>::new_with_max_length(max_length),
+    );
+    let mut recovering_from_error = false;
+    stream::poll_fn(move |cx| {
+        loop {
+            return match framed.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(message))) => {
+                    recovering_from_error = false;
+                    Poll::Ready(Some(message))
+                }
+                Poll::Ready(Some(Err(JsonRpcMessageCodecError::Io(error)))) => {
+                    tracing::error!(%error, "stdin read failed; ending session");
+                    Poll::Ready(None)
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    tracing::warn!(%error, "dropping oversized or malformed request line");
+                    recovering_from_error = true;
+                    continue;
+                }
+                Poll::Ready(None) if recovering_from_error => {
+                    recovering_from_error = false;
+                    continue;
+                }
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+    })
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -50,10 +126,214 @@ async fn main() -> Result<()> {
         env!("CARGO_PKG_VERSION")
     );
 
-    // Create and run the service with stdio transport
-    let service = GeneratorService::new().serve(stdio()).await?;
+    // Wire stdio through a size-bounded codec instead of `stdio()` directly: the
+    // default transport's read path bypasses the codec's max-length check entirely.
+    let (stdin, stdout) = stdio();
+    let sink = FramedWrite::new(
+        stdout,
+        JsonRpcMessageCodec::<TxJsonRpcMessage<RoleServer>>::new(),
+    );
+    let stream = bounded_request_stream(stdin, MAX_REQUEST_LINE_SIZE);
+
+    let service = GeneratorService::new().serve((sink, stream)).await?;
     service.waiting().await?;
 
     tracing::info!("Server shutdown complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncRead, StreamExt, bounded_request_stream};
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll};
+    use tokio::io::ReadBuf;
+
+    const TEST_MAX: usize = 64;
+
+    fn oversized_line() -> Vec<u8> {
+        let mut line = vec![b'x'; TEST_MAX * 3];
+        line.push(b'\n');
+        line
+    }
+
+    fn valid_notification_line() -> Vec<u8> {
+        br#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#
+            .iter()
+            .copied()
+            .chain(std::iter::once(b'\n'))
+            .collect()
+    }
+
+    /// `AsyncRead` that yields a fixed script of chunks in order, then a clean EOF.
+    struct Script {
+        chunks: Vec<Vec<u8>>,
+        idx: usize,
+    }
+
+    impl AsyncRead for Script {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            if self.idx < self.chunks.len() {
+                let chunk = self.chunks[self.idx].clone();
+                self.idx += 1;
+                debug_assert!(
+                    chunk.len() <= buf.remaining(),
+                    "test fixture chunk exceeds the reader's spare buffer capacity"
+                );
+                buf.put_slice(&chunk);
+                return Poll::Ready(Ok(()));
+            }
+            Poll::Ready(Ok(())) // 0 bytes read signals EOF
+        }
+    }
+
+    /// Number of times [`ErrAfter`] returns a real error before giving up and
+    /// signaling EOF. Bounds the fixture itself so that if a regression ever makes
+    /// `bounded_request_stream` treat an I/O error as recoverable again, the resulting
+    /// test fails its assertion instead of spinning forever with no `Poll::Pending`.
+    const MAX_ERR_AFTER_POLLS: usize = 8;
+
+    /// `AsyncRead` that yields a fixed script, then a persistent I/O error up to
+    /// [`MAX_ERR_AFTER_POLLS`] times, then a clean EOF; counts how many errors it returned.
+    struct ErrAfter {
+        chunks: Vec<Vec<u8>>,
+        idx: usize,
+        error_polls: Arc<AtomicUsize>,
+    }
+
+    impl AsyncRead for ErrAfter {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            if self.idx < self.chunks.len() {
+                let chunk = self.chunks[self.idx].clone();
+                self.idx += 1;
+                debug_assert!(
+                    chunk.len() <= buf.remaining(),
+                    "test fixture chunk exceeds the reader's spare buffer capacity"
+                );
+                buf.put_slice(&chunk);
+                return Poll::Ready(Ok(()));
+            }
+            if self.error_polls.fetch_add(1, Ordering::SeqCst) >= MAX_ERR_AFTER_POLLS {
+                return Poll::Ready(Ok(())); // give up: signal EOF so a regression fails loudly
+            }
+            Poll::Ready(Err(io::Error::other("persistent read failure")))
+        }
+    }
+
+    #[tokio::test]
+    async fn recovers_from_oversized_lines_and_keeps_serving() {
+        let script = Script {
+            chunks: vec![
+                oversized_line(),
+                oversized_line(),
+                valid_notification_line(),
+            ],
+            idx: 0,
+        };
+        let mut stream = bounded_request_stream(script, TEST_MAX);
+
+        assert!(
+            stream.next().await.is_some(),
+            "the trailing valid line must still decode after two oversized lines"
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "stream ends cleanly at EOF after the valid message"
+        );
+    }
+
+    #[tokio::test]
+    async fn ends_cleanly_when_oversized_line_is_last_before_eof() {
+        let script = Script {
+            chunks: vec![oversized_line()],
+            idx: 0,
+        };
+        let mut stream = bounded_request_stream(script, TEST_MAX);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ends_cleanly_on_unterminated_oversized_line_then_eof() {
+        let script = Script {
+            chunks: vec![vec![b'y'; TEST_MAX * 3]], // no trailing newline
+            idx: 0,
+        };
+        let mut stream = bounded_request_stream(script, TEST_MAX);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ends_session_on_persistent_io_error_without_spinning() {
+        let error_polls = Arc::new(AtomicUsize::new(0));
+        let reader = ErrAfter {
+            chunks: vec![valid_notification_line()],
+            idx: 0,
+            error_polls: error_polls.clone(),
+        };
+        let mut stream = bounded_request_stream::<ErrAfter>(reader, TEST_MAX);
+
+        assert!(
+            stream.next().await.is_some(),
+            "the valid line decodes before the reader starts failing"
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "a persistent I/O error must end the session rather than recover"
+        );
+        assert_eq!(
+            error_polls.load(Ordering::SeqCst),
+            1,
+            "the I/O error must be surfaced on the first failing poll, not retried in a hot loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_line_at_exact_cap_and_rejects_one_byte_over() {
+        // The codec's length check runs on raw byte count before any JSON parsing, so
+        // the rejected case doesn't need to be valid JSON — only the accepted case does.
+        let mut content = valid_notification_line();
+        assert_eq!(content.pop(), Some(b'\n'), "fixture must end in a newline");
+        let boundary_max = content.len();
+
+        let mut at_cap = content.clone();
+        at_cap.push(b'\n');
+        let mut stream = bounded_request_stream(
+            Script {
+                chunks: vec![at_cap],
+                idx: 0,
+            },
+            boundary_max,
+        );
+        assert!(
+            stream.next().await.is_some(),
+            "a line whose content is exactly max_length bytes must be accepted"
+        );
+        assert!(stream.next().await.is_none());
+
+        let mut one_over = content;
+        one_over.push(b' ');
+        one_over.push(b'\n');
+        let mut stream = bounded_request_stream(
+            Script {
+                chunks: vec![one_over],
+                idx: 0,
+            },
+            boundary_max,
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "a line one byte over max_length must be dropped, not accepted"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `mcp-execution-server`'s stdio transport had no line-length limit: `rmcp`'s `stdio()` reads via an unbounded `BufReader::read_until`, bypassing its own codec's length check, so a single oversized JSON-RPC request line was fully buffered and deserialized before any application-level validation ran (CWE-400). This is the ingestion-side residual left after the `save_categorized_tools` array-size cap only bounded the *processed* array, not the raw wire payload.
- Replaced `stdio()` with a manually constructed `(FramedWrite, FramedRead)` transport pair using `JsonRpcMessageCodec::new_with_max_length`, capping request lines at 4 MiB (real legitimate payloads, e.g. `MAX_TOOL_FILES`/`MAX_SKILL_CONTENT_SIZE`, stay well under 1 MiB).
- Added a `bounded_request_stream` wrapper: `tokio_util`'s `FramedImpl` treats a decode error as terminal (the poll following an `Err` unconditionally yields `None`, ending the stream), so a naive adapter would kill the whole session on the first oversized or malformed line. The wrapper swallows exactly that one sentinel `None` for a line-length/parse error (logging it via `tracing::warn!`) while still treating a genuine I/O error on the reader as fatal, matching the prior transport's behavior.
- One fix point covers all five `#[tool]` handlers, since the cap is transport-level, not per-handler.

## Notes for reviewers

- Two related client-side gaps were found during the security audit but are out of scope here and upstream-blocked in `rmcp` 2.2.0 (no injection point available): unbounded stdio read in `mcp-execution-introspector`'s `TokioChildProcess` usage, and unbounded HTTP/SSE body size in `StreamableHttpClientTransportConfig`. Will file follow-up tracking issues separately.
- Known, accepted tradeoff: the old transport replied with an `invalid_request` JSON-RPC error for JSON-valid-but-wrong-shape requests; this transport drops those silently to the client instead (logged server-side via `tracing::warn!`). Not security-relevant.
- The 4 MiB cap bounds peak buffer growth to roughly 4x itself (~16 MiB), not 1:1, since `tokio_util`'s internal buffer doubles capacity on a read before the length check fires — still strictly bounded, documented in the code comment and CHANGELOG.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (831/831)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New unit tests: recovery from one oversized line, back-to-back oversized lines, EOF while recovering, persistent I/O error terminates the stream (regression guard for the hot-loop bug found during review), and exact boundary (`max_length` accepted, `max_length + 1` rejected)
- [x] Manual live smoke test against the built binary: oversized line dropped and logged, session stays alive, subsequent requests still answered correctly

Closes #213