### PR TITLE
core: remove dead ServerConfigBuilder::try_build() alias and unused Error variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Result<ServerConfig, Error>` instead of an infallible `ServerConfig` (#177). Security
   validation (shell metacharacters, forbidden environment variables, URL scheme, header
   safety, timeout bounds — everything `validate_server_config` checks) now runs inside
-  `build()`/`try_build()` itself, so a `ServerConfig` built through the builder can no longer
+  `build()` itself, so a `ServerConfig` built through the builder can no longer
   be constructed without having already passed it; previously `build()` only checked
   structural completeness (command/url presence), leaving `validate_server_config` as a
   separate call callers had to remember to invoke before spawning a process. This is a
   builder-level guarantee, not a type-level one — every `ServerConfig` field is `pub` and the
   type derives `Deserialize`, so a config assembled by other means (a struct literal, or
-  deserializing untrusted JSON directly) is not covered by it. `try_build()` is now an alias
-  for `build()` (both run the same validation) and its error type changed from `String` to
-  `Error`. Every in-tree caller (`mcp-cli`, `mcp-server`, `mcp-introspector`) has been updated;
-  `Introspector::discover_server` still re-validates its `config` argument as defense in
-  depth, since it cannot assume every caller went through the builder.
+  deserializing untrusted JSON directly) is not covered by it. Every in-tree caller
+  (`mcp-cli`, `mcp-server`, `mcp-introspector`) has been updated; `Introspector::discover_server`
+  still re-validates its `config` argument as defense in depth, since it cannot assume every
+  caller went through the builder.
 
 - **`mcp-execution-cli`**: `McpServerEntry` no longer has `command`/`args`/`env` fields
   directly; they now live under a new `transport: McpTransport` field (`Stdio { command, args,
@@ -38,6 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an absolute target directory (any path the caller supplied was used verbatim) to a directory
   *relative to* `~/.claude/servers/{server_id}/`, as part of the path-confinement fix below
   (#216). A caller previously passing an absolute `output_dir` now gets `INVALID_PARAMS`.
+
+- **`mcp-execution-core`**: `ServerConfigBuilder::try_build()` removed — use `build()`, which
+  has returned `Result<ServerConfig, Error>` since #177 and runs identical validation; the
+  alias left the workspace's two builders with divergent surfaces where `FilesBuilder` exposes
+  only `build()` (#187).
+
+- **`mcp-execution-core`**: `Error::ResourceNotFound` and `Error::ConfigError` variants plus
+  their `is_not_found()`/`is_config_error()` predicates removed — never constructed by
+  production code; each crate owns its own error type for these conditions
+  (`mcp_files::FilesError::FileNotFound`, rmcp's `McpError` in `mcp-server`, `anyhow` in
+  `mcp-cli`), and `ServerConfigBuilder` uses the more precise `ValidationError` (#199). Note
+  `mcp_files::FilesError::is_not_found()` is a different type and is unchanged.
 
 ### Security
 
@@ -91,7 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now has a hand-written `Debug` impl that keeps `headers`/`env` keys visible but replaces every
   value with `<redacted>`; `Serialize`/`Deserialize` are unchanged and still round-trip real
   values for config persistence (#208). `ServerConfigBuilder`, which accumulates the same two
-  maps before `build()`/`try_build()` is called, derived `Debug` over them too and gets the same
+  maps before `build()` is called, derived `Debug` over them too and gets the same
   treatment, reusing the private `RedactedValues` helper introduced for `ServerConfig`.
 
 - **`mcp-execution-cli`**: `McpTransport`'s `Http`/`Sse` variants derived a plain `Debug`, so

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -228,10 +228,9 @@ fn classify_exit_code(error: &anyhow::Error) -> ExitCode {
             CoreError::ValidationError { .. }
             | CoreError::SecurityViolation { .. }
             | CoreError::InvalidArgument(_) => ExitCode::INVALID_INPUT,
-            CoreError::ResourceNotFound { .. }
-            | CoreError::ConfigError { .. }
-            | CoreError::SerializationError { .. }
-            | CoreError::ScriptGenerationError { .. } => ExitCode::ERROR,
+            CoreError::SerializationError { .. } | CoreError::ScriptGenerationError { .. } => {
+                ExitCode::ERROR
+            }
         })
 }
 
@@ -286,13 +285,16 @@ mod tests {
 
     #[test]
     fn test_classify_exit_code_other_core_errors_fall_back_to_error() {
-        let err = wrap(CoreError::ResourceNotFound {
-            resource: "server:missing".to_string(),
+        let err = wrap(CoreError::SerializationError {
+            message: "bad json".to_string(),
+            source: None,
         });
         assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
 
-        let err = wrap(CoreError::ConfigError {
-            message: "bad config".to_string(),
+        let err = wrap(CoreError::ScriptGenerationError {
+            tool: "example_tool".to_string(),
+            message: "template rendering failed".to_string(),
+            source: None,
         });
         assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
     }

--- a/crates/mcp-core/README.md
+++ b/crates/mcp-core/README.md
@@ -66,8 +66,9 @@ use mcp_execution_core::{Error, Result};
 
 fn process_server(id: &str) -> Result<()> {
     if id.is_empty() {
-        return Err(Error::ConfigError {
-            message: "Server ID cannot be empty".to_string(),
+        return Err(Error::ValidationError {
+            field: "id".to_string(),
+            reason: "Server ID cannot be empty".to_string(),
         });
     }
     Ok(())

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -289,7 +289,7 @@ fn validate_stdio_config(config: &ServerConfig) -> Result<()> {
 ///
 /// `url` is `Option` at the type level and `#[serde(default)]`, so a
 /// hand-edited `mcp.json` with `"transport": "http"` and no `url` key
-/// deserializes successfully, bypassing `ServerConfigBuilder::try_build`'s
+/// deserializes successfully, bypassing `ServerConfigBuilder::build`'s
 /// "url required" check. This function is the actual enforcement point.
 fn validate_network_config(config: &ServerConfig) -> Result<()> {
     let url = config.url().ok_or_else(|| Error::ValidationError {
@@ -588,14 +588,12 @@ mod tests {
     #[test]
     fn test_validate_server_config_empty_command() {
         // Empty command should fail during build
-        let result = ServerConfig::builder().command(String::new()).try_build();
+        let result = ServerConfig::builder().command(String::new()).build();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("empty"));
 
         // Whitespace-only command should fail during build
-        let result = ServerConfig::builder()
-            .command("   ".to_string())
-            .try_build();
+        let result = ServerConfig::builder().command("   ".to_string()).build();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("empty"));
     }
@@ -1019,7 +1017,7 @@ mod tests {
     }
 
     /// Constructs an Http-transport config missing `url` via deserialization
-    /// rather than the builder, since `try_build()` already refuses this and
+    /// rather than the builder, since `build()` already refuses this and
     /// would mask the bug this test guards against: a hand-edited `mcp.json`
     /// with `"transport": "http"` and no `url` key deserializes fine because
     /// every field is `#[serde(default)]`.

--- a/crates/mcp-core/src/error.rs
+++ b/crates/mcp-core/src/error.rs
@@ -10,15 +10,16 @@
 //!
 //! fn connect_to_server(name: &str) -> Result<()> {
 //!     if name.is_empty() {
-//!         return Err(Error::ConfigError {
-//!             message: "Server name cannot be empty".to_string(),
+//!         return Err(Error::ValidationError {
+//!             field: "name".to_string(),
+//!             reason: "Server name cannot be empty".to_string(),
 //!         });
 //!     }
 //!     Ok(())
 //! }
 //!
 //! let err = connect_to_server("").unwrap_err();
-//! assert!(err.is_config_error());
+//! assert!(err.is_validation_error());
 //! ```
 
 use thiserror::Error;
@@ -52,26 +53,6 @@ pub enum Error {
     SecurityViolation {
         /// Description of the security violation
         reason: String,
-    },
-
-    /// Resource not found error.
-    ///
-    /// Occurs when attempting to access a resource (file, tool, server)
-    /// that does not exist.
-    #[error("Resource not found: {resource}")]
-    ResourceNotFound {
-        /// Identifier of the missing resource
-        resource: String,
-    },
-
-    /// Configuration error.
-    ///
-    /// Raised when configuration is invalid, missing required fields,
-    /// or contains contradictory settings.
-    #[error("Configuration error: {message}")]
-    ConfigError {
-        /// Description of the configuration problem
-        message: String,
     },
 
     /// Timeout error.
@@ -166,40 +147,6 @@ impl Error {
         matches!(self, Self::SecurityViolation { .. })
     }
 
-    /// Returns `true` if this is a resource not found error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_core::Error;
-    ///
-    /// let err = Error::ResourceNotFound {
-    ///     resource: "tool:example".to_string(),
-    /// };
-    /// assert!(err.is_not_found());
-    /// ```
-    #[must_use]
-    pub const fn is_not_found(&self) -> bool {
-        matches!(self, Self::ResourceNotFound { .. })
-    }
-
-    /// Returns `true` if this is a configuration error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_core::Error;
-    ///
-    /// let err = Error::ConfigError {
-    ///     message: "Invalid port".to_string(),
-    /// };
-    /// assert!(err.is_config_error());
-    /// ```
-    #[must_use]
-    pub const fn is_config_error(&self) -> bool {
-        matches!(self, Self::ConfigError { .. })
-    }
-
     /// Returns `true` if this is a timeout error.
     ///
     /// # Examples
@@ -268,9 +215,9 @@ impl Error {
 ///
 /// fn validate_input(value: i32) -> Result<i32> {
 ///     if value < 0 {
-///         return Err(Error::ConfigError {
-///             message: "Value must be non-negative".to_string(),
-///         });
+///         return Err(Error::InvalidArgument(
+///             "Value must be non-negative".to_string(),
+///         ));
 ///     }
 ///     Ok(value)
 /// }
@@ -304,31 +251,13 @@ mod tests {
     }
 
     #[test]
-    fn test_not_found_error_detection() {
-        let err = Error::ResourceNotFound {
-            resource: "missing-tool".to_string(),
-        };
-        assert!(err.is_not_found());
-        assert!(!err.is_timeout());
-    }
-
-    #[test]
-    fn test_config_error_detection() {
-        let err = Error::ConfigError {
-            message: "Invalid configuration".to_string(),
-        };
-        assert!(err.is_config_error());
-        assert!(!err.is_timeout());
-    }
-
-    #[test]
     fn test_timeout_error_detection() {
         let err = Error::Timeout {
             operation: "long_operation".to_string(),
             duration_secs: 60,
         };
         assert!(err.is_timeout());
-        assert!(!err.is_not_found());
+        assert!(!err.is_validation_error());
     }
 
     #[test]
@@ -349,9 +278,7 @@ mod tests {
         }
 
         fn returns_err() -> Result<i32> {
-            Err(Error::ConfigError {
-                message: "test error".to_string(),
-            })
+            Err(Error::InvalidArgument("test error".to_string()))
         }
 
         assert_eq!(returns_ok().unwrap(), 42);

--- a/crates/mcp-core/src/server_config.rs
+++ b/crates/mcp-core/src/server_config.rs
@@ -105,7 +105,7 @@ pub enum TransportType {
 ///
 /// # Security
 ///
-/// [`ServerConfigBuilder::build`] (and its [`ServerConfigBuilder::try_build`] alias) run
+/// [`ServerConfigBuilder::build`] runs
 /// [`validate_server_config`] internally, so a `ServerConfig` built through the builder
 /// cannot be constructed without having already passed security validation. This is *not*
 /// a type-level guarantee, though: every field is `pub` and the type derives `Deserialize`,
@@ -144,7 +144,7 @@ pub enum TransportType {
 /// up with a secret-shaped key in `format!("{builder:?}")`. Keys are shown
 /// there deliberately regardless — redacting them would defeat the point of
 /// a debug impl for a type whose purpose is to be inspected before
-/// `build()`/`try_build()`.
+/// `build()`.
 ///
 /// `Serialize`/`Deserialize` are deliberately left unredacted: config
 /// persistence and the wire format must still round-trip real values.
@@ -785,31 +785,9 @@ impl ServerConfigBuilder {
     ///
     /// [`validate_server_config`]: fn.validate_server_config.html
     pub fn build(self) -> crate::Result<ServerConfig> {
-        let config = self.try_build_structural()?;
+        let config = self.build_structural()?;
         crate::validate_server_config(&config)?;
         Ok(config)
-    }
-
-    /// Alias for [`Self::build`], kept for call sites that prefer the
-    /// `try_`-prefixed fallible-constructor naming.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`Self::build`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_core::ServerConfig;
-    ///
-    /// let result = ServerConfig::builder()
-    ///     .command("docker".to_string())
-    ///     .try_build();
-    ///
-    /// assert!(result.is_ok());
-    /// ```
-    pub fn try_build(self) -> crate::Result<ServerConfig> {
-        self.build()
     }
 
     /// Checks structural completeness (command/url presence) and assembles
@@ -819,7 +797,7 @@ impl ServerConfigBuilder {
     /// "is this config structurally complete" and "is this config safe to
     /// spawn" — stay independently testable, while the public API only ever
     /// hands out a fully validated [`ServerConfig`].
-    fn try_build_structural(self) -> crate::Result<ServerConfig> {
+    fn build_structural(self) -> crate::Result<ServerConfig> {
         match self.transport {
             TransportType::Stdio => {
                 let command = self.command.ok_or_else(|| crate::Error::ValidationError {
@@ -994,8 +972,8 @@ mod tests {
     }
 
     #[test]
-    fn test_server_config_builder_try_build_missing_command() {
-        let result = ServerConfig::builder().try_build();
+    fn test_server_config_builder_build_missing_command() {
+        let result = ServerConfig::builder().build();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("command"));
     }
@@ -1083,7 +1061,7 @@ mod tests {
     #[test]
     fn test_server_config_debug_redacts_header_values() {
         // headers are only populated for HTTP/SSE transport (see the
-        // builder's `try_build`), so exercise them via `http_transport`.
+        // builder's `build`), so exercise them via `http_transport`.
         let config = ServerConfig::builder()
             .http_transport("https://api.example.com/mcp".to_string())
             .header(
@@ -1104,7 +1082,7 @@ mod tests {
     #[test]
     fn test_server_config_debug_redacts_env_values() {
         // env is only populated for stdio transport (see the builder's
-        // `try_build`), so exercise it via the default stdio transport.
+        // `build`), so exercise it via the default stdio transport.
         let config = ServerConfig::builder()
             .command("docker".to_string())
             .env(
@@ -1153,7 +1131,7 @@ mod tests {
         // Serialize/Deserialize must round-trip real values for config
         // persistence; only Debug formatting is redacted. Headers and env
         // are exercised separately since `build()` drops whichever one
-        // doesn't match the config's transport (see `try_build`).
+        // doesn't match the config's transport.
         let http_config = ServerConfig::builder()
             .http_transport("https://api.example.com/mcp".to_string())
             .header(
@@ -1240,8 +1218,8 @@ mod tests {
     }
 
     #[test]
-    fn test_server_config_http_try_build_missing_url() {
-        let result = ServerConfig::builder().try_build();
+    fn test_server_config_http_build_missing_url() {
+        let result = ServerConfig::builder().build();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("required"));
     }
@@ -1301,11 +1279,11 @@ mod tests {
     }
 
     #[test]
-    fn test_server_config_sse_try_build_missing_url() {
+    fn test_server_config_sse_build_missing_url() {
         let mut builder = ServerConfig::builder();
         builder.transport = TransportType::Sse;
 
-        let result = builder.try_build();
+        let result = builder.build();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("url is required"));
     }

--- a/crates/mcp-introspector/tests/integration_test.rs
+++ b/crates/mcp-introspector/tests/integration_test.rs
@@ -362,7 +362,7 @@ fn test_multiple_server_management() {
 #[test]
 fn test_discover_server_empty_command() {
     // Empty command should fail during build
-    let result = ServerConfig::builder().command(String::new()).try_build();
+    let result = ServerConfig::builder().command(String::new()).build();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("empty"));
 }
@@ -371,9 +371,7 @@ fn test_discover_server_empty_command() {
 #[test]
 fn test_discover_server_whitespace_command() {
     // Whitespace-only command should fail during build
-    let result = ServerConfig::builder()
-        .command("   ".to_string())
-        .try_build();
+    let result = ServerConfig::builder().command("   ".to_string()).build();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("empty"));
 }


### PR DESCRIPTION
## Summary
- Remove `ServerConfigBuilder::try_build()`, a pure `self.build()` alias left over from before `build()` itself was made fallible (#177/#233) — the alias was the only remaining divergence between `ServerConfigBuilder` and `FilesBuilder`'s single-terminal-method shape.
- Remove `mcp_execution_core::Error::ConfigError` and `Error::ResourceNotFound`, plus `is_config_error()`/`is_not_found()`, since neither is ever constructed by production code. `ServerConfigBuilder`'s real validation failures already use the richer `ValidationError { field, reason }`; each downstream crate owns its own error type for "not found" conditions instead.
- Update every workspace call site (`mcp-core` tests, `mcp-core/command.rs`, `mcp-introspector`'s integration test, `mcp-cli/runner.rs`'s exhaustive `classify_exit_code` match).

Closes #187, closes #199.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (789/789 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Workspace-wide sweep for `try_build`/`ConfigError`/`ResourceNotFound`/`is_config_error`/`is_not_found` confirms no dangling references (outside the unrelated `mcp_files::FilesError::is_not_found`)