### PR TITLE
fix(codegen): widen generated Result type and ship a working tsconfig.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,7 +333,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--format JSON`/`--format Pretty` (mixed/upper case) still parse successfully, matching the
   case-insensitive matching `OutputFormat::from_str` already performed on the previous
   `String`-typed field.
-
+- **`mcp-execution-codegen`**: each generated tool's `{Tool}Result` type was declared as
+  `interface {Tool}Result { [key: string]: unknown }`, an object-only shape, even though
+  `callMCPTool` can also resolve with a bare `string` (plain-text content) or an array
+  (JSON-list payloads) (#182). It is now `type {Tool}Result = Record<string, unknown> |
+  unknown[] | string`, matching every shape `callMCPTool` actually returns. **Breaking for
+  generated-code consumers**: code that read a field directly off a tool's result (e.g. `const
+  r = await createIssue(params); r.number;`), relying on the old interface's implicit index
+  signature, no longer compiles (`TS2339`) — the union requires narrowing first, e.g. `if
+  (typeof r === 'object' && r !== null && !Array.isArray(r)) { r.number }`, before accessing a
+  property. This is intentional: the previous type silently claimed every result was an object,
+  which was never actually guaranteed. Regenerate affected tools and add the narrowing check at
+  each call site.
+- **`mcp-execution-codegen`**: generated tool files import the runtime bridge with an explicit
+  `.ts` extension, which `tsc` only accepts under `allowImportingTsExtensions`, but the
+  generated package shipped no `tsconfig.json` enabling it — `tsc --noEmit` under a plain
+  `--module nodenext --moduleResolution nodenext` setup failed with `TS5097` (#183). A
+  `tsconfig.json` (with `allowImportingTsExtensions` and the `noEmit` it requires) is now
+  generated alongside `package.json`. The runtime bridge also imports Node builtins
+  (`child_process`, `fs/promises`, `os`, `path`) and references ambient globals (`process`, the
+  `NodeJS` namespace), none of which resolve without Node's own type declarations, so
+  `package.json` now additionally declares `@types/node` (pinned to the major version this
+  project's own CI targets) as a `devDependency` — without it, `tsc --noEmit` still failed
+  (`TS2307`/`TS2580`/`TS2503`) even with the corrected `tsconfig.json`.
 - **`mcp-execution-codegen`**: the generated runtime bridge (`_runtime/mcp-bridge.ts`) attached a
   fresh `stdout` listener per `callMCPTool` call and resolved on the first complete JSON-RPC
   message with an `id`, without checking that the `id` matched the request it sent. Two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,7 +355,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NodeJS` namespace), none of which resolve without Node's own type declarations, so
   `package.json` now additionally declares `@types/node` (pinned to the major version this
   project's own CI targets) as a `devDependency` — without it, `tsc --noEmit` still failed
-  (`TS2307`/`TS2580`/`TS2503`) even with the corrected `tsconfig.json`.
+  (`TS2307`/`TS2580`/`TS2503`) even with the corrected `tsconfig.json`. The generated
+  `tsconfig.json` also lists `"types": ["node"]` explicitly rather than relying on automatic
+  `@types/*` acquisition: TypeScript 5.x auto-includes every installed `@types` package when
+  `types` is unset, but TypeScript 7 (the native/Go-based compiler) does not extend that same
+  implicit inclusion to `@types/node`'s ambient globals (`process`, the `NodeJS` namespace) —
+  `tsc --noEmit` failed with `TS2591`/`TS2503` under TS 7 even with `@types/node` correctly
+  installed, until `types` named it explicitly.
 - **`mcp-execution-codegen`**: the generated runtime bridge (`_runtime/mcp-bridge.ts`) attached a
   fresh `stdout` listener per `callMCPTool` call and resolved on the first complete JSON-RPC
   message with an `id`, without checking that the `id` matched the request it sent. Two

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -47,8 +47,9 @@ use mcp_execution_introspector::{ServerInfo, ToolInfo};
 use std::collections::{HashMap, HashSet};
 
 /// Files emitted by every `generate`/`generate_with_categories` call regardless of tool
-/// count: `index.ts`, the runtime bridge, `package.json`, and the `_meta.json` sidecar.
-const FIXED_FILE_COUNT: usize = 4;
+/// count: `index.ts`, the runtime bridge, `package.json`, `tsconfig.json`, and the `_meta.json`
+/// sidecar.
+const FIXED_FILE_COUNT: usize = 5;
 
 /// Maximum number of files a single `generate`/`generate_with_categories` call will produce
 /// (denial-of-service protection, CWE-400).

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -80,6 +80,36 @@ pub const MAX_GENERATED_BYTES: usize = 2
         + mcp_execution_introspector::MAX_TOOL_DESCRIPTION_LEN
         + mcp_execution_introspector::MAX_SCHEMA_SIZE_BYTES);
 
