### PR TITLE
fix(core): redact secret-shaped header names/values and ServerConfig Debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   control characters (never legitimate in a header/env name) before it can reach that assumption
   (#190).
 
+- **`mcp-execution-core`**: `validate_network_config`'s duplicate-header-name check echoed the
+  raw header name verbatim in its `SecurityViolation` reason, even though the check only runs
+  after `validate_header_name_string` has already accepted the name as RFC 7230 `token`-charset
+  only (alphanumerics plus `` !#$%&'*+-.^_`|~ ``) — a misparsed CLI argument whose "key" portion
+  happens to be entirely token-charset (e.g. a hex-encoded key or a JWT-like value using only
+  `A-Za-z0-9-_.`) could still be echoed in full if it collided case-insensitively with another
+  header name. The duplicate-header error message no longer includes the name (#228).
+  `validate_header_name_string`'s own tchar-violation error had the identical leak on a wider,
+  more easily reachable branch (any name with a single character outside the token charset, no
+  collision required) — a `Name=Value` argument mis-split on the wrong `=` could put a full
+  secret in the name position and have it echoed here. That error message no longer includes the
+  name either, closing both the wide and narrow branches of the same leak (#215).
+  `validate_header_value_string`'s control-character error had the same leak on the remaining
+  third branch of the same loop: it always ran after the name had already cleared the
+  token-charset check, so a JWT-shaped or hex-encoded name (e.g. from a `~/.claude/mcp.json`
+  entry, which never goes through the CLI's argument parser at all) was still echoed whenever its
+  paired value contained a control character. That error message is now a static string that
+  omits the name as well.
+
+- **`mcp-execution-core`**: `ServerConfig` derived a plain `Debug` impl, so `headers` and `env` —
+  which routinely carry secrets such as a bearer token or `GITHUB_PERSONAL_ACCESS_TOKEN` — were
+  printed in full by `format!("{config:?}")`, with no redaction applied anywhere in the type
+  itself (unlike the error-message discipline already enforced in `command.rs`). `ServerConfig`
+  now has a hand-written `Debug` impl that keeps `headers`/`env` keys visible but replaces every
+  value with `<redacted>`; `Serialize`/`Deserialize` are unchanged and still round-trip real
+  values for config persistence (#208). `ServerConfigBuilder`, which accumulates the same two
+  maps before `build()`/`try_build()` is called, derived `Debug` over them too and gets the same
+  treatment, reusing the private `RedactedValues` helper introduced for `ServerConfig`.
+
 ### Fixed
 
 - **`mcp-execution-cli`**: `introspect`, `generate`, `skill`, and `setup` now exit with the

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -125,6 +125,11 @@ const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 /// - Environment variables are checked against forbidden names
 /// - Header values are never echoed into error messages, since they routinely
 ///   carry secrets such as bearer tokens
+/// - Header *names* are never echoed either, once rejected: a `Name=Value` or
+///   `Name: Value` CLI argument can be mis-split on the wrong separator,
+///   leaving a full secret value in the "name" position — the token-charset
+///   error, the duplicate-header-name error, and the header-value
+///   control-character error all omit the name for this reason
 /// - There is no infinite-timeout option: `0` is always rejected, since an
 ///   unbounded wait would let a hung server block this non-interactive tool
 ///   forever (see the `validate_timeout` design note in this module)
@@ -194,10 +199,12 @@ fn validate_network_config(config: &ServerConfig) -> Result<()> {
     let mut seen_header_names = std::collections::HashSet::new();
     for (name, value) in config.headers() {
         validate_header_name_string(name)?;
-        validate_header_value_string(name, value)?;
+        validate_header_value_string(value)?;
         if !seen_header_names.insert(name.to_ascii_lowercase()) {
             return Err(Error::SecurityViolation {
-                reason: format!("duplicate header name (case-insensitive): '{name}'"),
+                reason: "duplicate header name (case-insensitive); name omitted as it may \
+                         be secret-shaped"
+                    .to_string(),
             });
         }
     }
@@ -259,9 +266,16 @@ const fn is_header_name_tchar(c: char) -> bool {
 /// A plain control-character check is not tight enough: a space, `:`, or `@`
 /// is not a control character but is still an invalid header-name character
 /// that would otherwise pass here and fail later inside `http::HeaderName`
-/// construction with an opaque error that omits the offending name. The
-/// header name itself is not a secret, so it is safe to include in the error
-/// message.
+/// construction with an opaque error.
+///
+/// # Security
+///
+/// The rejected name is never echoed into the error message. A `Name=Value`
+/// or `Name: Value` CLI argument can be mis-split on the wrong separator,
+/// leaving a full secret value in the "name" position; that value only needs
+/// one non-`tchar` byte to reach this branch, so it must be treated the same
+/// as a secret — mirroring the duplicate-header-name check below, which
+/// redacts for the same reason.
 fn validate_header_name_string(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(Error::SecurityViolation {
@@ -270,9 +284,8 @@ fn validate_header_name_string(name: &str) -> Result<()> {
     }
     if !name.chars().all(is_header_name_tchar) {
         return Err(Error::SecurityViolation {
-            reason: format!(
-                "header name '{name}' contains characters outside the allowed HTTP token charset"
-            ),
+            reason: "header name contains characters outside the allowed HTTP token charset"
+                .to_string(),
         });
     }
     Ok(())
@@ -283,12 +296,16 @@ fn validate_header_name_string(name: &str) -> Result<()> {
 /// # Security
 ///
 /// The header *value* routinely carries secrets (e.g. bearer tokens), so it
-/// must never appear in the returned error's reason string — only the header
-/// *name* is included.
-fn validate_header_value_string(name: &str, value: &str) -> Result<()> {
+/// must never appear in the returned error's reason string. The header
+/// *name* is not echoed either: this runs after `validate_header_name_string`
+/// has already accepted it as RFC 7230 `token`-charset-only, the same
+/// "may still be secret-shaped input from a misparsed argument" condition
+/// that the tchar-violation and duplicate-header-name errors above already
+/// treat as untrusted.
+fn validate_header_value_string(value: &str) -> Result<()> {
     if contains_control_char(value) {
         return Err(Error::SecurityViolation {
-            reason: format!("value for header '{name}' contains control characters"),
+            reason: "header value contains control characters".to_string(),
         });
     }
     Ok(())
@@ -940,6 +957,41 @@ mod tests {
         assert!(result.is_err());
         if let Err(Error::SecurityViolation { reason }) = result {
             assert!(reason.contains("duplicate header"));
+            assert!(!reason.contains("Authorization"));
+            assert!(!reason.to_ascii_lowercase().contains("authorization"));
+        } else {
+            panic!("expected SecurityViolation for duplicate header name");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_duplicate_header_secret_shaped_name() {
+        // A misparsed `Name: Value`-style CLI argument can leave a "key" that
+        // is entirely RFC 7230 token-charset (alphanumerics plus
+        // `!#$%&'*+-.^_`|~`), e.g. a hex-encoded key or JWT-like value using
+        // only `A-Za-z0-9-_.`. Such a name passes `validate_header_name_string`
+        // and must not be echoed if it collides case-insensitively.
+        let secret_name = "eyJhbGciOiJIUzI1NiJ9.super-secret-token-material";
+        let mut config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+        config
+            .headers
+            .insert(secret_name.to_string(), "value one".to_string());
+        config
+            .headers
+            .insert(secret_name.to_ascii_uppercase(), "value two".to_string());
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("duplicate header"));
+            assert!(!reason.contains(secret_name));
+            assert!(
+                !reason
+                    .to_ascii_lowercase()
+                    .contains(&secret_name.to_ascii_lowercase())
+            );
         } else {
             panic!("expected SecurityViolation for duplicate header name");
         }
@@ -961,9 +1013,36 @@ mod tests {
             assert!(result.is_err(), "should reject header name: {bad_name}");
             if let Err(Error::SecurityViolation { reason }) = result {
                 assert!(reason.contains("header name"));
+                assert!(!reason.contains(bad_name));
             } else {
                 panic!("expected SecurityViolation for header name: {bad_name}");
             }
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_secret_shaped_header_name_without_leaking_it() {
+        // Reproduces the #215 leak vector: a `Name=Value` CLI argument
+        // mis-split on the wrong `=` leaves a base64-encoded secret in the
+        // "name" position. It only needs one non-tchar byte (here `/`) to
+        // reach `validate_header_name_string`'s tchar-violation branch,
+        // which must not echo it back.
+        let secret_name = "aGVsbG8/d29ybGQK=supersecretpayload";
+        let mut config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+        config
+            .headers
+            .insert(secret_name.to_string(), "value".to_string());
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("header name"));
+            assert!(!reason.contains(secret_name));
+            assert!(!reason.contains("aGVsbG8"));
+        } else {
+            panic!("expected SecurityViolation for header name");
         }
     }
 
@@ -980,6 +1059,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(Error::SecurityViolation { reason }) = result {
             assert!(reason.contains("header name"));
+            assert!(!reason.contains("X-Bad"));
         } else {
             panic!("expected SecurityViolation for header name");
         }
@@ -998,10 +1078,39 @@ mod tests {
         let result = validate_server_config(&config);
         assert!(result.is_err());
         if let Err(Error::SecurityViolation { reason }) = result {
-            assert!(reason.contains("Authorization"));
-            // The header VALUE must never appear in the error message.
+            assert!(reason.contains("header value"));
+            // Neither the header value nor its (ordinary, non-secret-shaped
+            // here) name need to appear — the name is withheld unconditionally
+            // since this path cannot distinguish an ordinary name from a
+            // secret-shaped one.
+            assert!(!reason.contains("Authorization"));
             assert!(!reason.contains("sekrit"));
             assert!(!reason.contains("X-Injected"));
+        } else {
+            panic!("expected SecurityViolation for header value");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_control_char_in_value_with_secret_shaped_name() {
+        // Reproduces the critic's S5 repro: a JWT-shaped header *name* (fully
+        // RFC 7230 token-charset, so it clears `validate_header_name_string`)
+        // paired with a control character in the *value*. Both the name and
+        // the control-char-bearing value must be absent from the error.
+        let secret_name = "eyJhbGciOiJIUzI1NiJ9.abc-secret_material";
+        let mut config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build();
+        config
+            .headers
+            .insert(secret_name.to_string(), "x\ry".to_string());
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("header value"));
+            assert!(!reason.contains(secret_name));
+            assert!(!reason.contains("eyJhbGciOiJIUzI1NiJ9"));
         } else {
             panic!("expected SecurityViolation for header value");
         }

--- a/crates/mcp-core/src/server_config.rs
+++ b/crates/mcp-core/src/server_config.rs
@@ -46,6 +46,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -104,6 +105,38 @@ pub enum TransportType {
 /// to construct instances, and call [`validate_server_config`] before execution
 /// to ensure security requirements are met.
 ///
+/// `headers` and `env` routinely carry secrets (e.g. an `Authorization: Bearer
+/// <token>` header, or a `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable),
+/// so this type's [`Debug`] implementation is hand-written to redact their
+/// *values* while keeping keys visible — a legitimately configured key (a
+/// chosen header or env var name, e.g. `"Authorization"`) is not itself a
+/// secret and remains useful for debugging. This mirrors the discipline
+/// already applied to header values in `command.rs`'s
+/// `validate_header_value_string`, which never echoes a header value into an
+/// error message.
+///
+/// This is a narrower guarantee than `command.rs`'s header-*name* validation
+/// errors, which redact the name too: those fire on input that has not yet
+/// been confirmed well-formed (e.g. a `Name=Value` CLI argument mis-split on
+/// the wrong separator can leave a secret value sitting in the name
+/// position), so any name reaching that error path must be treated as
+/// secret-shaped. Once [`validate_server_config`] has accepted a config,
+/// its `headers`/`env` keys are the caller's own identifiers rather than
+/// unvalidated split output, so trusting them for `Debug` output is not in
+/// tension with distrusting an unvalidated name in an error message.
+///
+/// [`ServerConfigBuilder`] carries the same [`Debug`] treatment for
+/// consistency, but that guarantee does not extend to it: the builder is
+/// populated *before* [`validate_server_config`] runs, so a caller that
+/// feeds it unvalidated input (e.g. a mis-split CLI argument) can still end
+/// up with a secret-shaped key in `format!("{builder:?}")`. Keys are shown
+/// there deliberately regardless — redacting them would defeat the point of
+/// a debug impl for a type whose purpose is to be inspected before
+/// `build()`/`try_build()`.
+///
+/// `Serialize`/`Deserialize` are deliberately left unredacted: config
+/// persistence and the wire format must still round-trip real values.
+///
 /// # Examples
 ///
 /// ```
@@ -126,8 +159,23 @@ pub enum TransportType {
 ///     .build();
 /// ```
 ///
+/// Debug output redacts header/env values but keeps keys:
+///
+/// ```
+/// use mcp_execution_core::ServerConfig;
+///
+/// let config = ServerConfig::builder()
+///     .http_transport("https://api.example.com/mcp".to_string())
+///     .header("Authorization".to_string(), "Bearer sk-secret-value".to_string())
+///     .build();
+///
+/// let debug_output = format!("{config:?}");
+/// assert!(debug_output.contains("Authorization"));
+/// assert!(!debug_output.contains("sk-secret-value"));
+/// ```
+///
 /// [`validate_server_config`]: fn.validate_server_config.html
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerConfig {
     /// Transport type (stdio or http).
     ///
@@ -160,6 +208,8 @@ pub struct ServerConfig {
     ///
     /// These are added to (or override) the parent process environment.
     /// Security validation blocks dangerous variables like `LD_PRELOAD`.
+    /// Values routinely hold secrets (e.g. `GITHUB_PERSONAL_ACCESS_TOKEN`); see
+    /// the redaction note on [`ServerConfig`]'s own doc comment.
     #[serde(default)]
     pub env: HashMap<String, String>,
 
@@ -191,6 +241,9 @@ pub struct ServerConfig {
     /// Common headers include:
     /// - `Authorization`: Authentication token
     /// - `Content-Type`: Request content type
+    ///
+    /// Values routinely hold secrets (e.g. a bearer token); see the redaction
+    /// note on [`ServerConfig`]'s own doc comment.
     #[serde(default)]
     pub headers: HashMap<String, String>,
 
@@ -207,6 +260,39 @@ pub struct ServerConfig {
     /// `list_all_tools` to respond. Defaults to 30 seconds.
     #[serde(default = "default_discover_timeout")]
     pub discover_timeout: Duration,
+}
+
+/// Debug-formats a `String`-valued map with keys visible and every value
+/// replaced by a fixed placeholder.
+///
+/// Used by `ServerConfig` and `ServerConfigBuilder`'s [`Debug`] impls for
+/// `headers` and `env`, both of which routinely carry secrets (bearer
+/// tokens, API keys). See the redaction note on [`ServerConfig`]'s own doc
+/// comment for why.
+struct RedactedValues<'a>(&'a HashMap<String, String>);
+
+impl fmt::Debug for RedactedValues<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map()
+            .entries(self.0.keys().map(|key| (key, "<redacted>")))
+            .finish()
+    }
+}
+
+impl fmt::Debug for ServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServerConfig")
+            .field("transport", &self.transport)
+            .field("command", &self.command)
+            .field("args", &self.args)
+            .field("env", &RedactedValues(&self.env))
+            .field("cwd", &self.cwd)
+            .field("url", &self.url)
+            .field("headers", &RedactedValues(&self.headers))
+            .field("connect_timeout", &self.connect_timeout)
+            .field("discover_timeout", &self.discover_timeout)
+            .finish()
+    }
 }
 
 impl ServerConfig {
@@ -330,7 +416,12 @@ impl ServerConfig {
 ///     .header("Authorization".to_string(), "Bearer token".to_string())
 ///     .build();
 /// ```
-#[derive(Debug, Clone)]
+///
+/// Like [`ServerConfig`] itself, this builder accumulates `env`/`headers`
+/// before secrets they may carry are known to be well-formed, so its
+/// [`Debug`] impl redacts values the same way — see the redaction note on
+/// [`ServerConfig`]'s doc comment.
+#[derive(Clone)]
 pub struct ServerConfigBuilder {
     transport: TransportType,
     command: Option<String>,
@@ -341,6 +432,22 @@ pub struct ServerConfigBuilder {
     headers: HashMap<String, String>,
     connect_timeout: Duration,
     discover_timeout: Duration,
+}
+
+impl fmt::Debug for ServerConfigBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServerConfigBuilder")
+            .field("transport", &self.transport)
+            .field("command", &self.command)
+            .field("args", &self.args)
+            .field("env", &RedactedValues(&self.env))
+            .field("cwd", &self.cwd)
+            .field("url", &self.url)
+            .field("headers", &RedactedValues(&self.headers))
+            .field("connect_timeout", &self.connect_timeout)
+            .field("discover_timeout", &self.discover_timeout)
+            .finish()
+    }
 }
 
 impl Default for ServerConfigBuilder {
@@ -880,6 +987,107 @@ mod tests {
 
         let debug_str = format!("{config:?}");
         assert!(debug_str.contains("docker"));
+    }
+
+    #[test]
+    fn test_server_config_debug_redacts_header_values() {
+        // headers are only populated for HTTP/SSE transport (see the
+        // builder's `try_build`), so exercise them via `http_transport`.
+        let config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header(
+                "Authorization".to_string(),
+                "Bearer sk-secret-header-value".to_string(),
+            )
+            .build();
+
+        let debug_str = format!("{config:?}");
+
+        // The key is useful for debugging and is not secret.
+        assert!(debug_str.contains("Authorization"));
+        // The value must never appear.
+        assert!(!debug_str.contains("sk-secret-header-value"));
+    }
+
+    #[test]
+    fn test_server_config_debug_redacts_env_values() {
+        // env is only populated for stdio transport (see the builder's
+        // `try_build`), so exercise it via the default stdio transport.
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .env(
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                "ghp_supersecretvalue".to_string(),
+            )
+            .build();
+
+        let debug_str = format!("{config:?}");
+
+        // The key is useful for debugging and is not secret.
+        assert!(debug_str.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
+        // The value must never appear.
+        assert!(!debug_str.contains("ghp_supersecretvalue"));
+    }
+
+    #[test]
+    fn test_server_config_builder_debug_redacts_env_and_header_values() {
+        // Unlike `ServerConfig::build()`, the builder itself doesn't drop
+        // env/headers based on transport, so both can be populated at once
+        // and inspected via `{:?}` before `build()` is ever called.
+        let builder = ServerConfig::builder()
+            .command("docker".to_string())
+            .env(
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                "ghp_supersecretvalue".to_string(),
+            )
+            .header(
+                "Authorization".to_string(),
+                "Bearer sk-secret-header-value".to_string(),
+            );
+
+        let debug_str = format!("{builder:?}");
+
+        // Keys are useful for debugging and are not secret.
+        assert!(debug_str.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
+        assert!(debug_str.contains("Authorization"));
+        // Values must never appear.
+        assert!(!debug_str.contains("ghp_supersecretvalue"));
+        assert!(!debug_str.contains("sk-secret-header-value"));
+    }
+
+    #[test]
+    fn test_server_config_serialize_still_contains_real_secret_values() {
+        // Serialize/Deserialize must round-trip real values for config
+        // persistence; only Debug formatting is redacted. Headers and env
+        // are exercised separately since `build()` drops whichever one
+        // doesn't match the config's transport (see `try_build`).
+        let http_config = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header(
+                "Authorization".to_string(),
+                "Bearer sk-secret-header-value".to_string(),
+            )
+            .build();
+
+        let http_json = serde_json::to_string(&http_config).unwrap();
+        assert!(http_json.contains("sk-secret-header-value"));
+
+        let http_deserialized: ServerConfig = serde_json::from_str(&http_json).unwrap();
+        assert_eq!(http_config, http_deserialized);
+
+        let stdio_config = ServerConfig::builder()
+            .command("docker".to_string())
+            .env(
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                "ghp_supersecretvalue".to_string(),
+            )
+            .build();
+
+        let stdio_json = serde_json::to_string(&stdio_config).unwrap();
+        assert!(stdio_json.contains("ghp_supersecretvalue"));
+
+        let stdio_deserialized: ServerConfig = serde_json::from_str(&stdio_json).unwrap();
+        assert_eq!(stdio_config, stdio_deserialized);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `validate_network_config`'s three error branches in `command.rs` (duplicate header name, header-name token-charset violation, header-value control-character violation) all interpolated the caller-supplied header name into `SecurityViolation` messages. Since a header name only needs to pass an RFC 7230 `token`-charset check, a misparsed or externally-supplied name can be secret-shaped (base64, hex, JWT-like) and get echoed in full. All three branches now return static reason strings.
- `ServerConfig` and `ServerConfigBuilder` derived plain `Debug` over their `headers`/`env` maps, which routinely carry bearer tokens and API keys. Both now have hand-written `Debug` impls that keep map keys visible but redact values via a shared `RedactedValues` helper. `Serialize`/`Deserialize` are unchanged, so config persistence still round-trips real values.

Fixes #228, #208. Also fixes #215, whose intended fix (PR #223) was still open/unmerged — the adversarial review pass that scoped this PR found the underlying leak was still live on master and the two PRs would have shipped self-contradictory doc comments in the same file, so it was folded in here rather than left conflicting with an in-flight PR.

A related but out-of-scope gap was found during review — `mcp-cli`'s `McpTransport` derives a Debug that isn't redacted, and a published doctest models printing it — filed separately as #229.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (898 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New/updated unit tests assert redacted output does not contain the raw secret value (not just "doesn't panic"), including direct repros for #215 and the header-value branch