### PR TITLE
fix(codegen): demultiplex JSON-RPC responses by request id in runtime bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-codegen`**: the generated runtime bridge (`_runtime/mcp-bridge.ts`) attached a
+  fresh `stdout` listener per `callMCPTool` call and resolved on the first complete JSON-RPC
+  message with an `id`, without checking that the `id` matched the request it sent. Two
+  concurrent calls to the same server raced on the shared stream, so one caller could receive
+  another's response (#232). The bridge now spawns a single shared response dispatcher per
+  connection that demultiplexes incoming messages by request id into a per-connection pending
+  map, so each call only ever resolves with its own response; entries are removed on
+  resolve/reject/timeout so the map cannot grow unbounded. Related hardening: `getConnection`
+  now caches the in-flight connection-setup promise (not just the resolved connection), so
+  concurrent calls on a cold server share one spawn instead of racing to spawn duplicate
+  processes; pending requests are rejected on the process `close` event rather than `exit` (Node
+  emits `exit` before stdio has fully drained, which could spuriously reject a request whose
+  response was still in the OS pipe buffer); stdout is read via `setEncoding('utf8')` instead of
+  manually concatenating `Buffer` chunks, so multi-byte UTF-8 characters split across chunk
+  boundaries no longer corrupt into unparseable replacement characters; a stdin write error no
+  longer leaks its pending-request entry, and a `stdin` error listener rejects the connection's
+  pending requests immediately (rather than only logging) so a broken pipe fails fast instead of
+  waiting out the full request timeout; a stdout stream error now also evicts the connection from
+  the server cache so a broken connection isn't reused and left to hang all subsequent requests.
+  Every cache eviction (on `close`, process `error`, stdout `error`, or stdin `error`) now checks
+  that the cache still points at the exact connection attempt being torn down before deleting it,
+  so a stale teardown can no longer race a concurrent reconnect and delete a newer, live
+  connection out from under it — leaving its process both running and unreachable. A bare JSON
+  primitive line (e.g. a lone `null`) from the server is now dropped like any other
+  non-response line instead of crashing the host process, since checking for an `id` property on
+  a non-object value threw a `TypeError` when only wrapped in a `try`/`catch` that covered
+  `JSON.parse` alone. The stale-connection liveness check also inspects `signalCode` (not just
+  `exitCode`), so a process killed by signal is no longer misclassified as alive.
+  `closeAllConnections` (used by the `SIGINT`/`SIGTERM` handlers) now signals every tracked child
+  process synchronously and immediately, then lets in-flight connection attempts settle
+  concurrently, instead of `await`-ing each cached connection sequentially first — which could
+  stall shutdown behind a single slow-initializing server for up to the full request timeout and
+  delay killing every other server behind it.
+
 - **`mcp-execution-skill`**: `extract_skill_metadata` parsed a `SKILL.md`'s YAML frontmatter with
   hand-rolled, single-line regexes, so a `description: |`/`description: >` block scalar had its
   multi-line body discarded in favor of the literal marker character, and a quoted scalar (e.g.

--- a/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
@@ -15,7 +15,6 @@ import { spawn, ChildProcess } from 'child_process';
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
-import { Readable } from 'stream';
 
 /**
  * Configuration for an MCP server
@@ -92,10 +91,38 @@ interface MCPInitializeRequest {
 }
 
 /**
- * Cache of active server connections
- * Key: serverId, Value: server process
+ * A single pending JSON-RPC request awaiting its response.
  */
-const serverConnections = new Map<string, ChildProcess>();
+interface PendingRequest {
+  resolve: (message: MCPToolCallResponse) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * An active connection to an MCP server: the child process plus the
+ * in-flight requests awaiting a response, keyed by JSON-RPC request id.
+ */
+interface ServerConnection {
+  process: ChildProcess;
+  pending: Map<number, PendingRequest>;
+}
+
+/**
+ * Cache of active (or in-flight) server connections.
+ *
+ * Key: serverId, Value: promise resolving to the connection once the child process has
+ * spawned and completed the JSON-RPC `initialize` handshake. Caching the in-flight promise
+ * (not just the eventually-resolved connection) means concurrent callers on a cold serverId
+ * await the same connection setup instead of each spawning a competing child process.
+ */
+const serverConnections = new Map<string, Promise<ServerConnection>>();
+
+/**
+ * Child processes spawned for active connections, tracked separately from
+ * {@link serverConnections} so the synchronous `process.on('exit', ...)` handler can kill
+ * them without needing to await a possibly-still-pending connection promise.
+ */
+const activeProcesses = new Set<ChildProcess>();
 
 /**
  * Request ID counter for JSON-RPC
@@ -394,7 +421,7 @@ async function loadServerConfig(serverId: string): Promise<ServerConfig> {
 
 /**
  * Default timeout, in milliseconds, for a single JSON-RPC round trip in
- * {@link readJsonRpcMessage}. Overridable via the `MCPBRIDGE_REQUEST_TIMEOUT_MS`
+ * {@link sendRequest}. Overridable via the `MCPBRIDGE_REQUEST_TIMEOUT_MS`
  * environment variable.
  */
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -411,147 +438,232 @@ const REQUEST_TIMEOUT_MS = (() => {
 })();
 
 /**
- * Reads a complete JSON-RPC message from a stream, guarding against the two ways this can
- * otherwise hang forever: the spawned server process exiting before ever writing a response,
- * and a server that simply never replies.
- *
- * @param stream - Readable stream (typically stdout from the MCP server)
- * @param child - The MCP server's child process; its `exit` event settles this promise with
- *   a clear error if the process dies before a response arrives
- * @param timeoutMs - Milliseconds to wait for a response before rejecting; defaults to
- *   {@link REQUEST_TIMEOUT_MS}
- * @returns Parsed JSON-RPC response
- * @throws {Error} If the stream errors, the child process exits before responding, or
- *   `timeoutMs` elapses with no response
+ * Request message shapes {@link sendRequest} may send: both carry a JSON-RPC `id` used to
+ * match the eventual response.
  */
-async function readJsonRpcMessage(
-  stream: Readable,
-  child: ChildProcess,
-  timeoutMs: number = REQUEST_TIMEOUT_MS
-): Promise<MCPToolCallResponse> {
-  return new Promise((resolve, reject) => {
-    let buffer = '';
-    let settled = false;
+type MCPRequestMessage = MCPToolCallRequest | MCPInitializeRequest;
 
-    const cleanup = (): void => {
-      stream.off('data', onData);
-      stream.off('error', onError);
-      child.off('exit', onExit);
-      clearTimeout(timer);
-    };
+/**
+ * Tears down a connection after it can no longer serve requests: rejects every request still
+ * awaiting a response, and removes the connection from {@link activeProcesses} and — only if
+ * the cache still points at this exact connection attempt — {@link serverConnections}. This
+ * identity check mirrors the one in {@link getConnection}'s catch handler: without it, a
+ * connection that already lost the race to a newer one (see `exit`-before-`close` ordering)
+ * would evict the newer, live connection from the cache instead of just itself.
+ *
+ * @param serverId - Server identifier the connection was cached under
+ * @param connection - The connection being torn down
+ * @param error - Rejection reason for any still-pending requests
+ * @param ownPromise - The {@link serverConnections} promise this connection was created from
+ */
+function teardownConnection(
+  serverId: string,
+  connection: ServerConnection,
+  error: Error,
+  ownPromise: Promise<ServerConnection>
+): void {
+  activeProcesses.delete(connection.process);
+  if (serverConnections.get(serverId) === ownPromise) {
+    serverConnections.delete(serverId);
+  }
 
-    const settleResolve = (message: MCPToolCallResponse): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(message);
-    };
+  const pendingRequests = [...connection.pending.values()];
+  for (const pendingRequest of pendingRequests) {
+    pendingRequest.reject(error);
+  }
+}
 
-    const settleReject = (error: Error): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    };
+/**
+ * Attaches the single, shared stdout listener for a connection: parses newline-delimited
+ * JSON-RPC messages and demultiplexes each response to the pending request with the matching
+ * `id`, so concurrent {@link sendRequest} calls on the same connection never receive each
+ * other's response.
+ *
+ * Uses `setEncoding('utf8')` rather than manually decoding `Buffer` chunks, so multi-byte
+ * UTF-8 characters split across chunk boundaries are reassembled correctly instead of
+ * producing replacement characters that fail `JSON.parse`.
+ *
+ * @param connection - The connection whose stdout should be dispatched
+ * @param serverId - Server identifier, used for debug logging and connection teardown
+ * @param getOwnPromise - Returns the {@link serverConnections} promise this connection was
+ *   created from, threaded through to {@link teardownConnection} so a stale teardown never
+ *   evicts a newer connection cached under the same `serverId`
+ */
+function attachResponseDispatcher(
+  connection: ServerConnection,
+  serverId: string,
+  getOwnPromise: () => Promise<ServerConnection>
+): void {
+  const stdout = connection.process.stdout!;
+  stdout.setEncoding('utf8');
+  let buffer = '';
 
-    const onData = (chunk: Buffer): void => {
-      buffer += chunk.toString();
+  stdout.on('data', (chunk: string): void => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
 
-      // Try to parse complete JSON messages
-      const lines = buffer.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
 
-      for (let i = 0; i < lines.length - 1; i++) {
-        const line = lines[i].trim();
-        if (line.length === 0) continue;
-
-        try {
-          const message = JSON.parse(line) as MCPToolCallResponse;
-
-          // Only process responses, ignore notifications
-          if ('id' in message) {
-            settleResolve(message);
-            return;
-          }
-        } catch (e) {
-          // Incomplete JSON, wait for more data
-          debug('Failed to parse JSON (waiting for more data):', line);
-        }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        // A complete, newline-terminated line that isn't valid JSON-RPC — drop it rather
+        // than waiting for more data, since no more data will make this line parse.
+        debug('Dropping unparseable line from server output:', trimmed);
+        continue;
       }
 
-      // Keep the last incomplete line in the buffer
-      buffer = lines[lines.length - 1];
-    };
+      // Only object messages carrying an `id` are responses; primitive JSON (e.g. a bare
+      // `null` line) and notifications are ignored the same way an unparseable line is —
+      // `'id' in parsed` would otherwise throw a TypeError on a non-object `parsed`.
+      if (typeof parsed !== 'object' || parsed === null || !('id' in parsed)) continue;
 
-    const onError = (error: Error): void => {
-      settleReject(error);
-    };
+      const message = parsed as MCPToolCallResponse;
+      const pendingRequest = connection.pending.get(message.id);
+      if (!pendingRequest) {
+        debug(`Received response for unknown or already-settled request id ${message.id}`);
+        continue;
+      }
+      pendingRequest.resolve(message);
+    }
+  });
 
-    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
-      settleReject(
-        new Error(
-          `MCP server process exited before responding (code ${code ?? 'null'}, ` +
-          `signal ${signal ?? 'null'})`
-        )
-      );
-    };
-
-    const timer = setTimeout(() => {
-      settleReject(new Error(`Timed out after ${timeoutMs}ms waiting for a response from the MCP server`));
-    }, timeoutMs);
-
-    stream.on('data', onData);
-    stream.on('error', onError);
-    child.on('exit', onExit);
+  stdout.on('error', (error: Error): void => {
+    debug(`stdout error for server ${serverId}:`, error);
+    teardownConnection(serverId, connection, error, getOwnPromise());
   });
 }
 
 /**
- * Connect to an MCP server or reuse existing connection
+ * Sends a JSON-RPC request on a connection and resolves once the response with the matching
+ * `id` arrives via {@link attachResponseDispatcher}, guarding against the two ways this could
+ * otherwise hang forever: the server process closing before ever responding, and a server
+ * that simply never replies.
  *
- * Implements connection caching: first call spawns server process,
- * subsequent calls reuse the same process.
+ * The pending-request entry is registered before the request is written to stdin, and is
+ * always removed — on resolve, reject, or timeout — so the pending map never grows unbounded.
+ *
+ * @param connection - The connection to send the request on
+ * @param request - The JSON-RPC request to send
+ * @param timeoutMs - Milliseconds to wait for a response before rejecting; defaults to
+ *   {@link REQUEST_TIMEOUT_MS}
+ * @returns Parsed JSON-RPC response matching the request's `id`
+ * @throws {Error} If writing to stdin fails, the connection closes before responding, or
+ *   `timeoutMs` elapses with no response
+ */
+async function sendRequest(
+  connection: ServerConnection,
+  request: MCPRequestMessage,
+  timeoutMs: number = REQUEST_TIMEOUT_MS
+): Promise<MCPToolCallResponse> {
+  return new Promise((resolve, reject) => {
+    const id = request.id;
+    let settled = false;
+
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      connection.pending.delete(id);
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      settle(() =>
+        reject(new Error(`Timed out after ${timeoutMs}ms waiting for a response from the MCP server`))
+      );
+    }, timeoutMs);
+
+    connection.pending.set(id, {
+      resolve: (message) => settle(() => resolve(message)),
+      reject: (error) => settle(() => reject(error))
+    });
+
+    try {
+      connection.process.stdin!.write(JSON.stringify(request) + '\n');
+    } catch (error) {
+      settle(() => reject(error instanceof Error ? error : new Error(String(error))));
+    }
+  });
+}
+
+/**
+ * Spawns the server process for `serverId`, wires up its response dispatcher and lifecycle
+ * handlers, and completes the JSON-RPC `initialize` handshake.
+ *
+ * Split out of {@link getConnection} so the latter can cache this function's promise —
+ * rather than only its resolved value — letting concurrent cold-start callers await the same
+ * in-flight setup instead of each spawning a competing child process.
  *
  * @param serverId - Server identifier
- * @returns Active server process
+ * @param getOwnPromise - Returns the {@link serverConnections} promise wrapping this very call,
+ *   so the process lifecycle handlers registered below can pass it to
+ *   {@link teardownConnection} for its cache-identity check. The promise doesn't exist yet when
+ *   this function starts running (the caller creates it from this call's return value), but by
+ *   the time any of these handlers fire the caller has assigned it, so the closure resolves it
+ *   correctly.
+ * @returns The newly established connection
+ * @throws {Error} If the config fails validation, or the server fails to initialize
  */
-async function getConnection(serverId: string): Promise<ChildProcess> {
-  // Return cached connection if exists
-  if (serverConnections.has(serverId)) {
-    const existingProcess = serverConnections.get(serverId)!;
-
-    // Check if process is still alive
-    if (!existingProcess.killed && existingProcess.exitCode === null) {
-      debug(`Reusing connection to server: ${serverId}`);
-      return existingProcess;
-    }
-
-    // Process died, remove from cache
-    debug(`Cached connection to ${serverId} is dead, reconnecting`);
-    serverConnections.delete(serverId);
-  }
-
-  // Spawn new server process
-  debug(`Connecting to server: ${serverId}`);
+async function createConnection(
+  serverId: string,
+  getOwnPromise: () => Promise<ServerConnection>
+): Promise<ServerConnection> {
   const config = await loadServerConfig(serverId);
 
-  const serverProcess = spawn(config.command, config.args, {
+  const childProcess = spawn(config.command, config.args, {
     stdio: ['pipe', 'pipe', 'inherit'],
     env: { ...process.env, ...config.env },
     cwd: config.cwd
   });
+  activeProcesses.add(childProcess);
 
-  // Handle process errors
-  serverProcess.on('error', (error) => {
+  const connection: ServerConnection = { process: childProcess, pending: new Map() };
+  attachResponseDispatcher(connection, serverId, getOwnPromise);
+
+  // An async EPIPE reported here (rather than as a synchronous throw from `stdin.write`)
+  // would otherwise leave the pending request(s) unrejected until they time out; tear down
+  // the same way as other stream/process failures so they fail fast instead.
+  childProcess.stdin!.on('error', (error) => {
+    debug(`stdin error for server ${serverId}:`, error);
+    teardownConnection(
+      serverId,
+      connection,
+      new Error(`MCP server stdin error: ${error.message}`),
+      getOwnPromise()
+    );
+  });
+
+  childProcess.on('error', (error) => {
     debug(`Server process error for ${serverId}:`, error);
-    serverConnections.delete(serverId);
+    teardownConnection(
+      serverId,
+      connection,
+      new Error(`MCP server process error: ${error.message}`),
+      getOwnPromise()
+    );
   });
 
-  serverProcess.on('exit', (code, signal) => {
-    debug(`Server ${serverId} exited with code ${code}, signal ${signal}`);
-    serverConnections.delete(serverId);
+  // 'close' (not 'exit') fires once stdio has fully drained, so a response already sitting
+  // in the OS pipe buffer is delivered to attachResponseDispatcher's listener before pending
+  // requests are rejected here.
+  childProcess.on('close', (code, signal) => {
+    debug(`Server ${serverId} closed (code ${code}, signal ${signal})`);
+    teardownConnection(
+      serverId,
+      connection,
+      new Error(
+        `MCP server process exited before responding (code ${code ?? 'null'}, ` +
+        `signal ${signal ?? 'null'})`
+      ),
+      getOwnPromise()
+    );
   });
 
-  // Send initialize request
   const initRequest: MCPInitializeRequest = {
     jsonrpc: '2.0',
     id: requestIdCounter++,
@@ -569,26 +681,86 @@ async function getConnection(serverId: string): Promise<ChildProcess> {
   };
 
   debug('Sending initialize request:', JSON.stringify(initRequest));
-  serverProcess.stdin!.write(JSON.stringify(initRequest) + '\n');
-
-  // Wait for initialize response
   try {
-    const initResponse = await readJsonRpcMessage(serverProcess.stdout!, serverProcess);
+    const initResponse = await sendRequest(connection, initRequest);
     debug('Received initialize response:', JSON.stringify(initResponse));
 
     if (initResponse.error) {
       throw new Error(`Server initialization failed: ${initResponse.error.message}`);
     }
   } catch (error) {
-    serverProcess.kill();
+    childProcess.kill();
     throw new Error(`Failed to initialize server ${serverId}: ${error}`);
   }
 
-  // Cache the connection
-  serverConnections.set(serverId, serverProcess);
   debug(`Connected to server: ${serverId}`);
+  return connection;
+}
 
-  return serverProcess;
+/**
+ * Returns whether `childProcess` is still running.
+ *
+ * Checking `exitCode` alone misses a process that was terminated by a signal without an exit
+ * code of its own (Node sets `signalCode` instead in that case), which would otherwise
+ * misclassify a signal-killed process as still alive.
+ *
+ * @param childProcess - The child process to check
+ */
+function isProcessAlive(childProcess: ChildProcess): boolean {
+  return childProcess.exitCode === null && childProcess.signalCode === null;
+}
+
+/**
+ * Connect to an MCP server or reuse an existing connection.
+ *
+ * Implements connection caching: the first call for a given `serverId` spawns the server
+ * process, subsequent calls reuse the same connection. Caches the in-flight
+ * {@link createConnection} promise (see {@link serverConnections}) so concurrent calls on a
+ * cold `serverId` share one connection attempt instead of racing to spawn duplicate
+ * processes.
+ *
+ * @param serverId - Server identifier
+ * @returns Active server connection
+ */
+async function getConnection(serverId: string): Promise<ServerConnection> {
+  const cached = serverConnections.get(serverId);
+  if (cached) {
+    try {
+      const connection = await cached;
+
+      if (isProcessAlive(connection.process)) {
+        debug(`Reusing connection to server: ${serverId}`);
+        return connection;
+      }
+
+      debug(`Cached connection to ${serverId} is dead, reconnecting`);
+      // Only clear the cache if it still points at this dead attempt — a concurrent caller
+      // may have already replaced it with a newer, live one.
+      if (serverConnections.get(serverId) === cached) {
+        serverConnections.delete(serverId);
+      }
+    } catch (error) {
+      if (serverConnections.get(serverId) === cached) {
+        serverConnections.delete(serverId);
+      }
+      throw error;
+    }
+  }
+
+  debug(`Connecting to server: ${serverId}`);
+  const connectionPromise: Promise<ServerConnection> = createConnection(serverId, () => connectionPromise);
+  serverConnections.set(serverId, connectionPromise);
+
+  try {
+    return await connectionPromise;
+  } catch (error) {
+    // Only clear the cache if it still points at this failed attempt — a concurrent caller
+    // may have already replaced it with a newer one.
+    if (serverConnections.get(serverId) === connectionPromise) {
+      serverConnections.delete(serverId);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -623,7 +795,7 @@ export async function callMCPTool(
 ): Promise<unknown> {
   debug(`Calling tool: ${serverId}.${toolName}`, params);
 
-  const serverProcess = await getConnection(serverId);
+  const connection = await getConnection(serverId);
 
   const request: MCPToolCallRequest = {
     jsonrpc: '2.0',
@@ -636,10 +808,7 @@ export async function callMCPTool(
   };
 
   debug('Sending tool call request:', JSON.stringify(request));
-  serverProcess.stdin!.write(JSON.stringify(request) + '\n');
-
-  // Wait for response
-  const response = await readJsonRpcMessage(serverProcess.stdout!, serverProcess);
+  const response = await sendRequest(connection, request);
   debug('Received tool call response:', JSON.stringify(response));
 
   // Handle errors
@@ -700,19 +869,29 @@ export async function callMCPTool(
 export async function closeAllConnections(): Promise<void> {
   debug('Closing all connections');
 
-  for (const [serverId, serverProcess] of serverConnections) {
-    debug(`Closing connection to: ${serverId}`);
-    serverProcess.kill('SIGTERM');
+  // Signal every tracked child process synchronously and immediately, before awaiting
+  // anything: a still-initializing server's connection-creation promise can take up to
+  // REQUEST_TIMEOUT_MS to settle, and awaiting each one in turn (as before) would both stall
+  // shutdown on a slow server and delay killing every other server behind it.
+  for (const childProcess of activeProcesses) {
+    if (!childProcess.killed) {
+      childProcess.kill('SIGTERM');
+    }
   }
 
+  // Best-effort: let in-flight connection attempts settle so their own teardown/cleanup runs,
+  // concurrently rather than sequentially. The kill signals above have already been sent
+  // regardless of how long (or whether) these resolve.
+  await Promise.allSettled([...serverConnections.values()]);
   serverConnections.clear();
 }
 
-// Cleanup on process exit
+// Cleanup on process exit. Synchronous — cannot await connection promises — so this walks
+// activeProcesses (populated synchronously at spawn time) rather than serverConnections.
 process.on('exit', () => {
-  for (const [_, serverProcess] of serverConnections) {
-    if (!serverProcess.killed) {
-      serverProcess.kill('SIGTERM');
+  for (const childProcess of activeProcesses) {
+    if (!childProcess.killed) {
+      childProcess.kill('SIGTERM');
     }
   }
 });

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -702,6 +702,47 @@ fn run_bridge_harness_with_env(
     server_id: &str,
     extra_env: &[(&str, &str)],
 ) -> Option<(bool, String, String)> {
+    let harness_ts = format!(
+        "import {{ callMCPTool }} from './mcp-bridge.js';\n\
+         \n\
+         const watchdog = setTimeout(() => {{\n\
+         \x20\x20console.log('TIMEOUT: did not settle before spawning');\n\
+         \x20\x20process.exit(2);\n\
+         }}, 5000);\n\
+         \n\
+         callMCPTool('{server_id}', 'noop', {{}}).then(\n\
+         \x20\x20() => {{\n\
+         \x20\x20\x20\x20clearTimeout(watchdog);\n\
+         \x20\x20\x20\x20console.log('UNEXPECTED_SUCCESS');\n\
+         \x20\x20\x20\x20process.exit(1);\n\
+         \x20\x20}},\n\
+         \x20\x20(err: unknown) => {{\n\
+         \x20\x20\x20\x20clearTimeout(watchdog);\n\
+         \x20\x20\x20\x20console.log('REJECTED:', String(err));\n\
+         \x20\x20\x20\x20process.exit(0);\n\
+         \x20\x20}}\n\
+         );\n"
+    );
+
+    compile_and_run_bridge_harness(test_name, bridge_ts, mcp_json, &harness_ts, extra_env)
+}
+
+/// Shared innards of [`run_bridge_harness_with_env`] and the concurrency regression test below:
+/// compiles `bridge_ts` plus a caller-supplied `harness_ts` under tsc, then runs the result
+/// under Node with `$HOME`/`%USERPROFILE%` pointed at a temp directory containing `mcp_json`
+/// as `~/.claude/mcp.json`. Factored out of `run_bridge_harness_with_env` so a harness body
+/// other than the single fixed `callMCPTool('...', 'noop', {})` call (e.g. two concurrent
+/// calls) does not need to duplicate the tsc/Node plumbing.
+///
+/// Returns `None` if `tsc`/`node` are not on `PATH` and the caller should skip locally; hard
+/// fails (via `require_ts_toolchain`) instead of returning `None` when running in CI.
+fn compile_and_run_bridge_harness(
+    test_name: &str,
+    bridge_ts: &str,
+    mcp_json: &serde_json::Value,
+    harness_ts: &str,
+    extra_env: &[(&str, &str)],
+) -> Option<(bool, String, String)> {
     if !require_ts_toolchain(test_name, true) {
         return None;
     }
@@ -723,31 +764,7 @@ fn run_bridge_harness_with_env(
         .expect("Failed to write src/package.json");
     std::fs::write(src_dir.join("mcp-bridge.ts"), bridge_ts)
         .expect("Failed to write mcp-bridge.ts");
-    std::fs::write(
-        src_dir.join("harness.ts"),
-        format!(
-            "import {{ callMCPTool }} from './mcp-bridge.js';\n\
-             \n\
-             const watchdog = setTimeout(() => {{\n\
-             \x20\x20console.log('TIMEOUT: did not settle before spawning');\n\
-             \x20\x20process.exit(2);\n\
-             }}, 5000);\n\
-             \n\
-             callMCPTool('{server_id}', 'noop', {{}}).then(\n\
-             \x20\x20() => {{\n\
-             \x20\x20\x20\x20clearTimeout(watchdog);\n\
-             \x20\x20\x20\x20console.log('UNEXPECTED_SUCCESS');\n\
-             \x20\x20\x20\x20process.exit(1);\n\
-             \x20\x20}},\n\
-             \x20\x20(err: unknown) => {{\n\
-             \x20\x20\x20\x20clearTimeout(watchdog);\n\
-             \x20\x20\x20\x20console.log('REJECTED:', String(err));\n\
-             \x20\x20\x20\x20process.exit(0);\n\
-             \x20\x20}}\n\
-             );\n"
-        ),
-    )
-    .expect("Failed to write harness.ts");
+    std::fs::write(src_dir.join("harness.ts"), harness_ts).expect("Failed to write harness.ts");
 
     let dist_dir = dir.path().join("dist");
     let tsc_output = Command::new(tsc_program())
@@ -796,8 +813,8 @@ fn run_bridge_harness_with_env(
         .recv_timeout(std::time::Duration::from_secs(15))
         .unwrap_or_else(|_| {
             panic!(
-                "node harness did not exit within 15s; the bridge may be hanging on an \
-                 unvalidated spawn instead of rejecting the hostile config"
+                "node harness for {test_name} did not exit within 15s; the bridge may be \
+                 hanging instead of settling every pending request"
             )
         })
         .expect("Failed to run node");
@@ -1293,5 +1310,141 @@ fn test_runtime_bridge_times_out_when_server_never_replies() {
     assert!(
         stdout.contains("Timed out"),
         "rejection reason should explain the request timed out: {stdout}"
+    );
+}
+
+/// Regression guard for #232: two concurrent `callMCPTool` calls on the same connection must
+/// each resolve with the response matching THEIR OWN JSON-RPC request id, even when the
+/// server replies out of order (responds to the second request before the first). Before the
+/// fix, each call's response was consumed by whichever per-call listener happened to fire
+/// first — not matched by id — so an out-of-order reply silently handed one caller the other's
+/// result.
+///
+/// The fake MCP server below deliberately buffers both `tools/call` requests and replies to
+/// the second-received one first, echoing back each call's own argument so a mismatch is
+/// directly observable in the result value rather than merely "no crash occurred".
+///
+/// Skips (does not fail) when `tsc` or `node` is not on `PATH`.
+#[test]
+fn test_runtime_bridge_dispatches_concurrent_out_of_order_responses_by_request_id() {
+    let generator = ProgressiveGenerator::new().expect("Failed to create generator");
+    let server_info = create_test_server_info();
+    let code = generator
+        .generate(&server_info)
+        .expect("Failed to generate code");
+    let bridge = code
+        .files
+        .iter()
+        .find(|f| f.path == "_runtime/mcp-bridge.ts")
+        .expect("_runtime/mcp-bridge.ts not found");
+
+    let fake_server_js = r"
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+const pendingToolCalls = [];
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return;
+  const message = JSON.parse(trimmed);
+
+  if (message.method === 'initialize') {
+    const response = {
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        serverInfo: { name: 'fake', version: '0.0.0' }
+      }
+    };
+    process.stdout.write(JSON.stringify(response) + '\n');
+    return;
+  }
+
+  if (message.method === 'tools/call') {
+    pendingToolCalls.push(message);
+    if (pendingToolCalls.length < 2) return;
+
+    // Deliberately reply in the REVERSE of arrival order: the second request received gets
+    // its response written first. This is the out-of-order scenario from issue #232 — a
+    // correct dispatcher must still resolve each caller with the response matching ITS OWN
+    // request id, not whichever response happens to arrive first.
+    const [receivedFirst, receivedSecond] = pendingToolCalls;
+    for (const call of [receivedSecond, receivedFirst]) {
+      const response = {
+        jsonrpc: '2.0',
+        id: call.id,
+        result: {
+          content: [{ type: 'text', text: `${call.params.arguments.value}-response` }]
+        }
+      };
+      process.stdout.write(JSON.stringify(response) + '\n');
+    }
+  }
+});
+";
+    let script_path = write_test_script(fake_server_js);
+
+    let mcp_json = json!({
+        "mcpServers": {
+            "fake": {
+                "command": "node",
+                "args": [script_path]
+            }
+        }
+    });
+
+    let harness_ts = r"
+import { callMCPTool } from './mcp-bridge.js';
+
+const watchdog = setTimeout(() => {
+  console.log('TIMEOUT: did not settle both calls');
+  process.exit(2);
+}, 5000);
+
+const first = callMCPTool('fake', 'echo', { value: 'first' });
+const second = callMCPTool('fake', 'echo', { value: 'second' });
+
+Promise.all([first, second]).then(
+  ([firstResult, secondResult]) => {
+    clearTimeout(watchdog);
+    console.log('FIRST:', JSON.stringify(firstResult));
+    console.log('SECOND:', JSON.stringify(secondResult));
+    if (firstResult === 'first-response' && secondResult === 'second-response') {
+      console.log('MATCH');
+      process.exit(0);
+    } else {
+      console.log('MISMATCH');
+      process.exit(1);
+    }
+  },
+  (err: unknown) => {
+    clearTimeout(watchdog);
+    console.log('REJECTED:', String(err));
+    process.exit(3);
+  }
+);
+";
+
+    let Some((success, stdout, stderr)) = compile_and_run_bridge_harness(
+        "test_runtime_bridge_dispatches_concurrent_out_of_order_responses_by_request_id",
+        &bridge.content,
+        &mcp_json,
+        harness_ts,
+        &[],
+    ) else {
+        return;
+    };
+
+    assert!(
+        success,
+        "bridge did not dispatch out-of-order concurrent responses correctly:\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("MATCH"),
+        "each caller must resolve with the response matching its own request id, not the \
+         other caller's response: stdout: {stdout}, stderr: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- The generated runtime bridge cached one child process per server and reused it across all `callMCPTool` invocations, but `readJsonRpcMessage` resolved on the first response containing any `id`, without checking it matched the request that call sent — concurrent calls to the same server could receive each other's responses.
- Replaces the per-call listener with a single per-connection dispatcher that demultiplexes incoming JSON-RPC messages into a pending-request map keyed by request id, so each call only ever resolves with its own response.
- Additional hardening surfaced during review: connection setup is deduplicated via a cached in-flight promise (no duplicate spawns on concurrent cold starts), pending requests reject on `close` instead of `exit`, stdout is decoded with `setEncoding('utf8')` to avoid multi-byte UTF-8 corruption across chunk boundaries, a bare JSON primitive line no longer crashes the host process, cache eviction during teardown is identity-checked so a stale teardown can't evict a live reconnected connection, and shutdown kills tracked processes synchronously instead of awaiting each connection sequentially.

Closes #232

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (785 passed)
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --doc --all-features --workspace`
- [x] New regression test (`test_runtime_bridge_dispatches_concurrent_out_of_order_responses_by_request_id`) verified to fail against the pre-fix template and pass against the fix