+/// Contents of the generated `package.json`.
+///
+/// Declares `@types/node` as a `devDependency` — pinned to major version 22, matching the
+/// Node.js version this project's own CI targets — because `_runtime/mcp-bridge.ts` imports
+/// Node builtins (`child_process`, `fs/promises`, `os`, `path`) and references ambient globals
+/// (`process`, the `NodeJS` namespace) that only resolve once type declarations for Node are
+/// present; without it, `tsc --noEmit` fails on the generated package even with a correct
+/// `tsconfig.json` (see `TSCONFIG_JSON` below).
+const PACKAGE_JSON: &str = "{\"type\":\"module\",\"devDependencies\":{\"@types/node\":\"^22\"}}\n";
+
+/// Contents of the generated `tsconfig.json`.
+///
+/// Tool files import the runtime bridge with an explicit `.ts` extension (see
+/// `tool.ts.hbs`), which requires `allowImportingTsExtensions`. TypeScript requires `noEmit`
+/// (or a declaration/emit setting) whenever `allowImportingTsExtensions` is set, since that
+/// option only changes how imports are type-checked, not how output is emitted.
+const TSCONFIG_JSON: &str = r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}
+"#;
+
 /// Generator for progressive loading TypeScript files.
 ///
 /// Creates one file per tool plus an index file and runtime bridge,
