### PR TITLE
fix(core): match Windows separator/case variants in sanitize_path_for_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now fall back to redacting the entire URL rather than risk a partial leak. A fragment-only URL
   (no query string) is now labeled `#<redacted>` rather than the misleading `?<redacted>`.
 
+- **`mcp-execution-core`**: `sanitize_path_for_error` compared the home directory against the
+  input path as a literal, case-sensitive string, so it silently failed to redact the OS username
+  on Windows whenever the two didn't match byte-for-byte — a caller-supplied forward-slash path
+  (`mcp.json` is JSON, so `"cwd": "C:/Users/Name/proj"` is natural) never matched
+  `dirs::home_dir()`'s backslash-separated form, and neither did a path differing only in case,
+  even though Windows treats both as the same location (#246). The comparison now walks path
+  components instead of raw strings, so separator style no longer matters, and on Windows/macOS
+  (both case-insensitive-but-case-preserving by default) components are compared
+  ASCII-case-insensitively. When the component walk still can't recognize `path` as rooted at
+  `home` — e.g. a `\\?\`-verbatim canonicalized path, or `home` reached through a different mount
+  point — the bare username is scrubbed from the rendered path as a defense-in-depth fallback
+  rather than the previous behavior of returning the path unredacted.
+
 ### Changed
 
 - **`mcp-execution-skill`**: `validate_server_id` and `extract_skill_metadata` now return

--- a/crates/mcp-core/src/path.rs
+++ b/crates/mcp-core/src/path.rs
@@ -12,7 +12,22 @@ use std::path::{Component, Path};
 /// Sanitizes a file path for inclusion in an error message, to prevent information disclosure.
 ///
 /// Replaces the home directory with `~` to avoid leaking usernames and full filesystem paths
-/// in error messages returned to callers (e.g. over the MCP protocol).
+/// in error messages returned to callers (e.g. over the MCP protocol). Note that the rebuilt
+/// suffix is composed from normalized path components, so incidental input artifacts such as
+/// repeated separators or `.` segments are not preserved verbatim.
+///
+/// The comparison walks path components rather than matching raw strings, so a `/`-separated
+/// input matches a backslash-separated home directory (and vice versa) on platforms where both
+/// separators are valid. On Windows and macOS, components are also compared
+/// ASCII-case-insensitively, matching those platforms' case-insensitive-but-case-preserving
+/// filesystem semantics; elsewhere the comparison stays case-sensitive.
+///
+/// When `path` does not begin with `home` — e.g. it reaches this function through a different
+/// mount point, or (on Windows) as a `\\?\`-verbatim canonicalized path whose prefix shape the
+/// component walk does not recognize as equivalent to `home`'s — this falls back to scrubbing
+/// the bare username (`home`'s final component) wherever it appears in the path, so the
+/// username itself is never disclosed verbatim even when the fuller `~`-collapse of the whole
+/// home directory isn't achieved.
 ///
 /// # Examples
 ///
@@ -35,11 +50,83 @@ use std::path::{Component, Path};
 pub fn sanitize_path_for_error(path: &Path) -> String {
     dirs::home_dir().map_or_else(
         || path.display().to_string(),
-        |home| {
-            let path_str = path.display().to_string();
-            path_str.replace(&home.display().to_string(), "~")
-        },
+        |home| strip_home_prefix(path, &home).unwrap_or_else(|| scrub_username(path, &home)),
     )
+}
+
+/// Returns `path` with its leading `home` components replaced by `~`, or `None` if `path` is
+/// not rooted at `home`.
+fn strip_home_prefix(path: &Path, home: &Path) -> Option<String> {
+    let mut path_components = path.components();
+    for home_component in home.components() {
+        if !components_match(home_component, path_components.next()?) {
+            return None;
+        }
+    }
+    let mut result = String::from("~");
+    for component in path_components {
+        result.push(std::path::MAIN_SEPARATOR);
+        result.push_str(&component.as_os_str().to_string_lossy());
+    }
+    Some(result)
+}
+
+/// Defense-in-depth redaction for when `path` is not rooted at `home` (see
+/// [`sanitize_path_for_error`]'s doc comment for when this triggers): scrubs `home`'s bare
+/// username wherever it textually appears in `path`, independent of path structure.
+///
+/// This scrub is a plain substring match, not scoped to a path component: on this fallback path
+/// only, a component that merely contains the username as a substring (e.g. `alice-website` when
+/// the username is `alice`) is partially mangled (`~-website`) rather than left alone.
+/// Over-redaction is the accepted safe-failure direction for an information-disclosure guard.
+fn scrub_username(path: &Path, home: &Path) -> String {
+    let path_str = path.display().to_string();
+    let Some(username) = home.file_name() else {
+        return path_str;
+    };
+    let username = username.to_string_lossy();
+    if username.is_empty() {
+        return path_str;
+    }
+    replace_case_aware(&path_str, &username, "~")
+}
+
+#[cfg(any(windows, target_os = "macos"))]
+fn components_match(home: Component<'_>, path: Component<'_>) -> bool {
+    // TODO(critic): ASCII-only case folding misses non-ASCII usernames (e.g. Cyrillic); the
+    // scrub_username fallback in sanitize_path_for_error covers that gap.
+    home.as_os_str()
+        .to_string_lossy()
+        .eq_ignore_ascii_case(&path.as_os_str().to_string_lossy())
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
+fn components_match(home: Component<'_>, path: Component<'_>) -> bool {
+    home == path
+}
+
+#[cfg(any(windows, target_os = "macos"))]
+fn replace_case_aware(haystack: &str, needle: &str, replacement: &str) -> String {
+    // `to_ascii_lowercase` only remaps bytes in the ASCII range and never changes a string's
+    // byte length, so every byte offset found in the lowered copies below is also a valid slice
+    // point into the original `haystack`/`needle`. This invariant breaks if the case-folding
+    // strategy is ever changed to something Unicode-aware (e.g. `to_lowercase`).
+    let haystack_lower = haystack.to_ascii_lowercase();
+    let needle_lower = needle.to_ascii_lowercase();
+    let mut result = String::with_capacity(haystack.len());
+    let mut last_end = 0;
+    for (start, _) in haystack_lower.match_indices(needle_lower.as_str()) {
+        result.push_str(&haystack[last_end..start]);
+        result.push_str(replacement);
+        last_end = start + needle.len();
+    }
+    result.push_str(&haystack[last_end..]);
+    result
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
+fn replace_case_aware(haystack: &str, needle: &str, replacement: &str) -> String {
+    haystack.replace(needle, replacement)
 }
 
 /// Validates that `segment` is a single plain path component: non-empty, and with no `..`,
@@ -116,5 +203,86 @@ mod tests {
     #[test]
     fn sanitize_path_for_error_leaves_non_home_path_unchanged() {
         assert_eq!(sanitize_path_for_error(Path::new("/tmp/x")), "/tmp/x");
+    }
+
+    // `Path::components()` only treats `/` as a separator alongside `\` on Windows, so this
+    // variation is only meaningful, and only exercised, on that platform.
+    #[cfg(windows)]
+    #[test]
+    fn sanitize_path_for_error_redacts_home_directory_with_forward_slashes() {
+        let home = dirs::home_dir().unwrap();
+        let home_str = home.display().to_string().replace('\\', "/");
+        let under_home = format!("{home_str}/secret-file.md");
+        assert_eq!(
+            sanitize_path_for_error(Path::new(&under_home)),
+            format!("~{}secret-file.md", std::path::MAIN_SEPARATOR),
+        );
+    }
+
+    // Windows and macOS both have case-insensitive-but-case-preserving default filesystems, so
+    // this is exercised on both.
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn sanitize_path_for_error_redacts_home_directory_case_insensitively() {
+        let home = dirs::home_dir().unwrap();
+        let flipped_case: String = home
+            .display()
+            .to_string()
+            .chars()
+            .map(|c| {
+                if c.is_ascii_uppercase() {
+                    c.to_ascii_lowercase()
+                } else if c.is_ascii_lowercase() {
+                    c.to_ascii_uppercase()
+                } else {
+                    c
+                }
+            })
+            .collect();
+        let under_home = format!("{flipped_case}{}secret-file.md", std::path::MAIN_SEPARATOR);
+        assert_eq!(
+            sanitize_path_for_error(Path::new(&under_home)),
+            format!("~{}secret-file.md", std::path::MAIN_SEPARATOR),
+        );
+    }
+
+    /// Reproduces the mounted/bind-mount scenario from the critic review: `home` appears as a
+    /// non-leading substring (e.g. under `/mnt/snapshot`), so the leading-prefix component walk
+    /// in `strip_home_prefix` cannot match it. Verifies the `scrub_username` fallback still
+    /// keeps the username out of the rendered output.
+    #[test]
+    fn sanitize_path_for_error_scrubs_username_when_home_is_not_a_leading_prefix() {
+        let home = dirs::home_dir().unwrap();
+        let username = home.file_name().unwrap().to_string_lossy().into_owned();
+
+        let mut mounted = std::path::PathBuf::from("mnt");
+        mounted.push("snapshot");
+        for component in home
+            .components()
+            .filter(|c| matches!(c, Component::Normal(_)))
+        {
+            mounted.push(component.as_os_str());
+        }
+        mounted.push("secret.md");
+
+        let sanitized = sanitize_path_for_error(&mounted);
+        assert!(!sanitized.to_lowercase().contains(&username.to_lowercase()));
+        assert!(sanitized.contains('~'));
+    }
+
+    /// Reproduces the Windows `\\?\`-verbatim canonicalized-path regression from the critic
+    /// review: `std::fs::canonicalize` prefixes the drive with `\\?\`, which
+    /// `strip_home_prefix`'s component walk does not recognize as equivalent to a plain `C:\`
+    /// prefix. Verifies the `scrub_username` fallback still keeps the username out of the
+    /// rendered output.
+    #[cfg(windows)]
+    #[test]
+    fn sanitize_path_for_error_scrubs_username_from_canonicalized_home_path() {
+        let home = dirs::home_dir().unwrap();
+        let username = home.file_name().unwrap().to_string_lossy().into_owned();
+        let canonical = std::fs::canonicalize(&home).unwrap();
+
+        let sanitized = sanitize_path_for_error(&canonical);
+        assert!(!sanitized.to_lowercase().contains(&username.to_lowercase()));
     }
 }


### PR DESCRIPTION
## Summary

- `sanitize_path_for_error` compared the home directory against the input path via a literal, case-sensitive string replace, so it silently failed to redact the OS username on Windows whenever the input path used forward slashes or differed in case from `dirs::home_dir()`'s output — both common since `mcp.json` is JSON.
- The comparison now walks path components instead of raw strings, so separator style no longer matters, and compares components ASCII-case-insensitively on Windows and macOS (both case-insensitive-but-case-preserving by default).
- When the component walk still can't recognize a path as rooted at home (a `\\?\`-verbatim canonicalized Windows path, or home reached through a different mount point), the bare username is scrubbed from the rendered path as a defense-in-depth fallback instead of being returned unredacted — this closes a regression an adversarial review caught in an earlier iteration of this fix, where canonicalized paths (the dominant real call shape from `mcp-skill`/`mcp-server`) would have leaked the username in full.

Fixes #246.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (820 tests)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Cross-compiled and clippy-checked against `x86_64-pc-windows-gnu` and `x86_64-unknown-linux-gnu` to exercise the platform-gated branches
- [x] New unit tests cover: forward-slash home paths, case-differing home paths, home as a non-leading substring (bind-mount scenario), and canonicalized `\\?\`-verbatim home paths (Windows-only)