### PR TITLE
refactor(introspector,server,codegen): named discovery structs and tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `benches/` or `examples/` directory. Removed the unused `static_assertions`, `dialoguer`, and
   `toml` entries from the root `[workspace.dependencies]` table, none of which any crate in the
   workspace still referenced (#193).
+- **`mcp-execution-introspector`**: the server-discovery pipeline now threads a `PeerMeta`
+  struct (`server_name`, `server_version`, `has_resources`, `has_prompts`) and a
+  `DiscoveryResult` struct (`tools`, `peer_meta`) instead of positional `(String, String, bool,
+  bool)` and `(Vec<Tool>, String, String, bool, bool)` tuples across `extract_peer_meta`,
+  `discover_via_stdio`, `discover_via_http`, `discover_via_stdio_process`, and
+  `build_server_info`. The two same-typed trailing `bool` fields could previously be
+  transposed at one call site without a compile error, silently producing wrong
+  `ServerCapabilities.supports_resources`/`supports_prompts` values (#207).
+- Added `#[tracing::instrument]` spans to `Introspector::discover_server`,
+  `GeneratorService::introspector_for`/`evict_introspector`/`export_lock_for`/
+  `evict_export_lock` and its `introspect_server`/`save_categorized_tools`/`generate_skill`/
+  `save_skill` tool handlers, and `ProgressiveGenerator::generate`/`generate_with_categories`,
+  each carrying a `server_id` (or, for the export lock helpers, `output_dir`) span field so
+  concurrent per-server-id log output can be correlated. No existing log call site's message
+  text changed. This does change the *shape* of `mcp-execution-cli generate`'s stderr output:
+  with the default `fmt` subscriber, log lines emitted inside an instrumented call now carry a
+  `generate{server_id=... tool_count=...}:` span-context prefix that was not there before
+  (#211).
 
 ### Fixed
 

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -144,6 +144,10 @@ impl<'a> ProgressiveGenerator<'a> {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(
+        skip_all,
+        fields(server_id = %server_info.id, tool_count = server_info.tools.len())
+    )]
     pub fn generate(&self, server_info: &ServerInfo) -> Result<GeneratedCode> {
         tracing::info!(
             "Generating progressive loading code for server: {}",
@@ -271,6 +275,10 @@ impl<'a> ProgressiveGenerator<'a> {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(
+        skip_all,
+        fields(server_id = %server_info.id, tool_count = server_info.tools.len())
+    )]
     pub fn generate_with_categories(
         &self,
         server_info: &ServerInfo,

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -278,6 +278,7 @@ impl Introspector {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(skip_all, fields(server_id = %server_id))]
     pub async fn discover_server(
         &mut self,
         server_id: ServerId,
@@ -293,22 +294,14 @@ impl Introspector {
         // constructed.
         validate_server_config(config)?;
 
-        let (tool_list, server_name, server_version, has_resources, has_prompts) =
-            match config.transport() {
-                TransportType::Stdio => discover_via_stdio_process(&server_id, config).await?,
-                TransportType::Http | TransportType::Sse => {
-                    discover_via_http(&server_id, config).await?
-                }
-            };
+        let discovery = match config.transport() {
+            TransportType::Stdio => discover_via_stdio_process(&server_id, config).await?,
+            TransportType::Http | TransportType::Sse => {
+                discover_via_http(&server_id, config).await?
+            }
+        };
 
-        let info = build_server_info(
-            &server_id,
-            server_name,
-            server_version,
-            has_resources,
-            has_prompts,
-            tool_list,
-        );
+        let info = build_server_info(&server_id, discovery.peer_meta, discovery.tools);
 
         self.servers.insert(server_id, info.clone());
 
@@ -448,6 +441,39 @@ impl Default for Introspector {
     }
 }
 
+/// Server name, version, and feature-support flags extracted from an MCP
+/// handshake result.
+///
+/// Replaces a positional `(String, String, bool, bool)` tuple that was
+/// previously threaded through [`extract_peer_meta`] and its callers, where a
+/// transposition of the two same-typed trailing `bool` fields would type-check
+/// silently and produce wrong [`ServerCapabilities`] values (issue #207).
+#[derive(Debug)]
+struct PeerMeta {
+    /// Human-readable server name from the handshake (or a fallback).
+    server_name: String,
+    /// Server version string from the handshake (or `"unknown"`).
+    server_version: String,
+    /// Whether the server advertised resource support.
+    has_resources: bool,
+    /// Whether the server advertised prompt support.
+    has_prompts: bool,
+}
+
+/// Tools and handshake metadata discovered from a single introspection
+/// round-trip.
+///
+/// Replaces a positional `(Vec<Tool>, String, String, bool, bool)` tuple
+/// previously returned by [`discover_via_stdio_process`], [`discover_via_stdio`],
+/// and [`discover_via_http`] (issue #207).
+#[derive(Debug)]
+struct DiscoveryResult {
+    /// Tools reported by the server.
+    tools: Vec<rmcp::model::Tool>,
+    /// Handshake-derived server metadata and capability flags.
+    peer_meta: PeerMeta,
+}
+
 /// Spawns the MCP server subprocess used for a single introspection
 /// round-trip, with piped stdin/stdout so it can be driven over stdio.
 ///
@@ -497,7 +523,7 @@ fn spawn_introspection_child(server_id: &ServerId, config: &ServerConfig) -> Res
 async fn discover_via_stdio_process(
     server_id: &ServerId,
     config: &ServerConfig,
-) -> Result<(Vec<rmcp::model::Tool>, String, String, bool, bool)> {
+) -> Result<DiscoveryResult> {
     let mut child = spawn_introspection_child(server_id, config)?;
     let stdout = child.stdout.take().ok_or_else(|| Error::ConnectionFailed {
         server: server_id.to_string(),
@@ -540,7 +566,7 @@ async fn discover_via_stdio(
     server_id: &ServerId,
     config: &ServerConfig,
     transport: (tokio::process::ChildStdout, tokio::process::ChildStdin),
-) -> Result<(Vec<rmcp::model::Tool>, String, String, bool, bool)> {
+) -> Result<DiscoveryResult> {
     // Create client using serve pattern, bounded by the connect timeout
     let client = tokio::time::timeout(config.connect_timeout(), ().serve(transport))
         .await
@@ -567,16 +593,12 @@ async fn discover_via_stdio(
 
     // Extract name, version, and capabilities from the MCP handshake result.
     // Falls back to the command string / "unknown" if the server did not send peer info.
-    let (server_name, server_version, has_resources, has_prompts) =
-        extract_peer_meta(config, client.peer_info().as_deref());
+    let peer_meta = extract_peer_meta(config, client.peer_info().as_deref());
 
-    Ok((
-        tool_list,
-        server_name,
-        server_version,
-        has_resources,
-        has_prompts,
-    ))
+    Ok(DiscoveryResult {
+        tools: tool_list,
+        peer_meta,
+    })
 }
 
 /// Connects to an MCP server over Streamable HTTP and lists its tools, with
@@ -594,10 +616,7 @@ async fn discover_via_stdio(
 /// constructed, or the underlying rmcp connection or request fails (this
 /// includes a reserved-header collision, e.g. a caller-supplied `Accept`
 /// header, which rmcp rejects as `StreamableHttpError::ReservedHeaderConflict`).
-async fn discover_via_http(
-    server_id: &ServerId,
-    config: &ServerConfig,
-) -> Result<(Vec<rmcp::model::Tool>, String, String, bool, bool)> {
+async fn discover_via_http(server_id: &ServerId, config: &ServerConfig) -> Result<DiscoveryResult> {
     // `ServerConfigBuilder::build` already guarantees `url` is `Some` for
     // Http/Sse transports — no `ServerConfig` can exist otherwise.
     let url = config
@@ -654,26 +673,20 @@ async fn discover_via_http(
     // cancels the worker task; a cancelled worker cannot itself issue a
     // session-DELETE request, so no explicit disconnect happens on this path
     // — the server-side session simply expires on its own timeout instead.
-    let (server_name, server_version, has_resources, has_prompts) =
-        extract_peer_meta(config, client.peer_info().as_deref());
+    let peer_meta = extract_peer_meta(config, client.peer_info().as_deref());
 
-    Ok((
-        tool_list,
-        server_name,
-        server_version,
-        has_resources,
-        has_prompts,
-    ))
+    Ok(DiscoveryResult {
+        tools: tool_list,
+        peer_meta,
+    })
 }
 
 /// Assembles a [`ServerInfo`] from the raw tool list and handshake metadata
-/// returned by [`discover_via_stdio`].
+/// returned by [`discover_server`](Introspector::discover_server)'s stdio or
+/// HTTP/SSE discovery path.
 fn build_server_info(
     server_id: &ServerId,
-    server_name: String,
-    server_version: String,
-    has_resources: bool,
-    has_prompts: bool,
+    peer_meta: PeerMeta,
     tool_list: Vec<rmcp::model::Tool>,
 ) -> ServerInfo {
     tracing::debug!(
@@ -697,44 +710,41 @@ fn build_server_info(
 
     let capabilities = ServerCapabilities {
         supports_tools: !tools.is_empty(),
-        supports_resources: has_resources,
-        supports_prompts: has_prompts,
+        supports_resources: peer_meta.has_resources,
+        supports_prompts: peer_meta.has_prompts,
     };
 
     ServerInfo {
         id: server_id.clone(),
-        name: server_name,
-        version: server_version,
+        name: peer_meta.server_name,
+        version: peer_meta.server_version,
         tools,
         capabilities,
     }
 }
 
 /// Extracts server name, version, resource support, and prompt support from
-/// the MCP handshake result (`peer_info`).
+/// the MCP handshake result (`peer_info`) into a [`PeerMeta`].
 ///
-/// Falls back to `(fallback_server_name(config), "unknown", false, false)`
-/// when the server did not send peer information (i.e. `peer_info` is `None`).
+/// Falls back to `PeerMeta { server_name: fallback_server_name(config), server_version:
+/// "unknown", has_resources: false, has_prompts: false }` when the server did not send
+/// peer information (i.e. `peer_info` is `None`).
 fn extract_peer_meta(
     config: &ServerConfig,
     peer_info: Option<&rmcp::model::InitializeResult>,
-) -> (String, String, bool, bool) {
+) -> PeerMeta {
     peer_info.map_or_else(
-        || {
-            (
-                fallback_server_name(config),
-                "unknown".to_string(),
-                false,
-                false,
-            )
+        || PeerMeta {
+            server_name: fallback_server_name(config),
+            server_version: "unknown".to_string(),
+            has_resources: false,
+            has_prompts: false,
         },
-        |info| {
-            (
-                info.server_info.name.clone(),
-                info.server_info.version.clone(),
-                info.capabilities.resources.is_some(),
-                info.capabilities.prompts.is_some(),
-            )
+        |info| PeerMeta {
+            server_name: info.server_info.name.clone(),
+            server_version: info.server_info.version.clone(),
+            has_resources: info.capabilities.resources.is_some(),
+            has_prompts: info.capabilities.prompts.is_some(),
         },
     )
 }
@@ -970,10 +980,10 @@ mod tests {
         let config = test_config("my-server-binary");
         let peer = make_peer_info("Handshake Name", "0.0.0", false, false);
 
-        let (name, _, _, _) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert_eq!(name, "Handshake Name");
-        assert_ne!(name, "my-server-binary");
+        assert_eq!(meta.server_name, "Handshake Name");
+        assert_ne!(meta.server_name, "my-server-binary");
     }
 
     /// #79 — version must come from the handshake, not the hardcoded "unknown"
@@ -982,10 +992,10 @@ mod tests {
         let config = test_config("cmd");
         let peer = make_peer_info("Server", "3.1.4", false, false);
 
-        let (_, version, _, _) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert_eq!(version, "3.1.4");
-        assert_ne!(version, "unknown");
+        assert_eq!(meta.server_version, "3.1.4");
+        assert_ne!(meta.server_version, "unknown");
     }
 
     /// #80 — `supports_resources` reflects `capabilities.resources` being `Some`
@@ -994,9 +1004,9 @@ mod tests {
         let config = test_config("cmd");
         let peer = make_peer_info("S", "1.0", true, false);
 
-        let (_, _, has_resources, _) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert!(has_resources);
+        assert!(meta.has_resources);
     }
 
     /// #80 — `supports_resources` is false when `capabilities.resources` is `None`
@@ -1005,9 +1015,9 @@ mod tests {
         let config = test_config("cmd");
         let peer = make_peer_info("S", "1.0", false, false);
 
-        let (_, _, has_resources, _) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert!(!has_resources);
+        assert!(!meta.has_resources);
     }
 
     /// Bonus — `supports_prompts` reflects `capabilities.prompts` being `Some`
@@ -1016,9 +1026,9 @@ mod tests {
         let config = test_config("cmd");
         let peer = make_peer_info("S", "1.0", false, true);
 
-        let (_, _, _, has_prompts) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert!(has_prompts);
+        assert!(meta.has_prompts);
     }
 
     /// Bonus — `supports_prompts` is false when `capabilities.prompts` is `None`
@@ -1027,9 +1037,9 @@ mod tests {
         let config = test_config("cmd");
         let peer = make_peer_info("S", "1.0", false, false);
 
-        let (_, _, _, has_prompts) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert!(!has_prompts);
+        assert!(!meta.has_prompts);
     }
 
     /// Fallback: `peer_info` is `None` — name falls back to `config.command`
@@ -1037,9 +1047,9 @@ mod tests {
     fn test_extract_peer_meta_fallback_name_is_command() {
         let config = test_config("fallback-binary");
 
-        let (name, _, _, _) = extract_peer_meta(&config, None);
+        let meta = extract_peer_meta(&config, None);
 
-        assert_eq!(name, "fallback-binary");
+        assert_eq!(meta.server_name, "fallback-binary");
     }
 
     /// Incidental fix: for Http/Sse configs `command` is always empty, so the
@@ -1051,9 +1061,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let (name, _, _, _) = extract_peer_meta(&config, None);
+        let meta = extract_peer_meta(&config, None);
 
-        assert_eq!(name, "https://api.example.com/mcp");
+        assert_eq!(meta.server_name, "https://api.example.com/mcp");
     }
 
     /// Fallback: `peer_info` is `None` — version falls back to `"unknown"`
@@ -1061,9 +1071,9 @@ mod tests {
     fn test_extract_peer_meta_fallback_version_is_unknown() {
         let config = test_config("cmd");
 
-        let (_, version, _, _) = extract_peer_meta(&config, None);
+        let meta = extract_peer_meta(&config, None);
 
-        assert_eq!(version, "unknown");
+        assert_eq!(meta.server_version, "unknown");
     }
 
     /// Fallback: `peer_info` is `None` — capabilities are all false
@@ -1071,10 +1081,10 @@ mod tests {
     fn test_extract_peer_meta_fallback_capabilities_false() {
         let config = test_config("cmd");
 
-        let (_, _, has_resources, has_prompts) = extract_peer_meta(&config, None);
+        let meta = extract_peer_meta(&config, None);
 
-        assert!(!has_resources);
-        assert!(!has_prompts);
+        assert!(!meta.has_resources);
+        assert!(!meta.has_prompts);
     }
 
     /// All four values are correct simultaneously when `peer_info` is fully populated
@@ -1083,11 +1093,11 @@ mod tests {
         let config = test_config("binary");
         let peer = make_peer_info("Full Server", "2.0.0", true, true);
 
-        let (name, version, has_resources, has_prompts) = extract_peer_meta(&config, Some(&peer));
+        let meta = extract_peer_meta(&config, Some(&peer));
 
-        assert_eq!(name, "Full Server");
-        assert_eq!(version, "2.0.0");
-        assert!(has_resources);
-        assert!(has_prompts);
+        assert_eq!(meta.server_name, "Full Server");
+        assert_eq!(meta.server_version, "2.0.0");
+        assert!(meta.has_resources);
+        assert!(meta.has_prompts);
     }
 }

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -211,6 +211,7 @@ impl GeneratorService {
     ///
     /// The outer map lock is released before the returned handle is awaited
     /// on, so discovery of unrelated server ids never contends on it.
+    #[tracing::instrument(skip_all, fields(server_id = %server_id))]
     async fn introspector_for(&self, server_id: &ServerId) -> Arc<Mutex<Introspector>> {
         let mut introspectors = self.introspectors.lock().await;
         introspectors
@@ -233,6 +234,7 @@ impl GeneratorService {
     /// would prune that live handle out from under the third call. Comparing
     /// with [`Arc::ptr_eq`] ensures a caller can only ever evict the entry it
     /// created.
+    #[tracing::instrument(skip_all, fields(server_id = %server_id))]
     async fn evict_introspector(&self, server_id: &ServerId, handle: &Arc<Mutex<Introspector>>) {
         let mut introspectors = self.introspectors.lock().await;
         if let std::collections::hash_map::Entry::Occupied(entry) =
@@ -259,6 +261,7 @@ impl GeneratorService {
     /// (same eviction-boundary gap as [`Self::evict_introspector`]). The
     /// age-gated sweep in `mcp-execution-files` is what ultimately prevents
     /// data loss if that happens.
+    #[tracing::instrument(skip_all, fields(output_dir = %output_dir.display()))]
     async fn export_lock_for(&self, output_dir: &Path) -> Arc<Mutex<()>> {
         let mut exports = self.exports.lock().await;
         exports
@@ -275,6 +278,7 @@ impl GeneratorService {
     /// without eviction the map grows without bound, and an unconditional
     /// `remove` keyed only by path would be a TOCTOU bug against a
     /// concurrently inserted fresh handle.
+    #[tracing::instrument(skip_all, fields(output_dir = %output_dir.display()))]
     async fn evict_export_lock(&self, output_dir: &Path, handle: &Arc<Mutex<()>>) {
         let mut exports = self.exports.lock().await;
         if let std::collections::hash_map::Entry::Occupied(entry) =
@@ -307,21 +311,38 @@ impl GeneratorService {
     /// filesystem-touching confinement walk (see
     /// [`crate::output_dir::resolve_output_dir`]) runs later, in `save_categorized_tools`,
     /// immediately before the generated files are written (issue #216).
+    // This function stacks `#[tool]` (rmcp's macro, which boxes the async body) under
+    // `#[tracing::instrument]`. That combination only produces a span covering the full
+    // call (not just future construction) because tracing-attributes' async-fn detection
+    // heuristic happens to match rmcp's current codegen shape; it is not guaranteed by
+    // either crate's public contract. The concurrency test below
+    // (`test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id`) is the
+    // regression guard for this: it asserts every `Discovering MCP server` event carries
+    // exactly 2 `server_id` values in its full span scope (this span's plus the nested
+    // `discover_server` span's). If the heuristic ever stops matching, this span no
+    // longer covers the async body, its `server_id` field is never recorded, and the
+    // count drops to 1, failing the assertion.
     #[tool(
         description = "Connect to an MCP server, discover its tools, and return metadata for categorization. Returns a session ID for use with save_categorized_tools."
     )]
+    #[tracing::instrument(skip_all, fields(server_id = tracing::field::Empty))]
     async fn introspect_server(
         &self,
         Parameters(params): Parameters<IntrospectServerParams>,
         ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
-        // Validate server_id format
+        // Validate server_id format. Deliberate: the `server_id` span field stays `Empty`
+        // on this early return rather than recording the raw, unvalidated input — logging
+        // an attacker-controlled string into a structured field before it's validated risks
+        // log injection, so an empty field on this path is accepted as a trade-off, not an
+        // oversight.
         validate_server_id(&params.server_id)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
         // Extract server_id before consuming params
         let server_id_str = params.server_id;
         let server_id = ServerId::new(&server_id_str);
+        tracing::Span::current().record("server_id", tracing::field::display(&server_id));
 
         // Reject an obviously malformed output_dir (absolute, or containing `..`) with fast
         // feedback, without touching the filesystem: no directory is created here, and the raw
@@ -455,6 +476,7 @@ impl GeneratorService {
     #[tool(
         description = "Generate progressive loading TypeScript files using Claude's categorization. Requires session_id from a previous introspect_server call."
     )]
+    #[tracing::instrument(skip_all, fields(server_id = tracing::field::Empty))]
     async fn save_categorized_tools(
         &self,
         Parameters(params): Parameters<SaveCategorizedToolsParams>,
@@ -466,6 +488,7 @@ impl GeneratorService {
                 None,
             )
         })?;
+        tracing::Span::current().record("server_id", tracing::field::display(&pending.server_id));
 
         // Validate categorized tools match introspected tools
         let introspected_names: HashSet<_> = pending
@@ -783,14 +806,17 @@ impl GeneratorService {
     #[tool(
         description = "Analyze generated TypeScript files and return context for Claude to create a SKILL.md file. Returns tool metadata, categories, and a generation prompt."
     )]
+    #[tracing::instrument(skip_all, fields(server_id = tracing::field::Empty))]
     async fn generate_skill(
         &self,
         Parameters(params): Parameters<GenerateSkillParams>,
         ct: CancellationToken,
     ) -> Result<CallToolResult, McpError> {
-        // Validate server_id format and length
+        // Validate server_id format and length. As in `introspect_server`, the span
+        // field is only recorded once validation succeeds (see the comment there).
         validate_server_id(&params.server_id)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        tracing::Span::current().record("server_id", tracing::field::display(&params.server_id));
 
         // Determine servers directory
         let servers_dir = params.servers_dir.unwrap_or_else(|| {
@@ -912,13 +938,16 @@ impl GeneratorService {
     #[tool(
         description = "Save generated SKILL.md content to ~/.claude/skills/{server_id}/. Use after Claude generates skill content from generate_skill context."
     )]
+    #[tracing::instrument(skip_all, fields(server_id = tracing::field::Empty))]
     async fn save_skill(
         &self,
         Parameters(params): Parameters<SaveSkillParams>,
     ) -> Result<CallToolResult, McpError> {
-        // Validate server_id format and length
+        // Validate server_id format and length. As in `introspect_server`, the span
+        // field is only recorded once validation succeeds (see the comment there).
         validate_server_id(&params.server_id)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        tracing::Span::current().record("server_id", tracing::field::display(&params.server_id));
 
         // Validate content size (DoS protection)
         if params.content.len() > MAX_SKILL_CONTENT_SIZE {
@@ -1860,6 +1889,227 @@ mod tests {
              (expected < {serialized_threshold:?}, i.e. close to a single {hold_time:?} hold); \
              took {elapsed:?}"
         );
+    }
+
+    /// Regression test for spec 004-tracing-instrument-spans's SC-004: concurrent
+    /// `introspect_server` calls for different `server_id`s must not cross-contaminate
+    /// the `server_id` span field. This is also the regression guard for the
+    /// `#[tool]`+`#[tracing::instrument]` stacking risk noted in the comment above
+    /// `introspect_server`: if tracing-attributes' async-fn-detection heuristic ever
+    /// stops matching rmcp's codegen shape, `introspect_server`'s span stops covering
+    /// the actual async body, so its `server_id` field is never recorded and it drops
+    /// out of the scope of every event emitted underneath it - the "exactly 2
+    /// `server_id` values in scope" assertion below then fails.
+    ///
+    /// Both calls target a nonexistent command so `discover_server` fails fast, before
+    /// any real subprocess I/O; the call's outcome is irrelevant here, only the
+    /// span-field correlation of the tracing events emitted along the way. Each call
+    /// runs in its own `tokio::spawn`ed task, released at the same instant via a
+    /// `Barrier`, on a multi-thread runtime, so both are concurrently scheduled
+    /// rather than driven one after the other by an inline `join!`. This does not
+    /// guarantee genuine wall-clock overlap - tokio's per-worker LIFO fast path
+    /// commonly runs the woken sibling task back-to-back on the same thread as the
+    /// waking one - but the property under test (correct span-stack correlation of
+    /// two differently-tagged concurrent calls) holds either way: whether the two
+    /// calls truly interleave or run sequentially on one worker, a stale or
+    /// mismatched `server_id` leaking from one call's span stack into the other's
+    /// events is exactly what the assertions below detect.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id() {
+        use std::sync::{Arc, Mutex};
+        use tokio::sync::Barrier;
+        use tracing::field::{Field, Visit};
+        use tracing::span;
+        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+        use tracing_subscriber::registry::LookupSpan;
+
+        /// Span extension holding the `server_id` field value once recorded (spans
+        /// declared with `fields(server_id = tracing::field::Empty)` start without
+        /// one, until a later `Span::current().record(...)` call fills it in).
+        struct SpanServerId(String);
+
+        #[derive(Default)]
+        struct FieldCapture {
+            server_id: Option<String>,
+            message: Option<String>,
+        }
+
+        impl Visit for FieldCapture {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                match field.name() {
+                    "server_id" => self.server_id = Some(format!("{value:?}")),
+                    "message" => self.message = Some(format!("{value:?}")),
+                    _ => {}
+                }
+            }
+        }
+
+        /// (event message, every `server_id` field found across the event's full span
+        /// scope, innermost to outermost) pairs captured so far.
+        type CapturedEvents = Arc<Mutex<Vec<(String, Vec<String>)>>>;
+
+        /// For every event carrying a `message` field, records the `server_id` field of
+        /// *every* span in the event's scope, not just the nearest one. Collecting all
+        /// of them (instead of stopping at the first match) is what makes this a
+        /// genuine regression guard: the `Discovering MCP server` event's scope
+        /// includes both `discover_server`'s own span and its parent
+        /// `introspect_server` span, so if `introspect_server`'s span silently stopped
+        /// covering the async body, its `server_id` field would never be recorded and
+        /// it would vanish from this list - dropping the count from 2 to 1 - even
+        /// though `discover_server`'s own span still resolves correctly on its own.
+        struct CorrelationLayer {
+            events: CapturedEvents,
+        }
+
+        impl<S> Layer<S> for CorrelationLayer
+        where
+            S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+        {
+            fn on_new_span(
+                &self,
+                attrs: &span::Attributes<'_>,
+                id: &span::Id,
+                ctx: Context<'_, S>,
+            ) {
+                let mut visitor = FieldCapture::default();
+                attrs.record(&mut visitor);
+                if let (Some(server_id), Some(span_ref)) = (visitor.server_id, ctx.span(id)) {
+                    span_ref.extensions_mut().insert(SpanServerId(server_id));
+                }
+            }
+
+            fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+                let mut visitor = FieldCapture::default();
+                values.record(&mut visitor);
+                if let (Some(server_id), Some(span_ref)) = (visitor.server_id, ctx.span(id)) {
+                    span_ref.extensions_mut().insert(SpanServerId(server_id));
+                }
+            }
+
+            fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+                let mut visitor = FieldCapture::default();
+                event.record(&mut visitor);
+                let Some(message) = visitor.message else {
+                    return;
+                };
+                let server_ids: Vec<String> = ctx
+                    .event_scope(event)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|span_ref| {
+                        span_ref
+                            .extensions()
+                            .get::<SpanServerId>()
+                            .map(|s| s.0.clone())
+                    })
+                    .collect();
+                self.events.lock().unwrap().push((message, server_ids));
+            }
+        }
+
+        let events: CapturedEvents = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(CorrelationLayer {
+            events: events.clone(),
+        });
+        // `set_default` only overrides the calling thread's thread-local dispatcher;
+        // the two calls below run as separate tasks that a multi-thread runtime can
+        // schedule onto other worker threads, so the subscriber must be installed
+        // process-wide instead. Because it is process-wide and never uninstalled,
+        // sibling tests that also emit "Discovering MCP server" events (in this
+        // process under plain `cargo test`, or in other tests entirely if this one
+        // ran outside nextest's per-test process isolation) can reach this layer
+        // too; isolation here comes from the `discovery_events` filter below
+        // matching on this test's own `corr-test-a`/`corr-test-b` ids, not from any
+        // assumption about process sharing. This test's process installs no other
+        // global subscriber, so the call itself cannot panic.
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("no global tracing subscriber should be set yet in this test process");
+
+        let service = GeneratorService::new();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let make_params = |server_id: &str| IntrospectServerParams {
+            server_id: server_id.to_string(),
+            command: "definitely-not-a-real-mcp-server-command-xyz".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            output_dir: None,
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+
+        // Each call runs as its own spawned task (not an inline future polled by
+        // `join!`) so the multi-thread runtime is free to run them on separate
+        // worker threads; the `Barrier` releases both tasks at the same instant
+        // instead of relying on scheduler luck. The runtime may still schedule both
+        // onto the same worker back-to-back (tokio's LIFO fast path) - see this
+        // test's doc comment above for why that does not weaken it.
+        let spawn_call = |server_id: &str| {
+            let service = service.clone();
+            let barrier = barrier.clone();
+            let params = make_params(server_id);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                service
+                    .introspect_server(Parameters(params), CancellationToken::new())
+                    .await
+            })
+        };
+
+        let task_a = spawn_call("corr-test-a");
+        let task_b = spawn_call("corr-test-b");
+
+        let (result_a, result_b) = tokio::join!(task_a, task_b);
+        let result_a = result_a.expect("call a task panicked");
+        let result_b = result_b.expect("call b task panicked");
+
+        // The nonexistent command means discovery always fails - only the tracing
+        // side effects are under test.
+        assert!(result_a.is_err());
+        assert!(result_b.is_err());
+
+        let captured: Vec<(String, Vec<String>)> = events.lock().unwrap().clone();
+        let discovery_events: Vec<_> = captured
+            .iter()
+            .filter(|(message, _)| {
+                message.contains("Discovering MCP server")
+                    && (message.contains("corr-test-a") || message.contains("corr-test-b"))
+            })
+            .collect();
+
+        assert_eq!(
+            discovery_events.len(),
+            2,
+            "expected one 'Discovering MCP server' event per concurrent call, got {discovery_events:?}"
+        );
+
+        for (message, server_ids) in &discovery_events {
+            // The message text embeds `server_id` via plain string interpolation,
+            // entirely independent of tracing's span machinery - it is ground truth
+            // for which call actually produced the event.
+            let expected = if message.contains("corr-test-a") {
+                "corr-test-a"
+            } else if message.contains("corr-test-b") {
+                "corr-test-b"
+            } else {
+                panic!("event message did not embed either server_id: {message}");
+            };
+
+            assert_eq!(
+                server_ids.len(),
+                2,
+                "event {message:?} should carry exactly 2 server_id values across its \
+                 span scope (discover_server's own span plus the outer introspect_server \
+                 span); got {server_ids:?} - introspect_server's span likely stopped \
+                 covering the async body"
+            );
+            assert!(
+                server_ids.iter().all(|id| id == expected),
+                "event {message:?} carried span server_id values {server_ids:?}, but its \
+                 own message text says it was produced by {expected:?} - cross-contamination \
+                 between concurrent server_id spans"
+            );
+        }
     }
 
     /// Regression test for the TOCTOU eviction bug (issue #130): eviction


### PR DESCRIPTION
## Summary
- Replace the positional `(String, String, bool, bool)` / `(Vec<Tool>, String, String, bool, bool)` tuples threaded through the introspector discovery pipeline with named `PeerMeta`/`DiscoveryResult` structs, so a field-order transposition is caught by the compiler instead of relying on convention across independently-edited functions.
- Add `#[tracing::instrument]` spans carrying a `server_id` field to the concurrent, multi-step async entry points in `mcp-introspector`, `mcp-server`, and `mcp-codegen`, so log output from concurrently-running introspection and generation sessions can be correlated without parsing message text.
- Add a regression test proving span-field correlation under concurrent calls with distinct `server_id`s, verified via mutation testing (fails when the guarded instrumentation is removed).

Closes #207
Closes #211

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (792/792)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo test -p mcp-execution-server --lib --all-features` run 5x (plain runner, non-nextest) to confirm no cross-test event leakage