@@ -130,6 +160,7 @@ impl<'a> ProgressiveGenerator<'a> {
     /// - `index.ts`: Re-exports all tools
     /// - `_runtime/mcp-bridge.ts`: Runtime bridge for calling MCP tools
     /// - `package.json`: ES module type declaration
+    /// - `tsconfig.json`: compiler options allowing the `.ts`-extensioned imports above
     ///
     /// # Arguments
     ///
@@ -173,6 +204,7 @@ impl<'a> ProgressiveGenerator<'a> {
     /// // - index.ts
     /// // - _runtime/mcp-bridge.ts
     /// // - package.json
+    /// // - tsconfig.json
     /// // - one file per tool
     /// println!("Generated {} files", code.file_count());
     /// # Ok(())
@@ -249,17 +281,31 @@ impl<'a> ProgressiveGenerator<'a> {
 
         tracing::debug!("Generated _runtime/mcp-bridge.ts");
 
-        // Generate package.json for ES module identification
+        // Generate package.json for ES module identification and the @types/node devDependency
+        // needed for the runtime bridge to type-check (see PACKAGE_JSON doc comment)
         add_tracked(
             &mut code,
             &mut total_bytes,
             GeneratedFile {
                 path: "package.json".to_string(),
-                content: "{\"type\":\"module\"}\n".to_string(),
+                content: PACKAGE_JSON.to_string(),
             },
         )?;
 
         tracing::debug!("Generated package.json");
+
+        // Generate tsconfig.json so `tsc --noEmit` accepts the `.ts`-extensioned import in
+        // each tool file (see TSCONFIG_JSON doc comment)
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "tsconfig.json".to_string(),
+                content: TSCONFIG_JSON.to_string(),
+            },
+        )?;
+
+        tracing::debug!("Generated tsconfig.json");
 
         // Generate _meta.json sidecar with structured tool metadata
         add_tracked(
@@ -417,17 +463,31 @@ impl<'a> ProgressiveGenerator<'a> {
 
         tracing::debug!("Generated _runtime/mcp-bridge.ts");
 
-        // Generate package.json for ES module identification
+        // Generate package.json for ES module identification and the @types/node devDependency
+        // needed for the runtime bridge to type-check (see PACKAGE_JSON doc comment)
         add_tracked(
             &mut code,
             &mut total_bytes,
             GeneratedFile {
                 path: "package.json".to_string(),
-                content: "{\"type\":\"module\"}\n".to_string(),
+                content: PACKAGE_JSON.to_string(),
             },
         )?;
 
         tracing::debug!("Generated package.json");
+
+        // Generate tsconfig.json so `tsc --noEmit` accepts the `.ts`-extensioned import in
+        // each tool file (see TSCONFIG_JSON doc comment)
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "tsconfig.json".to_string(),
+                content: TSCONFIG_JSON.to_string(),
+            },
+        )?;
+
+        tracing::debug!("Generated tsconfig.json");
 
         // Generate _meta.json sidecar with structured tool metadata
         add_tracked(
@@ -1024,8 +1084,9 @@ mod tests {
         // - 1 index.ts
         // - 1 runtime bridge
         // - 1 package.json
+        // - 1 tsconfig.json
         // - 1 _meta.json
-        assert_eq!(code.file_count(), 6);
+        assert_eq!(code.file_count(), 7);
 
         // Check tool files exist
         let tool_files: Vec<_> = code.files.iter().map(|f| f.path.as_str()).collect();
@@ -1035,7 +1096,58 @@ mod tests {
         assert!(tool_files.contains(&"index.ts"));
         assert!(tool_files.contains(&"_runtime/mcp-bridge.ts"));
         assert!(tool_files.contains(&"package.json"));
+        assert!(tool_files.contains(&"tsconfig.json"));
         assert!(tool_files.contains(&"_meta.json"));
+    }
+
+    /// Regression guard for #183: tool files import the runtime bridge with an explicit `.ts`
+    /// extension, which `tsc` only accepts under `allowImportingTsExtensions`; that option in
+    /// turn requires `noEmit` (or a declaration/emit setting) to be internally consistent.
+    #[test]
+    fn test_generate_tsconfig_json_allows_ts_extension_imports() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = create_test_server_info();
+
+        let code = generator.generate(&server_info).unwrap();
+
+        let tsconfig_file = code
+            .files
+            .iter()
+            .find(|f| f.path == "tsconfig.json")
+            .expect("tsconfig.json not found");
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&tsconfig_file.content).expect("tsconfig.json is not valid JSON");
+        let compiler_options = &parsed["compilerOptions"];
+
+        assert_eq!(compiler_options["allowImportingTsExtensions"], true);
+        assert_eq!(compiler_options["noEmit"], true);
+    }
+
+    /// Regression guard for #183: `tsconfig.json` alone does not make the generated package
+    /// pass `tsc --noEmit` — the runtime bridge imports Node builtins and references ambient
+    /// globals (`process`, `NodeJS`) that only resolve with `@types/node` installed. Without a
+    /// declared devDependency, a consumer running `tsc --noEmit` "out of the box" still fails.
+    #[test]
+    fn test_generate_package_json_declares_types_node_dev_dependency() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = create_test_server_info();
+
+        let code = generator.generate(&server_info).unwrap();
+
+        let package_json_file = code
+            .files
+            .iter()
+            .find(|f| f.path == "package.json")
+            .expect("package.json not found");
+
+        let parsed: serde_json::Value = serde_json::from_str(&package_json_file.content)
+            .expect("package.json is not valid JSON");
+
+        assert!(
+            parsed["devDependencies"]["@types/node"].is_string(),
+            "package.json is missing a @types/node devDependency: {parsed}"
+        );
     }
 
     #[test]

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -96,6 +96,14 @@ const PACKAGE_JSON: &str = "{\"type\":\"module\",\"devDependencies\":{\"@types/n
 /// `tool.ts.hbs`), which requires `allowImportingTsExtensions`. TypeScript requires `noEmit`
 /// (or a declaration/emit setting) whenever `allowImportingTsExtensions` is set, since that
 /// option only changes how imports are type-checked, not how output is emitted.
