### PR TITLE
cli,core: redact command/args/url/cwd and RawMcpServerEntry in Debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   builder chain that produces it is now a standalone `build_stdio_server_config` function so this
   last test can assert on it directly, rather than only on the params type feeding it (#209).
 
+- **`mcp-execution-core`**/**`mcp-execution-cli`**: the `#208`/`#229` `Debug` redaction only
+  covered `headers`/`env`; `args`, `url`, `command`, and `cwd` were still printed verbatim on
+  `ServerConfig`, `ServerConfigBuilder`, `McpTransport`, and `TransportArgs`, so an
+  `--api-key sk-...`-style argument or a `user:token@host`/`?token=`-style URL could still leak
+  through `{:?}`. `RawMcpServerEntry` (the raw `mcp.json` landing zone `McpTransport` is built
+  from) derived `Debug` outright, with no redaction at all (#241). Three shared, dependency-free
+  helpers now live in `mcp-execution-core::redact` (#240) — `RedactedMapValues` (keys visible,
+  values replaced), `RedactedItems` (every entry replaced wholesale), and `RedactedUrl`
+  (userinfo and query string stripped, scheme/host/path kept readable) — and every one of the
+  five types above now redacts `args`/`url` through them, while `command`/`cwd` are passed
+  through the existing `sanitize_path_for_error` (an absolute path leaks the OS username; the
+  program name itself, e.g. `docker`, stays readable) (#239, #241). `RedactedUrl` itself closes
+  two edge cases found during review: an unencoded `/` or `?` inside userinfo (e.g.
+  `user:p/assw0rd@host`) could previously move the authority terminator into the middle of the
+  credentials and leak them verbatim, and a "scheme" containing a character that can never
+  legally appear in a URI scheme (e.g. `ghp_leakedtoken://host.com/`) was echoed unbounded; both
+  now fall back to redacting the entire URL rather than risk a partial leak. A fragment-only URL
+  (no query string) is now labeled `#<redacted>` rather than the misleading `?<redacted>`.
+
 ### Changed
 
 - **`mcp-execution-skill`**: `validate_server_id` and `extract_skill_metadata` now return

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -4,7 +4,10 @@
 //! and loading MCP server definitions from `~/.claude/mcp.json`.
 
 use anyhow::{Context, Result, bail};
-use mcp_execution_core::{Error as CoreError, ServerConfig, ServerConfigBuilder, ServerId};
+use mcp_execution_core::{
+    Error as CoreError, REDACTED_PLACEHOLDER, RedactedItems, RedactedMapValues, RedactedUrl,
+    ServerConfig, ServerConfigBuilder, ServerId, sanitize_path_for_error,
+};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt;
@@ -47,8 +50,8 @@ pub struct McpConfig {
 /// assert!(matches!(transport, McpTransport::Http { .. }));
 /// ```
 ///
-/// Debug output redacts header/env values but keeps keys, mirroring
-/// `mcp_execution_core::ServerConfig`:
+/// Debug output redacts header/env values (keeping keys), `args` wholesale,
+/// and URL userinfo/query strings, mirroring `mcp_execution_core::ServerConfig`:
 ///
 /// ```
 /// use mcp_execution_cli::commands::common::McpTransport;
@@ -92,23 +95,6 @@ pub enum McpTransport {
     },
 }
 
-/// Debug-formats a `String`-valued map with keys visible and every value
-/// replaced by a fixed placeholder.
-///
-/// Mirrors `mcp_execution_core::ServerConfig`'s redaction convention: `env`
-/// and `headers` here are populated straight from `~/.claude/mcp.json` and
-/// routinely carry secrets (bearer tokens, API keys) before this crate ever
-/// validates them.
-struct RedactedValues<'a>(&'a HashMap<String, String>);
-
-impl fmt::Debug for RedactedValues<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_map()
-            .entries(self.0.keys().map(|key| (key, "<redacted>")))
-            .finish()
-    }
-}
-
 impl fmt::Debug for McpTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -119,20 +105,20 @@ impl fmt::Debug for McpTransport {
                 cwd,
             } => f
                 .debug_struct("Stdio")
-                .field("command", command)
-                .field("args", args)
-                .field("env", &RedactedValues(env))
-                .field("cwd", cwd)
+                .field("command", &sanitize_path_for_error(Path::new(command)))
+                .field("args", &RedactedItems(args))
+                .field("env", &RedactedMapValues(env))
+                .field("cwd", &cwd.as_deref().map(sanitize_path_for_error))
                 .finish(),
             Self::Http { url, headers } => f
                 .debug_struct("Http")
-                .field("url", url)
-                .field("headers", &RedactedValues(headers))
+                .field("url", &RedactedUrl(url))
+                .field("headers", &RedactedMapValues(headers))
                 .finish(),
             Self::Sse { url, headers } => f
                 .debug_struct("Sse")
-                .field("url", url)
-                .field("headers", &RedactedValues(headers))
+                .field("url", &RedactedUrl(url))
+                .field("headers", &RedactedMapValues(headers))
                 .finish(),
         }
     }
@@ -180,7 +166,14 @@ impl TransportTag {
 /// rather than hard-failing, since `~/.claude/mcp.json` is shared with other
 /// MCP clients that store keys this project doesn't model (`disabled`,
 /// `alwaysAllow`, ...).
-#[derive(Debug, Deserialize)]
+///
+/// This is a raw landing zone for the same `mcp.json` data [`McpTransport`]
+/// carries, so its hand-written [`Debug`] impl applies the identical
+/// redaction: `command`/`cwd` sanitized, `args` redacted wholesale, `url`
+/// stripped of userinfo/query, `env`/`headers` values redacted (keys kept),
+/// and `extra` values redacted (keys kept) since they are arbitrary JSON
+/// this project has not validated.
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase", rename = "McpServerEntry")]
 struct RawMcpServerEntry {
     #[serde(rename = "type")]
@@ -198,6 +191,51 @@ struct RawMcpServerEntry {
     discover_timeout_secs: Option<u64>,
     #[serde(flatten)]
     extra: HashMap<String, serde_json::Value>,
+}
+
+/// Debug-formats an `extra`-style unknown-fields map with keys visible and
+/// every value replaced by [`REDACTED_PLACEHOLDER`].
+///
+/// `extra` holds arbitrary JSON from a shared `mcp.json` this project
+/// doesn't validate — treated as secret-shaped for the same reason
+/// [`RedactedMapValues`] treats `env`/`headers` values that way.
+struct RedactedExtra<'a>(&'a HashMap<String, serde_json::Value>);
+
+impl fmt::Debug for RedactedExtra<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map()
+            .entries(self.0.keys().map(|key| (key, REDACTED_PLACEHOLDER)))
+            .finish()
+    }
+}
+
+impl fmt::Debug for RawMcpServerEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RawMcpServerEntry")
+            .field("transport_type", &self.transport_type)
+            .field(
+                "command",
+                &self
+                    .command
+                    .as_deref()
+                    .map(|command| sanitize_path_for_error(Path::new(command))),
+            )
+            .field("args", &RedactedItems(&self.args))
+            .field("env", &RedactedMapValues(&self.env))
+            .field(
+                "cwd",
+                &self
+                    .cwd
+                    .as_deref()
+                    .map(|cwd| sanitize_path_for_error(Path::new(cwd))),
+            )
+            .field("url", &self.url.as_deref().map(RedactedUrl))
+            .field("headers", &RedactedMapValues(&self.headers))
+            .field("connect_timeout_secs", &self.connect_timeout_secs)
+            .field("discover_timeout_secs", &self.discover_timeout_secs)
+            .field("extra", &RedactedExtra(&self.extra))
+            .finish()
+    }
 }
 
 /// Resolves the `url`/`command` pair for an http-like (`http` or `sse`)
@@ -631,24 +669,6 @@ pub enum TransportArgs {
     },
 }
 
-/// Debug-formats a list of raw `KEY=VALUE` CLI argument strings, replacing
-/// every entry wholesale with a fixed placeholder.
-///
-/// Unlike `RedactedValues` (which redacts only the value half of an
-/// already-split map), these strings are pre-`parse_key_value` and may not
-/// even contain a `=` — the whole string can be the secret with no
-/// discernible key, per that function's own doc comment — so the entire
-/// entry is replaced rather than just a value half.
-struct RedactedList<'a>(&'a [String]);
-
-impl fmt::Debug for RedactedList<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list()
-            .entries(self.0.iter().map(|_| "<redacted>"))
-            .finish()
-    }
-}
-
 impl fmt::Debug for TransportArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -659,20 +679,24 @@ impl fmt::Debug for TransportArgs {
                 cwd,
             } => f
                 .debug_struct("Stdio")
-                .field("command", command)
-                .field("args", args)
-                .field("env", &RedactedList(env))
-                .field("cwd", cwd)
+                .field("command", &sanitize_path_for_error(Path::new(command)))
+                .field("args", &RedactedItems(args))
+                .field("env", &RedactedItems(env))
+                .field(
+                    "cwd",
+                    &cwd.as_deref()
+                        .map(|cwd| sanitize_path_for_error(Path::new(cwd))),
+                )
                 .finish(),
             Self::Http { url, headers } => f
                 .debug_struct("Http")
-                .field("url", url)
-                .field("headers", &RedactedList(headers))
+                .field("url", &RedactedUrl(url))
+                .field("headers", &RedactedItems(headers))
                 .finish(),
             Self::Sse { url, headers } => f
                 .debug_struct("Sse")
-                .field("url", url)
-                .field("headers", &RedactedList(headers))
+                .field("url", &RedactedUrl(url))
+                .field("headers", &RedactedItems(headers))
                 .finish(),
         }
     }
@@ -1368,6 +1392,93 @@ mod tests {
         assert!(!stdio_debug.contains(secret_body));
         assert!(!stdio_debug.contains("GITHUB_TOKEN"));
         assert!(stdio_debug.contains("<redacted>"));
+    }
+
+    #[test]
+    fn test_mcp_transport_debug_redacts_args() {
+        let secret = "sk-live-secret";
+        let transport = McpTransport::Stdio {
+            command: "node".to_string(),
+            args: vec!["--api-key".to_string(), secret.to_string()],
+            env: HashMap::new(),
+            cwd: None,
+        };
+
+        let debug_output = format!("{transport:?}");
+        assert!(!debug_output.contains(secret));
+    }
+
+    #[test]
+    fn test_mcp_transport_debug_redacts_url_userinfo_and_query() {
+        let secret = "hunter2";
+        let http = McpTransport::Http {
+            url: format!("https://user:{secret}@api.example.com/mcp?token={secret}"),
+            headers: HashMap::new(),
+        };
+        let http_debug = format!("{http:?}");
+        assert!(!http_debug.contains(secret));
+        assert!(http_debug.contains("api.example.com/mcp"));
+
+        let sse = McpTransport::Sse {
+            url: format!("https://user:{secret}@api.example.com/sse?token={secret}"),
+            headers: HashMap::new(),
+        };
+        let sse_debug = format!("{sse:?}");
+        assert!(!sse_debug.contains(secret));
+        assert!(sse_debug.contains("api.example.com/sse"));
+    }
+
+    #[test]
+    fn test_transport_args_debug_redacts_args() {
+        let secret = "sk-live-secret";
+        let stdio = TransportArgs::Stdio {
+            command: "node".to_string(),
+            args: vec!["--api-key".to_string(), secret.to_string()],
+            env: vec![],
+            cwd: None,
+        };
+
+        let debug_output = format!("{stdio:?}");
+        assert!(!debug_output.contains(secret));
+    }
+
+    #[test]
+    fn test_transport_args_debug_redacts_url_userinfo_and_query() {
+        let secret = "hunter2";
+        let http = TransportArgs::Http {
+            url: format!("https://user:{secret}@api.example.com/mcp?token={secret}"),
+            headers: vec![],
+        };
+        let http_debug = format!("{http:?}");
+        assert!(!http_debug.contains(secret));
+        assert!(http_debug.contains("api.example.com/mcp"));
+    }
+
+    #[test]
+    fn test_raw_mcp_server_entry_debug_redacts_secret_shaped_fields() {
+        let secret = "sk-live-secret";
+        let entry = RawMcpServerEntry {
+            transport_type: Some(TransportTag::Stdio),
+            command: Some("node".to_string()),
+            args: vec!["--api-key".to_string(), secret.to_string()],
+            env: HashMap::from([("GITHUB_TOKEN".to_string(), secret.to_string())]),
+            cwd: None,
+            url: None,
+            headers: HashMap::new(),
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+            extra: HashMap::from([(
+                "someUnknownSecret".to_string(),
+                serde_json::Value::String(secret.to_string()),
+            )]),
+        };
+
+        let debug_output = format!("{entry:?}");
+        assert!(!debug_output.contains(secret));
+        // Keys stay visible for debugging.
+        assert!(debug_output.contains("GITHUB_TOKEN"));
+        assert!(debug_output.contains("someUnknownSecret"));
+        assert!(debug_output.contains("node"));
     }
 
     #[test]

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -34,6 +34,7 @@
 mod command;
 mod error;
 mod path;
+mod redact;
 mod server_config;
 mod types;
 
@@ -56,3 +57,6 @@ pub use command::{
 
 // Re-export path helpers shared by confinement checks
 pub use path::{sanitize_path_for_error, validate_path_segment};
+
+// Re-export Debug-redaction helpers shared by secret-shaped fields
+pub use redact::{REDACTED_PLACEHOLDER, RedactedItems, RedactedMapValues, RedactedUrl};

--- a/crates/mcp-core/src/redact.rs
+++ b/crates/mcp-core/src/redact.rs
@@ -1,0 +1,292 @@
+//! Shared `Debug`-redaction helpers for secret-shaped fields.
+//!
+//! `ServerConfig` and the transport types built on top of it (in
+//! `mcp-execution-cli`) carry fields that routinely hold secrets: header/env
+//! values, CLI argument lists, and URLs with embedded credentials or a
+//! `?token=`-style query string. Every one of those types needs the same
+//! redaction behavior in its hand-written [`Debug`] impl, so the wrapper
+//! types here are the single source of truth — implement it once, reuse it
+//! everywhere a `{:?}` might otherwise leak a credential into a log line or
+//! error message.
+
+use std::collections::HashMap;
+use std::fmt;
+
+/// Fixed placeholder substituted for every redacted value.
+///
+/// A single constant so every redacting [`Debug`] impl (and every test that
+/// asserts on the placeholder) stays in sync if the text ever changes.
+pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
+
+/// Debug-formats a `String`-valued map with keys visible and every value
+/// replaced by [`REDACTED_PLACEHOLDER`].
+///
+/// Intended for `env`/`headers`-style maps: the key (e.g. `"Authorization"`
+/// or `"GITHUB_PERSONAL_ACCESS_TOKEN"`) is a caller-chosen identifier and
+/// useful for debugging, but the value routinely holds a bearer token or API
+/// key and must never be echoed.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::RedactedMapValues;
+/// use std::collections::HashMap;
+///
+/// let mut headers = HashMap::new();
+/// headers.insert("Authorization".to_string(), "Bearer sk-secret".to_string());
+///
+/// let debug_output = format!("{:?}", RedactedMapValues(&headers));
+/// assert!(debug_output.contains("Authorization"));
+/// assert!(!debug_output.contains("sk-secret"));
+/// ```
+#[derive(Clone, Copy)]
+pub struct RedactedMapValues<'a>(pub &'a HashMap<String, String>);
+
+impl fmt::Debug for RedactedMapValues<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map()
+            .entries(self.0.keys().map(|key| (key, REDACTED_PLACEHOLDER)))
+            .finish()
+    }
+}
+
+/// Debug-formats a list of strings, replacing every entry wholesale with
+/// [`REDACTED_PLACEHOLDER`].
+///
+/// Unlike [`RedactedMapValues`] (which redacts only the value half of an
+/// already-split key/value pair), this is for lists where a single entry may
+/// not have a discernible key at all — a raw pre-parse `KEY=VALUE` CLI
+/// argument may not even contain a `=`, and a `ServerConfig::args` entry can
+/// itself be an entire `--api-key sk-...`-style secret. Since there is no
+/// safe-to-keep half, the whole entry is replaced.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::RedactedItems;
+///
+/// let args = vec!["--api-key".to_string(), "sk-secret".to_string()];
+/// let debug_output = format!("{:?}", RedactedItems(&args));
+/// assert!(!debug_output.contains("sk-secret"));
+/// assert!(debug_output.contains("<redacted>"));
+/// ```
+#[derive(Clone, Copy)]
+pub struct RedactedItems<'a>(pub &'a [String]);
+
+impl fmt::Debug for RedactedItems<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(self.0.iter().map(|_| REDACTED_PLACEHOLDER))
+            .finish()
+    }
+}
+
+/// Debug-formats a URL with userinfo credentials and query string hidden,
+/// keeping the scheme, host, and path readable.
+///
+/// A URL can carry a secret two ways: `user:pass@host` userinfo, or a
+/// `?api_key=...`-style query parameter. Both are stripped; everything else
+/// (scheme, host, path) is left intact since it's the most useful part of a
+/// URL for telling two server entries apart in a log.
+///
+/// This is deliberately parse-free (mcp-core does not depend on the `url`
+/// crate) rather than a strict parser: if the input doesn't contain `://`, if
+/// the scheme before it contains a character that is never valid in a URI
+/// scheme, or if userinfo redaction would be ambiguous (see below), the whole
+/// input is treated as unparseable and redacted in full — mirroring the
+/// discard-on-parse-failure rule `mcp-execution-cli` already applies when
+/// deriving a server ID from a URL. Ambiguity arises when the authority
+/// terminator (the first `/`, `?`, or `#` after the scheme) lands *inside*
+/// unencoded userinfo rather than at a true authority boundary — e.g. an
+/// unencoded `/` in a password — which would otherwise let the userinfo
+/// escape redaction entirely. Detected by checking whether an `@` still
+/// appears after that terminator.
+///
+/// # Examples
+///
+/// A URL with userinfo and a query string has both hidden, while the host
+/// and path stay readable:
+///
+/// ```
+/// use mcp_execution_core::RedactedUrl;
+///
+/// let url = "https://user:sk-secret@api.example.com/mcp?token=sk-secret";
+/// let debug_output = format!("{:?}", RedactedUrl(url));
+/// assert!(!debug_output.contains("sk-secret"));
+/// assert!(debug_output.contains("api.example.com/mcp"));
+/// ```
+///
+/// A plain URL with neither is unchanged:
+///
+/// ```
+/// use mcp_execution_core::RedactedUrl;
+///
+/// let url = "https://api.example.com/mcp";
+/// let debug_output = format!("{:?}", RedactedUrl(url));
+/// assert_eq!(debug_output, "https://api.example.com/mcp");
+/// ```
+#[derive(Clone, Copy)]
+pub struct RedactedUrl<'a>(pub &'a str);
+
+impl fmt::Debug for RedactedUrl<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Some((scheme, rest)) = self.0.split_once("://") else {
+            return f.write_str(REDACTED_PLACEHOLDER);
+        };
+
+        let scheme_is_valid = !scheme.is_empty()
+            && scheme
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'));
+        if !scheme_is_valid {
+            return f.write_str(REDACTED_PLACEHOLDER);
+        }
+
+        let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+        let (authority, remainder) = rest.split_at(authority_end);
+
+        // See the type doc comment: an `@` past the authority terminator
+        // means the terminator landed inside unencoded userinfo rather than
+        // at a true authority boundary, so the split can't be trusted.
+        if remainder.contains('@') {
+            return f.write_str(REDACTED_PLACEHOLDER);
+        }
+
+        let authority = authority.rfind('@').map_or_else(
+            || authority.to_string(),
+            |at| format!("{REDACTED_PLACEHOLDER}@{}", &authority[at + 1..]),
+        );
+
+        let separator_pos = remainder.find(['?', '#']);
+        let path = separator_pos.map_or(remainder, |pos| &remainder[..pos]);
+
+        write!(f, "{scheme}://{authority}{path}")?;
+        if let Some(pos) = separator_pos {
+            let separator = &remainder[pos..=pos];
+            write!(f, "{separator}{REDACTED_PLACEHOLDER}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacted_map_values_keeps_keys_hides_values() {
+        let mut map = HashMap::new();
+        map.insert("Authorization".to_string(), "Bearer secret".to_string());
+
+        let debug_output = format!("{:?}", RedactedMapValues(&map));
+        assert!(debug_output.contains("Authorization"));
+        assert!(!debug_output.contains("Bearer secret"));
+    }
+
+    #[test]
+    fn redacted_items_hides_every_entry() {
+        let items = vec!["KEY=VALUE".to_string(), "just-a-secret".to_string()];
+        let debug_output = format!("{:?}", RedactedItems(&items));
+        assert!(!debug_output.contains("KEY=VALUE"));
+        assert!(!debug_output.contains("just-a-secret"));
+        assert_eq!(debug_output.matches(REDACTED_PLACEHOLDER).count(), 2);
+    }
+
+    #[test]
+    fn redacted_url_hides_userinfo() {
+        let debug_output = format!("{:?}", RedactedUrl("https://user:pass@host.com/path"));
+        assert_eq!(debug_output, "https://<redacted>@host.com/path");
+    }
+
+    #[test]
+    fn redacted_url_hides_query_string() {
+        let debug_output = format!(
+            "{:?}",
+            RedactedUrl("https://host.com/path?api_key=sk-secret")
+        );
+        assert_eq!(debug_output, "https://host.com/path?<redacted>");
+        assert!(!debug_output.contains("sk-secret"));
+    }
+
+    #[test]
+    fn redacted_url_hides_fragment() {
+        // M2: a fragment-only URL must be labeled `#<redacted>`, not
+        // `?<redacted>` — no query string was ever present.
+        let debug_output = format!("{:?}", RedactedUrl("https://host.com/path#sk-secret"));
+        assert_eq!(debug_output, "https://host.com/path#<redacted>");
+    }
+
+    #[test]
+    fn redacted_url_hides_userinfo_and_query_together() {
+        let debug_output = format!(
+            "{:?}",
+            RedactedUrl("https://user:pass@host.com/path?token=secret")
+        );
+        assert_eq!(debug_output, "https://<redacted>@host.com/path?<redacted>");
+    }
+
+    #[test]
+    fn redacted_url_leaves_plain_url_unchanged() {
+        let debug_output = format!("{:?}", RedactedUrl("https://api.example.com/mcp"));
+        assert_eq!(debug_output, "https://api.example.com/mcp");
+    }
+
+    #[test]
+    fn redacted_url_no_path_with_userinfo() {
+        let debug_output = format!("{:?}", RedactedUrl("https://user:pass@host.com?q=secret"));
+        assert_eq!(debug_output, "https://<redacted>@host.com?<redacted>");
+    }
+
+    #[test]
+    fn redacted_url_redacts_unparseable_input_entirely() {
+        let debug_output = format!("{:?}", RedactedUrl("not-a-url"));
+        assert_eq!(debug_output, REDACTED_PLACEHOLDER);
+    }
+
+    #[test]
+    fn redacted_url_uses_last_at_sign_for_authority_split() {
+        // A literal '@' can legally appear (percent-decoded) inside userinfo;
+        // splitting on the *last* '@' keeps the host resolution correct.
+        let debug_output = format!("{:?}", RedactedUrl("https://a@b:pass@host.com/path"));
+        assert_eq!(debug_output, "https://<redacted>@host.com/path");
+    }
+
+    #[test]
+    fn redacted_url_redacts_entirely_when_userinfo_contains_slash() {
+        // S1: an unencoded '/' inside a password moves the authority
+        // terminator into the middle of the credentials, so the naive split
+        // would leak them verbatim. The whole URL must be redacted instead.
+        let secret = "p/assw0rd";
+        let debug_output = format!(
+            "{:?}",
+            RedactedUrl(&format!("https://user:{secret}@host.com/mcp"))
+        );
+        assert_eq!(debug_output, REDACTED_PLACEHOLDER);
+        assert!(!debug_output.contains(secret));
+        assert!(!debug_output.contains("host.com"));
+    }
+
+    #[test]
+    fn redacted_url_redacts_entirely_when_userinfo_contains_query_marker() {
+        // Same ambiguity as above, via '?' instead of '/'.
+        let secret = "pa?ssw0rd";
+        let debug_output = format!(
+            "{:?}",
+            RedactedUrl(&format!("https://user:{secret}@host.com/mcp"))
+        );
+        assert_eq!(debug_output, REDACTED_PLACEHOLDER);
+        assert!(!debug_output.contains(secret));
+    }
+
+    #[test]
+    fn redacted_url_redacts_entirely_when_scheme_is_malformed() {
+        // M3: a scheme containing a character that can never legally appear
+        // in a URI scheme (e.g. '_') is a sign the "scheme" is actually
+        // secret-shaped text that happens to contain "://" — redact in full
+        // rather than echoing it verbatim.
+        let secret = "ghp_leakedtoken";
+        let debug_output = format!("{:?}", RedactedUrl(&format!("{secret}://host.com/")));
+        assert_eq!(debug_output, REDACTED_PLACEHOLDER);
+        assert!(!debug_output.contains(secret));
+    }
+}

--- a/crates/mcp-core/src/server_config.rs
+++ b/crates/mcp-core/src/server_config.rs
@@ -48,10 +48,12 @@
 //!     .build().unwrap();
 //! ```
 
+use crate::path::sanitize_path_for_error;
+use crate::redact::{RedactedItems, RedactedMapValues, RedactedUrl};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Default timeout for establishing an MCP server connection (handshake).
@@ -117,15 +119,26 @@ pub enum TransportType {
 /// connection; `mcp_execution_introspector::Introspector::discover_server` does this as
 /// defense-in-depth even though its own callers always go through the builder.
 ///
-/// `headers` and `env` routinely carry secrets (e.g. an `Authorization: Bearer
-/// <token>` header, or a `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable),
-/// so this type's [`Debug`] implementation is hand-written to redact their
-/// *values* while keeping keys visible — a legitimately configured key (a
-/// chosen header or env var name, e.g. `"Authorization"`) is not itself a
-/// secret and remains useful for debugging. This mirrors the discipline
-/// already applied to header values in `command.rs`'s
-/// `validate_header_value_string`, which never echoes a header value into an
-/// error message.
+/// `headers`, `env`, `args`, and `url` routinely carry secrets (e.g. an
+/// `Authorization: Bearer <token>` header, a `GITHUB_PERSONAL_ACCESS_TOKEN`
+/// environment variable, an `--api-key sk-...`-style argument, or a
+/// `?token=`-style query string), so this type's [`Debug`] implementation is
+/// hand-written to redact them:
+///
+/// - `headers`/`env`: keys stay visible, values are replaced — a legitimately
+///   configured key (a chosen header or env var name, e.g. `"Authorization"`)
+///   is not itself a secret and remains useful for debugging. This mirrors
+///   the discipline already applied to header values in `command.rs`'s
+///   `validate_header_value_string`, which never echoes a header value into
+///   an error message.
+/// - `args`: every entry is replaced wholesale (via [`crate::RedactedItems`])
+///   since an argument has no key/value split to preserve half of.
+/// - `url`: userinfo credentials and any query string are stripped (via
+///   [`crate::RedactedUrl`]); scheme, host, and path stay readable.
+/// - `command`/`cwd`: passed through [`crate::sanitize_path_for_error`] —
+///   not a secret, but an absolute path leaks the OS username, and the
+///   program name itself (`docker`, `npx`) is worth keeping readable for
+///   telling server entries apart in a log.
 ///
 /// This is a narrower guarantee than `command.rs`'s header-*name* validation
 /// errors, which redact the name too: those fire on input that has not yet
@@ -184,6 +197,31 @@ pub enum TransportType {
 /// let debug_output = format!("{config:?}");
 /// assert!(debug_output.contains("Authorization"));
 /// assert!(!debug_output.contains("sk-secret-value"));
+/// ```
+///
+/// Debug output redacts `args` wholesale and strips URL userinfo/query,
+/// while keeping `command` and the URL host/path readable:
+///
+/// ```
+/// use mcp_execution_core::ServerConfig;
+///
+/// let config = ServerConfig::builder()
+///     .command("docker".to_string())
+///     .arg("--api-key".to_string())
+///     .arg("sk-secret-arg".to_string())
+///     .build();
+///
+/// let debug_output = format!("{config:?}");
+/// assert!(debug_output.contains("docker"));
+/// assert!(!debug_output.contains("sk-secret-arg"));
+///
+/// let config = ServerConfig::builder()
+///     .http_transport("https://user:sk-secret@api.example.com/mcp?token=sk-secret".to_string())
+///     .build();
+///
+/// let debug_output = format!("{config:?}");
+/// assert!(debug_output.contains("api.example.com/mcp"));
+/// assert!(!debug_output.contains("sk-secret"));
 /// ```
 ///
 /// [`validate_server_config`]: fn.validate_server_config.html
@@ -274,33 +312,19 @@ pub struct ServerConfig {
     pub discover_timeout: Duration,
 }
 
-/// Debug-formats a `String`-valued map with keys visible and every value
-/// replaced by a fixed placeholder.
-///
-/// Used by `ServerConfig` and `ServerConfigBuilder`'s [`Debug`] impls for
-/// `headers` and `env`, both of which routinely carry secrets (bearer
-/// tokens, API keys). See the redaction note on [`ServerConfig`]'s own doc
-/// comment for why.
-struct RedactedValues<'a>(&'a HashMap<String, String>);
-
-impl fmt::Debug for RedactedValues<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_map()
-            .entries(self.0.keys().map(|key| (key, "<redacted>")))
-            .finish()
-    }
-}
-
 impl fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ServerConfig")
             .field("transport", &self.transport)
-            .field("command", &self.command)
-            .field("args", &self.args)
-            .field("env", &RedactedValues(&self.env))
-            .field("cwd", &self.cwd)
-            .field("url", &self.url)
-            .field("headers", &RedactedValues(&self.headers))
+            .field(
+                "command",
+                &sanitize_path_for_error(Path::new(&self.command)),
+            )
+            .field("args", &RedactedItems(&self.args))
+            .field("env", &RedactedMapValues(&self.env))
+            .field("cwd", &self.cwd.as_deref().map(sanitize_path_for_error))
+            .field("url", &self.url.as_deref().map(RedactedUrl))
+            .field("headers", &RedactedMapValues(&self.headers))
             .field("connect_timeout", &self.connect_timeout)
             .field("discover_timeout", &self.discover_timeout)
             .finish()
@@ -450,12 +474,18 @@ impl fmt::Debug for ServerConfigBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ServerConfigBuilder")
             .field("transport", &self.transport)
-            .field("command", &self.command)
-            .field("args", &self.args)
-            .field("env", &RedactedValues(&self.env))
-            .field("cwd", &self.cwd)
-            .field("url", &self.url)
-            .field("headers", &RedactedValues(&self.headers))
+            .field(
+                "command",
+                &self
+                    .command
+                    .as_deref()
+                    .map(|command| sanitize_path_for_error(Path::new(command))),
+            )
+            .field("args", &RedactedItems(&self.args))
+            .field("env", &RedactedMapValues(&self.env))
+            .field("cwd", &self.cwd.as_deref().map(sanitize_path_for_error))
+            .field("url", &self.url.as_deref().map(RedactedUrl))
+            .field("headers", &RedactedMapValues(&self.headers))
             .field("connect_timeout", &self.connect_timeout)
             .field("discover_timeout", &self.discover_timeout)
             .finish()
@@ -1098,6 +1128,60 @@ mod tests {
         assert!(debug_str.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
         // The value must never appear.
         assert!(!debug_str.contains("ghp_supersecretvalue"));
+    }
+
+    #[test]
+    fn test_server_config_debug_redacts_args() {
+        let secret = "sk-live-secret-arg-value";
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .arg("--api-key".to_string())
+            .arg(secret.to_string())
+            .build()
+            .unwrap();
+
+        let debug_str = format!("{config:?}");
+        assert!(!debug_str.contains(secret));
+    }
+
+    #[test]
+    fn test_server_config_debug_redacts_url_userinfo_and_query() {
+        let secret = "hunter2";
+        let config = ServerConfig::builder()
+            .http_transport(format!(
+                "https://user:{secret}@api.example.com/mcp?token={secret}"
+            ))
+            .build()
+            .unwrap();
+
+        let debug_str = format!("{config:?}");
+        assert!(!debug_str.contains(secret));
+        // Host/path stay readable.
+        assert!(debug_str.contains("api.example.com/mcp"));
+    }
+
+    #[test]
+    fn test_server_config_builder_debug_redacts_args() {
+        let secret = "sk-live-secret-arg-value";
+        let builder = ServerConfig::builder()
+            .command("docker".to_string())
+            .arg("--api-key".to_string())
+            .arg(secret.to_string());
+
+        let debug_str = format!("{builder:?}");
+        assert!(!debug_str.contains(secret));
+    }
+
+    #[test]
+    fn test_server_config_builder_debug_redacts_url_userinfo_and_query() {
+        let secret = "hunter2";
+        let builder = ServerConfig::builder().url(format!(
+            "https://user:{secret}@api.example.com/mcp?token={secret}"
+        ));
+
+        let debug_str = format!("{builder:?}");
+        assert!(!debug_str.contains(secret));
+        assert!(debug_str.contains("api.example.com/mcp"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Consolidates three duplicate `Debug`-redaction wrapper implementations (mcp-core's private `ServerConfig` wrapper, mcp-cli's `RedactedValues`/`RedactedList`) into a single shared `mcp_execution_core::redact` module (`REDACTED_PLACEHOLDER`, `RedactedMapValues`, `RedactedItems`, `RedactedUrl`), closing #240.
- Closes the redaction gap left by #208/#229: `args`, `url`, `command`, and `cwd` printed verbatim on `ServerConfig`, `ServerConfigBuilder`, `McpTransport`, and `TransportArgs`. `args`/`url` now route through the shared helpers; `command`/`cwd` route through the existing `sanitize_path_for_error` (keeps the program name readable, strips the OS username from absolute paths). Closes #239.
- `RawMcpServerEntry` (the pre-validation `mcp.json` landing-zone struct) derived plain `Debug` with no redaction at all — now hand-written, covering every field including its `extra` map. Closes #241.
- `RedactedUrl`'s parse-free algorithm falls back to full redaction on ambiguous input (an unencoded `/` or `?` inside userinfo, or an invalid URI scheme) rather than risk a partial credential leak — found and fixed during adversarial review of this PR.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (812 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests for args/url/command/cwd leak coverage across all 5 affected types, plus `RedactedUrl` edge cases (userinfo with `/`/`?`, malformed scheme, fragment-only URL)

## Follow-ups filed (out of scope for this PR)

- #245 — `Cli`/`Commands` clap structs have the same latent gap, earlier in the pipeline
- #246 — `sanitize_path_for_error` no-ops on Windows for forward-slash/case-differing home paths
- #247 — `ServerConfig` still derives `Serialize`, which bypasses the `Debug`-redaction guarantee