+///
+/// `"types": ["node"]` is explicit rather than relying on automatic `@types/*` acquisition:
+/// TypeScript 5.x auto-includes every package under `node_modules/@types` when `types` is
+/// unset, but TypeScript 7 (the native/Go-based compiler) does not extend that same implicit
+/// behavior to `@types/node`'s ambient globals (`process`, the `NodeJS` namespace) — `tsc
+/// --noEmit` fails with `TS2591`/`TS2503` under TS 7 even with `@types/node` correctly
+/// installed, unless `types` names it explicitly. Listing it explicitly works identically
+/// under both major versions.
 const TSCONFIG_JSON: &str = r#"{
   "compilerOptions": {
     "target": "ES2022",
@@ -104,7 +112,8 @@ const TSCONFIG_JSON: &str = r#"{
     "strict": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["**/*.ts"]
 }
@@ -1103,6 +1112,9 @@ mod tests {
     /// Regression guard for #183: tool files import the runtime bridge with an explicit `.ts`
     /// extension, which `tsc` only accepts under `allowImportingTsExtensions`; that option in
     /// turn requires `noEmit` (or a declaration/emit setting) to be internally consistent.
+    /// `types` must explicitly name `node` — TypeScript 7's automatic `@types/*` acquisition
+    /// does not extend `@types/node`'s ambient globals the way TypeScript 5.x's does, so
+    /// `tsc --noEmit` fails under TS 7 without this even with `@types/node` installed.
     #[test]
     fn test_generate_tsconfig_json_allows_ts_extension_imports() {
         let generator = ProgressiveGenerator::new().unwrap();
@@ -1122,6 +1134,7 @@ mod tests {
 
         assert_eq!(compiler_options["allowImportingTsExtensions"], true);
         assert_eq!(compiler_options["noEmit"], true);
+        assert_eq!(compiler_options["types"], serde_json::json!(["node"]));
     }
 
     /// Regression guard for #183: `tsconfig.json` alone does not make the generated package

--- a/crates/mcp-codegen/templates/progressive/tool.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/tool.ts.hbs
@@ -68,13 +68,15 @@ export type {{typescript_name}}Params = {
 /**
  * Result type for {{typescript_name}} tool.
  *
- * The structure of the result depends on the specific tool implementation.
- * Refer to the MCP server documentation for details.
+ * `callMCPTool` returns a parsed JSON object or array for JSON-shaped text content, a bare
+ * string for plain-text content, or the content item itself (an object) for non-text content
+ * types — this union reflects all three, rather than narrowing to an object-only shape.
+ * Refer to the MCP server documentation for the specific shape this tool actually returns.
+ *
+ * Narrow before accessing a property, e.g.:
+ * `if (typeof result === 'object' && result !== null && !Array.isArray(result)) { result.foo }`
  */
-{{!-- TODO(critic): Result is declared as Record<string, unknown> but callMCPTool returns string for text content and arrays for JSON lists — see #176 discussion --}}
-export interface {{typescript_name}}Result {
-  [key: string]: unknown;
-}
+export type {{typescript_name}}Result = Record<string, unknown> | unknown[] | string;
 
 // CLI mode: Execute when run directly
 // This enables autonomous execution via: node {{typescript_name}}.ts '{"param":"value"}'

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -99,8 +99,9 @@ fn test_progressive_generator_creates_correct_number_of_files() {
     // - 1 index.ts
     // - 1 runtime bridge (_runtime/mcp-bridge.ts)
     // - 1 package.json
+    // - 1 tsconfig.json
     // - 1 _meta.json
-    assert_eq!(code.file_count(), 7);
+    assert_eq!(code.file_count(), 8);
 }
 
 #[test]
@@ -130,6 +131,10 @@ fn test_progressive_tool_files_exist() {
     assert!(
         file_paths.contains(&"_runtime/mcp-bridge.ts"),
         "Missing _runtime/mcp-bridge.ts"
+    );
+    assert!(
+        file_paths.contains(&"tsconfig.json"),
+        "Missing tsconfig.json"
     );
 }
 
@@ -163,10 +168,13 @@ fn test_progressive_tool_file_structure() {
         "Missing Params type alias"
     );
 
-    // Should contain result interface
+    // Should contain the widened Result union — an object-only shape would misdescribe what
+    // callMCPTool can actually return (issue #182)
     assert!(
-        content.contains("export interface createIssueResult"),
-        "Missing Result interface"
+        content.contains(
+            "export type createIssueResult = Record<string, unknown> | unknown[] | string;"
+        ),
+        "Missing widened Result type union"
     );
 
     // Should call callMCPTool
@@ -382,13 +390,15 @@ fn test_progressive_generator_with_empty_server() {
     // - 1 index.ts
     // - 1 runtime bridge
     // - 1 package.json
+    // - 1 tsconfig.json
     // - 1 _meta.json
-    assert_eq!(code.file_count(), 4);
+    assert_eq!(code.file_count(), 5);
 
     let file_paths: Vec<_> = code.files.iter().map(|f| f.path.as_str()).collect();
     assert!(file_paths.contains(&"index.ts"));
     assert!(file_paths.contains(&"_runtime/mcp-bridge.ts"));
     assert!(file_paths.contains(&"package.json"));
+    assert!(file_paths.contains(&"tsconfig.json"));
 }
 
 #[test]
@@ -559,27 +569,82 @@ fn require_ts_toolchain(test_name: &str, require_node: bool) -> bool {
     false
 }
 
-/// Regression guard for #176: generated tool wrappers must actually type-check under
-/// `tsc --strict --noEmit`, not merely contain the right substrings. Type-checks the real
-/// generated `createIssue.ts` against a minimal stub of `callMCPTool` (mirroring the
-/// signature declared in `runtime-bridge.ts.hbs`) rather than the full runtime bridge, so
-/// the test stays offline and doesn't depend on `@types/node` being installed.
+/// `npm install -g typescript` installs a global `tsc`, but not `npm` itself as `npm.cmd` on
+/// Windows in a way `Command::new("npm")` would find — mirrors `tsc_program`'s reasoning.
+const fn npm_program() -> &'static str {
+    if cfg!(windows) { "npm.cmd" } else { "npm" }
+}
+
+/// Installs `dir`'s `package.json` `devDependencies` (currently just `@types/node`, added for
+/// #183) via `npm install`, so `tsc --noEmit` can resolve the Node builtin modules and ambient
+/// globals the real runtime bridge references. Without this, `tsc` would fail with `TS2307`/
+/// `TS2580`/`TS2503` regardless of how correct the generated `tsconfig.json` is.
 ///
-/// Skips locally (hard-fails in CI — see `require_ts_toolchain`) when `tsc` is not on `PATH`.
-#[test]
-fn test_generated_tool_passes_tsc_noemit() {
-    if !require_ts_toolchain("test_generated_tool_passes_tsc_noemit", false) {
-        return;
+/// Same skip-locally/hard-fail-in-CI policy as [`require_ts_toolchain`]: this exists to catch
+/// exactly the kind of regression a missing `@types/node` produces (see #183's critique), so
+/// silently skipping in CI would defeat the point. A local `npm install` failure (e.g. no
+/// network) skips rather than hard-failing, since CI is presumed to have registry access but a
+/// local sandbox may not.
+///
+/// Returns `true` if the install succeeded and the caller should proceed to `tsc`.
+fn install_declared_dev_dependencies(dir: &std::path::Path, test_name: &str) -> bool {
+    if Command::new(npm_program())
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "{test_name}: npm not found on PATH in CI — cannot install the generated \
+             package.json's devDependencies, so this test cannot catch a missing @types/node \
+             regression."
+        );
+        eprintln!("skipping {test_name}: npm not found on PATH");
+        return false;
     }
 
-    // Guard against the stub below silently going stale if callMCPTool's signature changes.
-    let bridge_template = include_str!("../templates/progressive/runtime-bridge.ts.hbs");
-    assert!(
-        bridge_template.contains("params: Record<string, unknown>")
-            && bridge_template.contains("): Promise<unknown> {"),
-        "callMCPTool signature in runtime-bridge.ts.hbs changed — update the stub in \
-         test_generated_tool_passes_tsc_noemit to match"
-    );
+    let output = Command::new(npm_program())
+        .args(["install", "--no-save", "--no-audit", "--no-fund"])
+        .current_dir(dir)
+        .output()
+        .expect("Failed to run npm install");
+
+    if !output.status.success() {
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "{test_name}: npm install failed in CI:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        eprintln!(
+            "skipping {test_name}: npm install failed (no network access?):\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return false;
+    }
+
+    true
+}
+
+/// Regression guard for #176/#182/#183: the *actual* exported package — every file `generate`
+/// produces, unmodified — must pass `tsc --noEmit` out of the box. Earlier versions of this
+/// test substituted a 9-line stub for `_runtime/mcp-bridge.ts` and a hand-written
+/// `globals.d.ts` declaring `process`, which meant it passed regardless of whether the real
+/// ~900-line bridge (which imports `child_process`/`fs/promises`/`os`/`path` and references the
+/// `NodeJS` namespace) actually type-checked — exactly the gap that let #183 regress even after
+/// a tsconfig-only fix (missing `@types/node`) landed. This writes every `code.files` entry
+/// verbatim, installs the generated `package.json`'s devDependencies for real via `npm
+/// install`, and only then runs `tsc --noEmit` against the generated `tsconfig.json`.
+///
+/// Skips locally (hard-fails in CI) when `tsc`/`node`/`npm` are not on `PATH`, or when `npm
+/// install` fails (e.g. no network) — see `require_ts_toolchain` and
+/// `install_declared_dev_dependencies`.
+#[test]
+fn test_generated_tool_passes_tsc_noemit() {
+    let test_name = "test_generated_tool_passes_tsc_noemit";
+    if !require_ts_toolchain(test_name, true) {
+        return;
+    }
 
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
@@ -587,70 +652,22 @@ fn test_generated_tool_passes_tsc_noemit() {
         .generate(&server_info)
         .expect("Failed to generate code");
 
-    let tool_file = code
-        .files
-        .iter()
-        .find(|f| f.path == "createIssue.ts")
-        .expect("createIssue.ts not found");
-    let package_json = code
-        .files
-        .iter()
-        .find(|f| f.path == "package.json")
-        .expect("package.json not found");
-
     let dir = tempfile::tempdir().expect("Failed to create temp dir");
 
-    std::fs::write(dir.path().join("createIssue.ts"), &tool_file.content)
-        .expect("Failed to write createIssue.ts");
-    // Real package.json declares `"type": "module"`, which is what makes `import.meta.url`
-    // in the generated CLI-mode block legal under NodeNext module resolution.
-    std::fs::write(dir.path().join("package.json"), &package_json.content)
-        .expect("Failed to write package.json");
-    // Minimal ambient declaration for the subset of the Node `process` global the generated
-    // CLI-mode block references, so the test doesn't depend on `@types/node` being installed.
-    std::fs::write(
-        dir.path().join("globals.d.ts"),
-        "declare const process: {\n\
-         \x20\x20argv: string[];\n\
-         \x20\x20exit(code?: number): never;\n\
-         };\n",
-    )
-    .expect("Failed to write globals.d.ts");
+    // Write every generated file verbatim — real bridge, real package.json, real
+    // tsconfig.json, real tool/index files — rather than substituting stand-ins for any of
+    // them, so this test proves the actual exported package type-checks, not a stand-in of it.
+    for file in &code.files {
+        let path = dir.path().join(&file.path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("Failed to create parent dir for file");
+        }
+        std::fs::write(&path, &file.content).expect("Failed to write generated file");
+    }
 
-    let runtime_dir = dir.path().join("_runtime");
-    std::fs::create_dir_all(&runtime_dir).expect("Failed to create _runtime dir");
-    std::fs::write(
-        runtime_dir.join("mcp-bridge.ts"),
-        "export async function callMCPTool(\n\
-         \x20\x20serverId: string,\n\
-         \x20\x20toolName: string,\n\
-         \x20\x20params: Record<string, unknown>\n\
-         ): Promise<unknown> {\n\
-         \x20\x20void serverId;\n\
-         \x20\x20void toolName;\n\
-         \x20\x20void params;\n\
-         \x20\x20return undefined;\n\
-         }\n",
-    )
-    .expect("Failed to write mcp-bridge.ts stub");
-
-    std::fs::write(
-        dir.path().join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "strict": true,
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
-    "skipLibCheck": true
-  },
-  "include": ["**/*.ts"]
-}
-"#,
-    )
-    .expect("Failed to write tsconfig.json");
+    if !install_declared_dev_dependencies(dir.path(), test_name) {
+        return;
+    }
 
     let output = Command::new(tsc_program())
         .arg("--noEmit")
@@ -661,7 +678,7 @@ fn test_generated_tool_passes_tsc_noemit() {
 
     assert!(
         output.status.success(),
-        "tsc --noEmit failed on generated createIssue.ts:\nstdout: {}\nstderr: {}",
+        "tsc --noEmit failed on the real generated package:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -586,6 +586,11 @@ const fn npm_program() -> &'static str {
 /// network) skips rather than hard-failing, since CI is presumed to have registry access but a
 /// local sandbox may not.
 ///
+/// Passes `--include=dev` explicitly: with `NODE_ENV=production` set in the environment, `npm
+/// install` silently omits `devDependencies` (exit success, nothing installed) instead of
+/// failing, which would otherwise let a missing `@types/node` regression slip through with no
+/// signal — `--include=dev` overrides that regardless of `NODE_ENV`.
+///
 /// Returns `true` if the install succeeded and the caller should proceed to `tsc`.
 fn install_declared_dev_dependencies(dir: &std::path::Path, test_name: &str) -> bool {
     if Command::new(npm_program())
@@ -604,7 +609,13 @@ fn install_declared_dev_dependencies(dir: &std::path::Path, test_name: &str) -> 
     }
 
     let output = Command::new(npm_program())
-        .args(["install", "--no-save", "--no-audit", "--no-fund"])
+        .args([
+            "install",
+            "--no-save",
+            "--no-audit",
+            "--no-fund",
+            "--include=dev",
+        ])
         .current_dir(dir)
         .output()
         .expect("Failed to run npm install");


### PR DESCRIPTION
## Summary
- Widen the generated `{Tool}Result` type from an object-only `interface` to a union (`Record<string, unknown> | unknown[] | string`) matching every shape `callMCPTool` can actually return (fixes #182). This is a breaking change for generated-code consumers: direct property access now requires narrowing the union first.
- Emit a `tsconfig.json` alongside `package.json` enabling `allowImportingTsExtensions` so `tsc --noEmit` accepts the `.ts`-extensioned bridge import under plain nodenext resolution (fixes #183).
- Declare `@types/node` as a `devDependency` in the generated `package.json` — the runtime bridge imports Node builtins and ambient globals that don't resolve without it; the tsconfig fix alone was not sufficient to make `tsc --noEmit` pass on a real exported package.
- Rework `test_generated_tool_passes_tsc_noemit` to compile the real generated file tree (real bridge, real package.json, real tsconfig.json) via `npm install --no-save` + `tsc --noEmit`, instead of a stubbed bridge — verified this catches the regression (37 TS2307/TS2580/TS2503 errors) if `@types/node` is removed.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (820 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Real `tsc --noEmit` run against a freshly generated package (0 errors)
- [x] CHANGELOG.md updated under `[Unreleased]`