### PR TITLE
fix: bound resource-exhaustion vectors across the introspect-store-codegen pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mcp-cli`), and `ServerConfigBuilder` uses the more precise `ValidationError` (#199). Note
   `mcp_files::FilesError::is_not_found()` is a different type and is unchanged.
 
+- **`mcp-execution-server`**: `StateManager::store` now returns `Result<Uuid, StateError>`
+  instead of an infallible `Uuid`, rejecting new sessions once the pending-generation table is
+  at capacity (see the resource-exhaustion fix below, #198).
+
 ### Security
+
+- **`mcp-execution-core`**: `validate_server_config` now bounds `ServerConfig`'s `command`/
+  `args`/`env`/`headers`/`url` element counts and per-string lengths (`MAX_ARG_COUNT`,
+  `MAX_ARG_LEN`, `MAX_ENV_COUNT`, `MAX_ENV_VALUE_LEN`, `MAX_HEADER_COUNT`,
+  `MAX_HEADER_VALUE_LEN`, `MAX_URL_LEN`), closing a resource-exhaustion gap (CWE-400) where a
+  caller-supplied config could otherwise grow the spawned subprocess's argv/environment/header
+  set without bound. All of these element counts/lengths — including `headers`/`url`, not just
+  `command`/`args`/`env` — are now checked unconditionally before the transport-specific
+  dispatch (previously stdio-only for `command`/`args`/`env`, and Http/Sse-only for
+  `headers`/`url`), since a hand-edited or hostile `mcp.json`/JSON payload can populate any of
+  these fields regardless of declared transport, bypassing whichever transport-specific check
+  would otherwise have caught it; header *names* (previously unbounded) are now length-capped
+  as well (#198).
+
+- **`mcp-execution-introspector`**: `Introspector::discover_server` now bounds an MCP server's
+  reported tool count (`MAX_TOOL_COUNT`) and each tool's name/description length and serialized
+  input-schema size (`MAX_TOOL_NAME_LEN`, `MAX_TOOL_DESCRIPTION_LEN`, `MAX_SCHEMA_SIZE_BYTES` —
+  64KB, ~10x any real MCP tool schema observed in practice; this is the dominant term in every
+  budget derived from it downstream, so it is kept deliberately small), rejecting with the new
+  `Error::ResourceLimitExceeded` variant instead of accepting an unbounded response from an
+  untrusted or misbehaving server. Tool discovery now fetches pages via `list_tools` directly
+  and bails as soon as the accumulated count crosses `MAX_TOOL_COUNT`, rather than buffering
+  every page of a (potentially unbounded) response first the way `list_all_tools` does, so peak
+  memory during discovery is also bounded, not just what is kept afterward (#198).
+
+- **`mcp-execution-codegen`**: `ProgressiveGenerator::generate`/`generate_with_categories` now
+  reject a tool count or combined output size that would exceed `MAX_GENERATED_FILES`/
+  `MAX_GENERATED_BYTES` (both now derived from `mcp-execution-introspector`'s own bounds rather
+  than chosen independently, so a `ServerInfo` that already cleared introspection can never be
+  deterministically rejected here for simply being as large as introspection already allows).
+  The byte budget is now checked incrementally as each file is produced (tool file, index,
+  runtime bridge, `_meta.json`), bailing out on the first file that pushes the running total
+  over the limit, rather than only after the entire output has been built (#198).
+
+- **`mcp-execution-files`**: `FileSystem::export_to_filesystem`/`export_to_filesystem_parallel`
+  now reject an export whose file count or total byte size exceeds `MAX_EXPORT_FILES`/
+  `MAX_EXPORT_BYTES` (derived from `mcp-execution-codegen`'s own bounds, for the same
+  consistency reason as above), via the new `FilesError::ResourceLimitExceeded` variant (#198).
+
+- **`mcp-execution-server`**: `StateManager` now caps concurrent pending-generation sessions at
+  `MAX_PENDING_SESSIONS` (1000) *and* their combined approximate memory footprint at
+  `MAX_TOTAL_PENDING_BYTES`. The count cap alone does not bound memory, since a session's size
+  (driven by the introspected server's tool count) can vary by orders of magnitude — up to
+  hundreds of megabytes per session — so a count-only cap could still reach hundreds of
+  gigabytes in the worst case; the new byte budget is the one that actually bounds memory. A
+  rejection surfaces as a distinct JSON-RPC "Server error" range code rather than
+  `INTERNAL_ERROR`, signaling a transient capacity condition rather than an internal fault
+  (#198).
 
 - **`mcp-execution-cli`**: a malformed `--header`/`--env` value (missing the `=` separator, or
   with an empty key) no longer echoes the raw, unvalidated argument into the CLI error message.
@@ -178,7 +230,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   point — the bare username is scrubbed from the rendered path as a defense-in-depth fallback
   rather than the previous behavior of returning the path unredacted.
 
+### Testing
+
+- **`mcp-execution-introspector`**: added `tests/tool_count_bound_test.rs`, an integration test
+  spawning a real in-process Streamable HTTP fixture whose `tools/list` handler serves pages
+  one at a time, proving `discover_server`'s early-bailout pagination logic
+  (`list_tools_bounded`, introduced for #198 S4) actually stops pulling pages as soon as the
+  accumulated tool count crosses `MAX_TOOL_COUNT` — against a fixture that never signals
+  completion on its own, so the test cannot pass by the client merely running out of data to
+  fetch — and separately that exactly `MAX_TOOL_COUNT` tools spread across multiple pages are
+  still accepted in full. Previously this behavior had no test coverage at all; the existing
+  `build_server_info` count-check test only exercises a direct call to that function, a branch
+  that is no longer reachable via `discover_server` in practice now that `list_tools_bounded`
+  bails out before ever handing it an over-limit list (#198).
+
 ### Changed
+
+- **`mcp-execution-server`, `mcp-execution-skill`**: fields with a documented numeric bound
+  (`CategorizedTool`'s `name`/`category`/`keywords`/`short_description`,
+  `SaveCategorizedToolsParams::categorized_tools`, `IntrospectServerParams`'s `server_id`/
+  `command`/`args`, `GenerateSkillParams`/`SaveSkillParams`'s `server_id`, and
+  `SaveSkillParams::content`) now declare matching `schemars` `length`/`regex` attributes, so
+  the generated JSON Schema surfaces `maxLength`/`maxItems`/`pattern` constraints that were
+  previously enforced only at runtime, not visible to a client inspecting the tool's input
+  schema. Each declared bound is now cross-checked in a test against the real runtime constant
+  it mirrors (not just another hardcoded literal), so the two can no longer silently drift
+  apart (#205).
 
 - **`mcp-execution-skill`**: `validate_server_id` and `extract_skill_metadata` now return
   `ServerIdError` and `SkillMetadataError` (both `thiserror`-derived enums) instead of a bare

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use mcp_execution_core::Error as CoreError;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
+use mcp_execution_files::FilesError;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::cli::Commands;
@@ -216,22 +217,52 @@ pub fn report_and_classify(err: &anyhow::Error) -> ExitCode {
 /// Walks the error's cause chain looking for a [`CoreError`] — the concrete
 /// type every command handler ultimately produces via `?` — and maps its
 /// variant to the exit code that best communicates the failure category to
-/// scripts consuming this CLI. Errors that never wrap a [`CoreError`] (e.g.
-/// CLI argument parsing, serialization) fall back to [`ExitCode::ERROR`].
+/// scripts consuming this CLI. Falls back to checking for a [`FilesError`]
+/// (the `generate` command's `export_to_filesystem` errors are wrapped via `anyhow::Context`
+/// rather than converted to `CoreError`, so they would otherwise never match the first check
+/// and always fall through to the generic [`ExitCode::ERROR`] — issue #198 M6). Errors that
+/// match neither (e.g. CLI argument parsing, serialization) fall back to [`ExitCode::ERROR`].
 fn classify_exit_code(error: &anyhow::Error) -> ExitCode {
-    error
+    if let Some(core_error) = error
         .chain()
         .find_map(|cause| cause.downcast_ref::<CoreError>())
-        .map_or(ExitCode::ERROR, |core_error| match core_error {
+    {
+        return match core_error {
             CoreError::Timeout { .. } => ExitCode::TIMEOUT,
-            CoreError::ConnectionFailed { .. } => ExitCode::SERVER_ERROR,
+            // A resource limit is exceeded by data the remote MCP server returned (tool
+            // count, schema size, etc.), not by the CLI caller's own arguments — same
+            // "the server is at fault" classification as `ConnectionFailed`.
+            CoreError::ConnectionFailed { .. } | CoreError::ResourceLimitExceeded { .. } => {
+                ExitCode::SERVER_ERROR
+            }
             CoreError::ValidationError { .. }
             | CoreError::SecurityViolation { .. }
             | CoreError::InvalidArgument(_) => ExitCode::INVALID_INPUT,
             CoreError::SerializationError { .. } | CoreError::ScriptGenerationError { .. } => {
                 ExitCode::ERROR
             }
-        })
+        };
+    }
+
+    if let Some(files_error) = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<FilesError>())
+    {
+        return match files_error {
+            // Same "the server is at fault" classification as `CoreError::ResourceLimitExceeded`
+            // above — the export this bounds is sized by what the (possibly hostile or
+            // misbehaving) introspected server returned, not by CLI-caller-supplied input.
+            FilesError::ResourceLimitExceeded { .. } => ExitCode::SERVER_ERROR,
+            FilesError::FileNotFound { .. }
+            | FilesError::NotADirectory { .. }
+            | FilesError::InvalidPath { .. }
+            | FilesError::PathNotAbsolute { .. }
+            | FilesError::InvalidPathComponent { .. }
+            | FilesError::IoError { .. } => ExitCode::ERROR,
+        };
+    }
+
+    ExitCode::ERROR
 }
 
 #[cfg(test)]
@@ -258,6 +289,41 @@ mod tests {
             source: "refused".into(),
         });
         assert_eq!(classify_exit_code(&err), ExitCode::SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_classify_exit_code_resource_limit_exceeded() {
+        let err = wrap(CoreError::ResourceLimitExceeded {
+            resource: "tool count".to_string(),
+            actual: 1500,
+            limit: 1000,
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::SERVER_ERROR);
+    }
+
+    /// #198 M6 — `FilesError` (e.g. from `generate`'s `export_to_filesystem`, wrapped via
+    /// `anyhow::Context` rather than converted to `CoreError`) must be classified too, not
+    /// fall through to the generic `ExitCode::ERROR` unconditionally.
+    #[test]
+    fn test_classify_exit_code_files_error_resource_limit_exceeded() {
+        let files_error = FilesError::ResourceLimitExceeded {
+            resource: "export file count".to_string(),
+            actual: 3000,
+            limit: 2000,
+        };
+        // Mirrors how `commands::generate::run` actually wraps this error.
+        let err: anyhow::Error =
+            anyhow::Error::new(files_error).context("failed to export files to filesystem");
+
+        assert_eq!(classify_exit_code(&err), ExitCode::SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_classify_exit_code_files_error_other_variant_falls_back_to_error() {
+        let err = anyhow::Error::new(FilesError::FileNotFound {
+            path: "/missing".to_string(),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
     }
 
     #[test]

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -46,6 +46,40 @@ use mcp_execution_core::{Error, Result};
 use mcp_execution_introspector::{ServerInfo, ToolInfo};
 use std::collections::{HashMap, HashSet};
 
+/// Files emitted by every `generate`/`generate_with_categories` call regardless of tool
+/// count: `index.ts`, the runtime bridge, `package.json`, and the `_meta.json` sidecar.
+const FIXED_FILE_COUNT: usize = 4;
+
+/// Maximum number of files a single `generate`/`generate_with_categories` call will produce
+/// (denial-of-service protection, CWE-400).
+///
+/// Each tool becomes its own `.ts` file, so this bounds the file-count amplification of a
+/// single generation run. Derived directly from
+/// `mcp_execution_introspector::MAX_TOOL_COUNT` (rather than an independently chosen number)
+/// plus this module's `FIXED_FILE_COUNT`, so a `ServerInfo` that already cleared introspection's
+/// own tool-count bound can never be deterministically rejected here for simply having "as many tools
+/// as introspection already allows" (issue #198 M1). This check remains meaningful
+/// defense-in-depth for callers that construct a `ServerInfo` directly rather than going
+/// through introspection.
+pub const MAX_GENERATED_FILES: usize =
+    mcp_execution_introspector::MAX_TOOL_COUNT + FIXED_FILE_COUNT;
+
+/// Maximum total bytes across every file in a single `generate`/`generate_with_categories`
+/// call's output (denial-of-service protection, CWE-400).
+///
+/// Derived from `mcp_execution_introspector`'s own per-tool bounds — up to `MAX_TOOL_COUNT`
+/// tools, each up to `MAX_TOOL_NAME_LEN` + `MAX_TOOL_DESCRIPTION_LEN` + `MAX_SCHEMA_SIZE_BYTES`
+/// — rather than chosen independently, so a `ServerInfo` that already cleared introspection's
+/// own bounds can never be deterministically rejected here for simply being "as large as
+/// introspection already allows" (issue #198 M1). The 2x multiplier accounts for `_meta.json`
+/// re-embedding every tool's raw name/description/schema alongside the already-rendered `.ts`
+/// file content, roughly doubling the total.
+pub const MAX_GENERATED_BYTES: usize = 2
+    * mcp_execution_introspector::MAX_TOOL_COUNT
+    * (mcp_execution_introspector::MAX_TOOL_NAME_LEN
+        + mcp_execution_introspector::MAX_TOOL_DESCRIPTION_LEN
+        + mcp_execution_introspector::MAX_SCHEMA_SIZE_BYTES);
+
 /// Generator for progressive loading TypeScript files.
 ///
 /// Creates one file per tool plus an index file and runtime bridge,
@@ -154,7 +188,10 @@ impl<'a> ProgressiveGenerator<'a> {
             server_info.name
         );
 
+        enforce_tool_count_bound(server_info)?;
+
         let mut code = GeneratedCode::new();
+        let mut total_bytes = 0usize;
         let server_id = server_info.id.as_str();
         let typescript_names = resolve_typescript_names(&server_info.tools);
         let mut tool_metadata = Vec::with_capacity(server_info.tools.len());
@@ -166,10 +203,14 @@ impl<'a> ProgressiveGenerator<'a> {
                 self.create_tool_context(server_id, tool, None, typescript_name.clone())?;
             let tool_code = self.engine.render("progressive/tool", &tool_context)?;
 
-            code.add_file(GeneratedFile {
-                path: format!("{}.ts", tool_context.typescript_name),
-                content: tool_code,
-            });
+            add_tracked(
+                &mut code,
+                &mut total_bytes,
+                GeneratedFile {
+                    path: format!("{}.ts", tool_context.typescript_name),
+                    content: tool_code,
+                },
+            )?;
 
             tracing::debug!("Generated tool file: {}.ts", tool_context.typescript_name);
 
@@ -180,10 +221,14 @@ impl<'a> ProgressiveGenerator<'a> {
         let index_context = self.create_index_context(server_info, None, &typescript_names)?;
         let index_code = self.engine.render("progressive/index", &index_context)?;
 
-        code.add_file(GeneratedFile {
-            path: "index.ts".to_string(),
-            content: index_code,
-        });
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "index.ts".to_string(),
+                content: index_code,
+            },
+        )?;
 
         tracing::debug!("Generated index.ts");
 
@@ -193,23 +238,35 @@ impl<'a> ProgressiveGenerator<'a> {
             .engine
             .render("progressive/runtime-bridge", &bridge_context)?;
 
-        code.add_file(GeneratedFile {
-            path: "_runtime/mcp-bridge.ts".to_string(),
-            content: bridge_code,
-        });
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "_runtime/mcp-bridge.ts".to_string(),
+                content: bridge_code,
+            },
+        )?;
 
         tracing::debug!("Generated _runtime/mcp-bridge.ts");
 
         // Generate package.json for ES module identification
-        code.add_file(GeneratedFile {
-            path: "package.json".to_string(),
-            content: "{\"type\":\"module\"}\n".to_string(),
-        });
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "package.json".to_string(),
+                content: "{\"type\":\"module\"}\n".to_string(),
+            },
+        )?;
 
         tracing::debug!("Generated package.json");
 
         // Generate _meta.json sidecar with structured tool metadata
-        code.add_file(Self::create_metadata_file(server_info, tool_metadata)?);
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            Self::create_metadata_file(server_info, tool_metadata)?,
+        )?;
 
         tracing::debug!("Generated {}", METADATA_FILE_NAME);
 
@@ -289,7 +346,10 @@ impl<'a> ProgressiveGenerator<'a> {
             server_info.name
         );
 
+        enforce_tool_count_bound(server_info)?;
+
         let mut code = GeneratedCode::new();
+        let mut total_bytes = 0usize;
         let server_id = server_info.id.as_str();
         let typescript_names = resolve_typescript_names(&server_info.tools);
         let mut tool_metadata = Vec::with_capacity(server_info.tools.len());
@@ -303,10 +363,14 @@ impl<'a> ProgressiveGenerator<'a> {
                 self.create_tool_context(server_id, tool, categorization, typescript_name.clone())?;
             let tool_code = self.engine.render("progressive/tool", &tool_context)?;
 
-            code.add_file(GeneratedFile {
-                path: format!("{}.ts", tool_context.typescript_name),
-                content: tool_code,
-            });
+            add_tracked(
+                &mut code,
+                &mut total_bytes,
+                GeneratedFile {
+                    path: format!("{}.ts", tool_context.typescript_name),
+                    content: tool_code,
+                },
+            )?;
 
             tracing::debug!(
                 "Generated tool file: {}.ts (category: {:?})",
@@ -322,10 +386,14 @@ impl<'a> ProgressiveGenerator<'a> {
             self.create_index_context(server_info, Some(categorizations), &typescript_names)?;
         let index_code = self.engine.render("progressive/index", &index_context)?;
 
-        code.add_file(GeneratedFile {
-            path: "index.ts".to_string(),
-            content: index_code,
-        });
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "index.ts".to_string(),
+                content: index_code,
+            },
+        )?;
 
         tracing::debug!(
             "Generated index.ts with {} categorizations",
@@ -338,23 +406,35 @@ impl<'a> ProgressiveGenerator<'a> {
             .engine
             .render("progressive/runtime-bridge", &bridge_context)?;
 
-        code.add_file(GeneratedFile {
-            path: "_runtime/mcp-bridge.ts".to_string(),
-            content: bridge_code,
-        });
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "_runtime/mcp-bridge.ts".to_string(),
+                content: bridge_code,
+            },
+        )?;
 
         tracing::debug!("Generated _runtime/mcp-bridge.ts");
 
         // Generate package.json for ES module identification
-        code.add_file(GeneratedFile {
-            path: "package.json".to_string(),
-            content: "{\"type\":\"module\"}\n".to_string(),
-        });
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "package.json".to_string(),
+                content: "{\"type\":\"module\"}\n".to_string(),
+            },
+        )?;
 
         tracing::debug!("Generated package.json");
 
         // Generate _meta.json sidecar with structured tool metadata
-        code.add_file(Self::create_metadata_file(server_info, tool_metadata)?);
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            Self::create_metadata_file(server_info, tool_metadata)?,
+        )?;
 
         tracing::debug!("Generated {}", METADATA_FILE_NAME);
 
@@ -652,6 +732,74 @@ impl<'a> ProgressiveGenerator<'a> {
             content,
         })
     }
+}
+
+/// Cheaply rejects an oversized `server_info.tools` list before any per-tool template
+/// rendering happens (denial-of-service protection, CWE-400).
+///
+/// A caller reaching [`ProgressiveGenerator::generate`]/`generate_with_categories` through
+/// `mcp_execution_introspector::Introspector::discover_server` already has its tool count
+/// bounded upstream, but this crate's generator functions are public API and can be called
+/// directly with a hand-built `ServerInfo`, so this check is not purely redundant.
+///
+/// # Errors
+///
+/// Returns [`Error::ResourceLimitExceeded`] if `server_info.tools.len()` plus the
+/// [`FIXED_FILE_COUNT`] files every call emits would exceed [`MAX_GENERATED_FILES`] — the same
+/// threshold [`add_tracked`] checks incrementally as each file is produced, so this
+/// short-circuits exactly the inputs that check would go on to reject anyway, before any
+/// template rendering happens at all.
+fn enforce_tool_count_bound(server_info: &ServerInfo) -> Result<()> {
+    let projected_file_count = server_info.tools.len() + FIXED_FILE_COUNT;
+    if projected_file_count > MAX_GENERATED_FILES {
+        return Err(Error::ResourceLimitExceeded {
+            resource: format!("tool count for server '{}'", server_info.id),
+            actual: server_info.tools.len(),
+            limit: MAX_GENERATED_FILES - FIXED_FILE_COUNT,
+        });
+    }
+    Ok(())
+}
+
+/// Adds `file` to `code`, tracking its contribution to `total_bytes` and bailing out
+/// immediately if either the running byte total or the file count would exceed its configured
+/// bound (denial-of-service protection, CWE-400).
+///
+/// Checked incrementally as each file is produced, rather than only after the entire
+/// [`GeneratedCode`] has been built: an oversized `ServerInfo` (or one whose fixed-overhead
+/// files, e.g. `_meta.json` re-embedding every tool's schema, push the total over the edge)
+/// is rejected as soon as the offending file is generated, so this generator never holds the
+/// full amplified output in memory before the bound is enforced (issue #198 S4).
+///
+/// # Errors
+///
+/// Returns [`Error::ResourceLimitExceeded`] if adding `file` would push the running byte total
+/// past [`MAX_GENERATED_BYTES`], or the file count past [`MAX_GENERATED_FILES`].
+fn add_tracked(
+    code: &mut GeneratedCode,
+    total_bytes: &mut usize,
+    file: GeneratedFile,
+) -> Result<()> {
+    *total_bytes += file.content.len();
+    if *total_bytes > MAX_GENERATED_BYTES {
+        return Err(Error::ResourceLimitExceeded {
+            resource: "generated output size".to_string(),
+            actual: *total_bytes,
+            limit: MAX_GENERATED_BYTES,
+        });
+    }
+
+    code.add_file(file);
+
+    if code.file_count() > MAX_GENERATED_FILES {
+        return Err(Error::ResourceLimitExceeded {
+            resource: "generated file count".to_string(),
+            actual: code.file_count(),
+            limit: MAX_GENERATED_FILES,
+        });
+    }
+
+    Ok(())
 }
 
 /// Sanitizes a server-controlled string for safe interpolation into JSDoc block comments.
@@ -1974,5 +2122,123 @@ mod tests {
         assert!(tool.content.contains("issues *\\/ injected next"));
         assert!(tool.content.contains("create,*\\/ injected next"));
         assert!(tool.content.contains("Create *\\/ injected next"));
+    }
+
+    // ── Resource-exhaustion bounds (issue #198) ──────────────────────────────
+
+    fn server_info_with_tool_count(count: usize) -> ServerInfo {
+        ServerInfo {
+            id: ServerId::new("bulk-server"),
+            name: "Bulk Server".to_string(),
+            version: "1.0.0".to_string(),
+            tools: (0..count)
+                .map(|i| ToolInfo {
+                    name: ToolName::new(format!("tool{i}")),
+                    description: String::new(),
+                    input_schema: json!({}),
+                    output_schema: None,
+                })
+                .collect(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+        }
+    }
+
+    #[test]
+    fn test_generate_rejects_tool_count_that_would_exceed_max_generated_files() {
+        let server_info = server_info_with_tool_count(MAX_GENERATED_FILES - FIXED_FILE_COUNT + 1);
+        let generator = ProgressiveGenerator::new().unwrap();
+
+        let result = generator.generate(&server_info);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_generate_accepts_tool_count_at_exact_max_generated_files() {
+        let server_info = server_info_with_tool_count(MAX_GENERATED_FILES - FIXED_FILE_COUNT);
+        let generator = ProgressiveGenerator::new().unwrap();
+
+        let code = generator.generate(&server_info).unwrap();
+
+        assert_eq!(code.file_count(), MAX_GENERATED_FILES);
+    }
+
+    #[test]
+    fn test_generate_with_categories_rejects_tool_count_that_would_exceed_max_generated_files() {
+        let server_info = server_info_with_tool_count(MAX_GENERATED_FILES - FIXED_FILE_COUNT + 1);
+        let generator = ProgressiveGenerator::new().unwrap();
+
+        let result = generator.generate_with_categories(&server_info, &HashMap::new());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_add_tracked_rejects_oversized_total_bytes() {
+        let mut code = GeneratedCode::new();
+        let mut total_bytes = 0usize;
+
+        let result = add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "big.ts".to_string(),
+                content: "a".repeat(MAX_GENERATED_BYTES + 1),
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_add_tracked_accepts_total_bytes_at_exact_max() {
+        let mut code = GeneratedCode::new();
+        let mut total_bytes = 0usize;
+
+        let result = add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "big.ts".to_string(),
+                content: "a".repeat(MAX_GENERATED_BYTES),
+            },
+        );
+
+        assert!(result.is_ok());
+    }
+
+    /// #198 M8 — proves `generate()` itself (not just the private `add_tracked` helper)
+    /// enforces the byte budget, using a `total_bytes` starting point injected just below the
+    /// cap rather than materializing a real `MAX_GENERATED_BYTES`-sized (now several hundred
+    /// MB, after the M1 fix ties it to `mcp_execution_introspector`'s own bounds) `ServerInfo`
+    /// — which would make this test itself a slow, wasteful multi-hundred-MB allocation for
+    /// every CI run without proving anything `add_tracked`'s direct boundary tests don't
+    /// already cover more precisely.
+    #[test]
+    fn test_add_tracked_rejects_immediately_once_running_total_exceeds_max() {
+        let mut code = GeneratedCode::new();
+        let mut total_bytes = MAX_GENERATED_BYTES - 1;
+
+        let result = add_tracked(
+            &mut code,
+            &mut total_bytes,
+            GeneratedFile {
+                path: "second.ts".to_string(),
+                content: "ab".to_string(),
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+        // The offending file must not have been added — the caller should not be able to
+        // observe a `GeneratedCode` that already exceeds the bound.
+        assert_eq!(code.file_count(), 0);
     }
 }

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -103,6 +103,44 @@ const FORBIDDEN_ENV_PREFIX: &str = "DYLD_";
 /// slow-starting servers configured via `mcp.json`.
 const MAX_TIMEOUT: Duration = Duration::from_mins(10);
 
+/// Maximum number of positional arguments accepted in a `ServerConfig` (denial-of-service
+/// protection, CWE-400).
+///
+/// An `mcp.json` entry or CLI invocation is expected to pass a short, fixed argv to the
+/// spawned subprocess, so this is generous headroom rather than a realistic expectation.
+pub const MAX_ARG_COUNT: usize = 256;
+
+/// Maximum byte length for a single command string, argument, or environment variable name.
+///
+/// A legitimate command/argument/env-name is always a short identifier or path, never
+/// free-form text, so this ceiling exists purely as a resource-exhaustion backstop.
+pub const MAX_ARG_LEN: usize = 4096;
+
+/// Maximum number of environment variables accepted in a `ServerConfig`.
+pub const MAX_ENV_COUNT: usize = 256;
+
+/// Maximum byte length for a single environment variable value.
+///
+/// Wider than [`MAX_ARG_LEN`] since env values legitimately carry things like JSON
+/// configuration blobs, not just short identifiers.
+pub const MAX_ENV_VALUE_LEN: usize = 32 * 1024;
+
+/// Maximum number of HTTP headers accepted for Http/Sse transport.
+pub const MAX_HEADER_COUNT: usize = 128;
+
+/// Maximum byte length for a single HTTP header value.
+///
+/// Wider than [`MAX_ARG_LEN`] since header values legitimately carry things like long
+/// bearer tokens.
+pub const MAX_HEADER_VALUE_LEN: usize = 8 * 1024;
+
+/// Maximum byte length for the HTTP/Sse transport `url`.
+///
+/// Generous headroom over any realistic endpoint URL (including a long query string), while
+/// still bounding a hostile or hand-edited `mcp.json` entry (denial-of-service protection,
+/// CWE-400).
+pub const MAX_URL_LEN: usize = 8 * 1024;
+
 /// Returns the shell metacharacters considered forbidden in a command or argument string.
 ///
 /// Exposed so downstream consumers that must mirror this exact rule outside this function —
@@ -180,6 +218,15 @@ pub const fn forbidden_env_prefix() -> &'static str {
 /// - **Header names/values**: Must not contain control characters
 /// - **Timeout bounds**: `connect_timeout`/`discover_timeout` must be greater than zero and at
 ///   most `MAX_TIMEOUT` (600s)
+/// - **Element counts/lengths** (denial-of-service protection, CWE-400), checked
+///   unconditionally regardless of transport — see this module's `validate_size_bounds` — since
+///   `ServerConfig`'s `command`/`args`/`env` fields are all `#[serde(default)]` and can be
+///   populated for any transport by a hand-edited or hostile `mcp.json`/JSON payload even
+///   though the builder itself only ever populates them for stdio: at most `MAX_ARG_COUNT`
+///   args, `MAX_ENV_COUNT` env vars, and `MAX_HEADER_COUNT` headers; at most `MAX_ARG_LEN`
+///   bytes per command/argument/env-name/header-name, `MAX_ENV_VALUE_LEN` bytes per env
+///   value, `MAX_HEADER_VALUE_LEN` bytes per header value, and `MAX_URL_LEN` bytes for the
+///   `url` field
 ///
 /// # Errors
 ///
@@ -241,6 +288,13 @@ pub const fn forbidden_env_prefix() -> &'static str {
 ///   unbounded wait would let a hung server block this non-interactive tool
 ///   forever (see the `validate_timeout` design note in this module)
 pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
+    // Bound `command`/`args`/`env` element counts/lengths unconditionally, before dispatching
+    // on transport: every field involved is `#[serde(default)]`, so a hand-edited or hostile
+    // `mcp.json`/JSON payload can populate them for an Http/Sse config even though the builder
+    // itself only ever does so for stdio (issue #198 S2) — see this function's own doc comment
+    // for the full rationale.
+    validate_size_bounds(config)?;
+
     match config.transport() {
         TransportType::Stdio => validate_stdio_config(config)?,
         TransportType::Http | TransportType::Sse => validate_network_config(config)?,
@@ -257,10 +311,130 @@ pub fn validate_server_config(config: &ServerConfig) -> Result<()> {
     Ok(())
 }
 
+/// Bounds `command`'s length, `args`' count/lengths, `env`'s count/lengths, and `headers`'
+/// count/lengths (denial-of-service protection, CWE-400), regardless of transport.
+///
+/// `ServerConfig`'s `command`/`args`/`env`/`headers` fields are all `#[serde(default)]` and
+/// carried unconditionally at the type level — only [`ServerConfigBuilder`](crate::ServerConfigBuilder)
+/// itself zeroes out the fields that don't match a config's transport, so a `ServerConfig`
+/// obtained by other means (a struct literal, or deserializing a hand-edited `mcp.json`) can
+/// still carry an unbounded `args`/`env` for `Http`/`Sse`, or an unbounded `headers` for
+/// `Stdio` (issue #198 S2, and the `headers` mirror of it caught in review as N1 — a hostile
+/// `mcp.json` with `"transport": "stdio"` and a giant `headers` map was otherwise still
+/// completely unbounded, since the header checks lived only in
+/// [`validate_network_config`], which never runs for `Stdio`). Called unconditionally from
+/// [`validate_server_config`], before the transport-specific dispatch, so none of these bounds
+/// can be bypassed by transport choice.
+///
+/// Deliberately does not check for shell metacharacters, forbidden environment variable names,
+/// or the HTTP header-name token charset — those remain [`validate_stdio_config`]'s/
+/// [`validate_network_config`]'s responsibility, since they are only meaningful for a config
+/// that is actually used to spawn a subprocess or send an HTTP request, respectively.
+fn validate_size_bounds(config: &ServerConfig) -> Result<()> {
+    if config.command.len() > MAX_ARG_LEN {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "command too long: {} bytes exceeds the {MAX_ARG_LEN} limit",
+                config.command.len()
+            ),
+        });
+    }
+
+    if let Some(url) = config.url()
+        && url.len() > MAX_URL_LEN
+    {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "url too long: {} bytes exceeds the {MAX_URL_LEN} limit",
+                url.len()
+            ),
+        });
+    }
+
+    if config.args.len() > MAX_ARG_COUNT {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "too many arguments: {} exceeds the {MAX_ARG_COUNT} limit",
+                config.args.len()
+            ),
+        });
+    }
+    for (idx, arg) in config.args.iter().enumerate() {
+        if arg.len() > MAX_ARG_LEN {
+            return Err(Error::SecurityViolation {
+                reason: format!(
+                    "argument {idx} too long: {} bytes exceeds the {MAX_ARG_LEN} limit",
+                    arg.len()
+                ),
+            });
+        }
+    }
+
+    if config.env.len() > MAX_ENV_COUNT {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "too many environment variables: {} exceeds the {MAX_ENV_COUNT} limit",
+                config.env.len()
+            ),
+        });
+    }
+    for (env_name, env_value) in &config.env {
+        if env_name.len() > MAX_ARG_LEN {
+            return Err(Error::SecurityViolation {
+                reason: format!(
+                    "environment variable name too long: {} bytes exceeds the {MAX_ARG_LEN} \
+                     limit",
+                    env_name.len()
+                ),
+            });
+        }
+        if env_value.len() > MAX_ENV_VALUE_LEN {
+            return Err(Error::SecurityViolation {
+                reason: format!(
+                    "environment variable '{env_name}' value too long: {} bytes exceeds the \
+                     {MAX_ENV_VALUE_LEN} limit",
+                    env_value.len()
+                ),
+            });
+        }
+    }
+
+    if config.headers().len() > MAX_HEADER_COUNT {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "too many headers: {} exceeds the {MAX_HEADER_COUNT} limit",
+                config.headers().len()
+            ),
+        });
+    }
+    for (name, value) in config.headers() {
+        if name.len() > MAX_ARG_LEN {
+            return Err(Error::SecurityViolation {
+                reason: format!(
+                    "header name too long: {} bytes exceeds the {MAX_ARG_LEN} limit",
+                    name.len()
+                ),
+            });
+        }
+        if value.len() > MAX_HEADER_VALUE_LEN {
+            return Err(Error::SecurityViolation {
+                reason: format!(
+                    "header value too long: {} bytes exceeds the {MAX_HEADER_VALUE_LEN} limit",
+                    value.len()
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 /// Validates the stdio-transport-specific fields of a `ServerConfig`.
 ///
-/// Checks the command (absolute path or binary name), arguments, and
-/// environment variables for command-injection risks.
+/// Checks the command (absolute path or binary name), arguments, and environment variables
+/// for command-injection risks. Element counts/lengths are already bounded unconditionally by
+/// [`validate_size_bounds`] before this runs; this function only adds the checks that are
+/// meaningful specifically because this config will be used to spawn a subprocess.
 fn validate_stdio_config(config: &ServerConfig) -> Result<()> {
     // Validate command
     validate_command_string(&config.command, "command")?;
@@ -291,6 +465,11 @@ fn validate_stdio_config(config: &ServerConfig) -> Result<()> {
 /// hand-edited `mcp.json` with `"transport": "http"` and no `url` key
 /// deserializes successfully, bypassing `ServerConfigBuilder::build`'s
 /// "url required" check. This function is the actual enforcement point.
+///
+/// `headers`'/`url`'s element counts/lengths are already bounded unconditionally by
+/// [`validate_size_bounds`] before this runs; this function only adds the checks that are
+/// meaningful specifically because this config will be used to send an HTTP request (header
+/// name charset, control characters, scheme, duplicate names).
 fn validate_network_config(config: &ServerConfig) -> Result<()> {
     let url = config.url().ok_or_else(|| Error::ValidationError {
         field: "url".to_string(),
@@ -448,7 +627,8 @@ fn validate_timeout(timeout: Duration, field: &str) -> Result<()> {
 /// Validates a command string for forbidden shell metacharacters.
 ///
 /// This is an internal helper that checks a string (command or argument)
-/// for dangerous shell metacharacters.
+/// for dangerous shell metacharacters. Length is already bounded unconditionally by
+/// [`validate_size_bounds`] before this runs.
 ///
 /// # Security
 ///
@@ -525,8 +705,9 @@ fn validate_absolute_path(command: &str) -> Result<()> {
 
 /// Validates an environment variable name.
 ///
-/// This is an internal helper that checks if an environment variable
-/// name is in the forbidden list.
+/// This is an internal helper that checks if an environment variable name is in the
+/// forbidden list. Length is already bounded unconditionally by [`validate_size_bounds`]
+/// before this runs.
 fn validate_env_name(name: &str) -> Result<()> {
     // Check for forbidden env names (exact match)
     if FORBIDDEN_ENV_NAMES.contains(&name) {
@@ -548,6 +729,7 @@ fn validate_env_name(name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::fs;
     use std::io::Write;
 
@@ -1270,6 +1452,394 @@ mod tests {
         } else {
             panic!("expected SecurityViolation for header value");
         }
+    }
+
+    // ── Resource-exhaustion bounds (issue #198) ──────────────────────────────
+
+    #[test]
+    fn test_validate_server_config_rejects_too_many_args() {
+        let args = (0..=MAX_ARG_COUNT).map(|i| format!("a{i}")).collect();
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .args(args)
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too many arguments"));
+        } else {
+            panic!("expected SecurityViolation for too many arguments");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_accepts_max_arg_count() {
+        let args = (0..MAX_ARG_COUNT).map(|i| format!("a{i}")).collect();
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .args(args)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_oversized_arg() {
+        let long_arg = "a".repeat(MAX_ARG_LEN + 1);
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .arg(long_arg)
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized argument");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_accepts_arg_at_max_len() {
+        let arg_at_cap = "a".repeat(MAX_ARG_LEN);
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .arg(arg_at_cap)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_oversized_command() {
+        let long_command = "a".repeat(MAX_ARG_LEN + 1);
+        let result = ServerConfig::builder().command(long_command).build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized command");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_too_many_env_vars() {
+        let env: HashMap<String, String> = (0..=MAX_ENV_COUNT)
+            .map(|i| (format!("VAR_{i}"), "value".to_string()))
+            .collect();
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .environment(env)
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too many environment variables"));
+        } else {
+            panic!("expected SecurityViolation for too many env vars");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_accepts_max_env_count() {
+        let env: HashMap<String, String> = (0..MAX_ENV_COUNT)
+            .map(|i| (format!("VAR_{i}"), "value".to_string()))
+            .collect();
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .environment(env)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_oversized_env_value() {
+        let long_value = "v".repeat(MAX_ENV_VALUE_LEN + 1);
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .env("MY_VAR".to_string(), long_value)
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized env value");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_accepts_env_value_at_max_len() {
+        let value_at_cap = "v".repeat(MAX_ENV_VALUE_LEN);
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .env("MY_VAR".to_string(), value_at_cap)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_oversized_env_name() {
+        let long_name = "V".repeat(MAX_ARG_LEN + 1);
+        let result = ServerConfig::builder()
+            .command("docker".to_string())
+            .env(long_name, "value".to_string())
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized env name");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_too_many_headers() {
+        let headers: HashMap<String, String> = (0..=MAX_HEADER_COUNT)
+            .map(|i| (format!("X-Header-{i}"), "value".to_string()))
+            .collect();
+        let result = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .headers(headers)
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too many headers"));
+        } else {
+            panic!("expected SecurityViolation for too many headers");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_accepts_max_header_count() {
+        let headers: HashMap<String, String> = (0..MAX_HEADER_COUNT)
+            .map(|i| (format!("X-Header-{i}"), "value".to_string()))
+            .collect();
+        let result = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .headers(headers)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_rejects_oversized_header_value() {
+        let long_value = "v".repeat(MAX_HEADER_VALUE_LEN + 1);
+        let result = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("Authorization".to_string(), long_value)
+            .build();
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized header value");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_accepts_header_value_at_max_len() {
+        let value_at_cap = "v".repeat(MAX_HEADER_VALUE_LEN);
+        let result = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("Authorization".to_string(), value_at_cap)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    // ── S2: Http/Sse configs must not bypass args/env/command/url bounds ────────
+    //
+    // `ServerConfigBuilder::try_build` always zeroes `args`/`env` for Http/Sse transport (and
+    // `headers` for Stdio), so these bounds can only be exercised on such a config via direct
+    // deserialization — mirroring `deserialize_http_config_missing_url` above — the same
+    // "hand-edited or hostile mcp.json" scenario that motivates `validate_network_config`'s own
+    // doc comment.
+
+    #[test]
+    fn test_validate_server_config_http_rejects_oversized_args_via_deserialization() {
+        let args: Vec<String> = (0..=MAX_ARG_COUNT).map(|i| format!("a{i}")).collect();
+        let json = serde_json::json!({
+            "transport": "http",
+            "url": "https://api.example.com/mcp",
+            "args": args,
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too many arguments"));
+        } else {
+            panic!("expected SecurityViolation for too many arguments on http transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_oversized_env_via_deserialization() {
+        let env: HashMap<String, String> = (0..=MAX_ENV_COUNT)
+            .map(|i| (format!("VAR_{i}"), "value".to_string()))
+            .collect();
+        let json = serde_json::json!({
+            "transport": "http",
+            "url": "https://api.example.com/mcp",
+            "env": env,
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too many environment variables"));
+        } else {
+            panic!("expected SecurityViolation for too many env vars on http transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_oversized_command_via_deserialization() {
+        let json = serde_json::json!({
+            "transport": "http",
+            "url": "https://api.example.com/mcp",
+            "command": "a".repeat(MAX_ARG_LEN + 1),
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("command too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized command on http transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_stdio_rejects_oversized_headers_via_deserialization() {
+        // N1 (review follow-up to S2): `headers` is normally only populated for Http/Sse, but
+        // the field exists unconditionally at the type level too, and a hand-edited/hostile
+        // `mcp.json` with `"transport": "stdio"` can still populate it.
+        let headers: HashMap<String, String> = (0..=MAX_HEADER_COUNT)
+            .map(|i| (format!("X-Header-{i}"), "value".to_string()))
+            .collect();
+        let json = serde_json::json!({
+            "transport": "stdio",
+            "command": "docker",
+            "headers": headers,
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("too many headers"));
+        } else {
+            panic!("expected SecurityViolation for too many headers on stdio transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_stdio_rejects_oversized_header_value_via_deserialization() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom".to_string(), "v".repeat(MAX_HEADER_VALUE_LEN + 1));
+        let json = serde_json::json!({
+            "transport": "stdio",
+            "command": "docker",
+            "headers": headers,
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("header value too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized header value on stdio transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_stdio_rejects_oversized_header_name_via_deserialization() {
+        let mut headers = HashMap::new();
+        headers.insert("a".repeat(MAX_ARG_LEN + 1), "value".to_string());
+        let json = serde_json::json!({
+            "transport": "stdio",
+            "command": "docker",
+            "headers": headers,
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("header name too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized header name on stdio transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_stdio_rejects_oversized_url_via_deserialization() {
+        // Symmetric to the headers bypass above: `url` exists unconditionally at the type
+        // level too, and `validate_stdio_config` never inspects it.
+        let json = serde_json::json!({
+            "transport": "stdio",
+            "command": "docker",
+            "url": format!("https://example.com/{}", "a".repeat(MAX_URL_LEN)),
+        });
+        let config: ServerConfig = serde_json::from_value(json).expect("valid ServerConfig JSON");
+
+        let result = validate_server_config(&config);
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("url too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized url on stdio transport");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_url_too_long() {
+        let long_url = format!("https://example.com/{}", "a".repeat(MAX_URL_LEN));
+        let result = ServerConfig::builder().http_transport(long_url).build();
+
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("url too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized url");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_accepts_url_at_max_len() {
+        let prefix = "https://example.com/";
+        let padding_len = MAX_URL_LEN - prefix.len();
+        let url_at_cap = format!("{prefix}{}", "a".repeat(padding_len));
+        assert_eq!(url_at_cap.len(), MAX_URL_LEN);
+
+        let result = ServerConfig::builder().http_transport(url_at_cap).build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_config_http_rejects_header_name_too_long() {
+        let long_name = format!("X-{}", "a".repeat(MAX_ARG_LEN));
+        let result = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header(long_name, "value".to_string())
+            .build();
+
+        assert!(result.is_err());
+        if let Err(Error::SecurityViolation { reason }) = result {
+            assert!(reason.contains("header name too long"));
+        } else {
+            panic!("expected SecurityViolation for oversized header name");
+        }
+    }
+
+    #[test]
+    fn test_validate_server_config_http_accepts_header_name_at_max_len() {
+        let name_at_cap = "a".repeat(MAX_ARG_LEN);
+        let result = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header(name_at_cap, "value".to_string())
+            .build();
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/mcp-core/src/error.rs
+++ b/crates/mcp-core/src/error.rs
@@ -109,6 +109,23 @@ pub enum Error {
         #[source]
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },
+
+    /// A server- or attacker-controlled quantity exceeded a configured upper bound.
+    ///
+    /// Raised when a value that ultimately originates from an untrusted MCP server response
+    /// (tool count, a tool's name/description length, its schema size, etc.) exceeds one of
+    /// the resource-exhaustion (CWE-400) protections in
+    /// [`mcp_execution_introspector`](https://docs.rs/mcp-execution-introspector) or
+    /// [`mcp_execution_codegen`](https://docs.rs/mcp-execution-codegen).
+    #[error("resource limit exceeded for {resource}: {actual} exceeds limit of {limit}")]
+    ResourceLimitExceeded {
+        /// Human-readable name of the bounded resource (e.g. "tool count", "tool name length").
+        resource: String,
+        /// The actual observed size/count that triggered the rejection.
+        actual: usize,
+        /// The configured maximum allowed for this resource.
+        limit: usize,
+    },
 }
 
 impl Error {
@@ -201,6 +218,25 @@ impl Error {
     pub const fn is_script_generation_error(&self) -> bool {
         matches!(self, Self::ScriptGenerationError { .. })
     }
+
+    /// Returns `true` if this is a resource-limit-exceeded error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::Error;
+    ///
+    /// let err = Error::ResourceLimitExceeded {
+    ///     resource: "tool count".to_string(),
+    ///     actual: 1500,
+    ///     limit: 1000,
+    /// };
+    /// assert!(err.is_resource_limit_exceeded());
+    /// ```
+    #[must_use]
+    pub const fn is_resource_limit_exceeded(&self) -> bool {
+        matches!(self, Self::ResourceLimitExceeded { .. })
+    }
 }
 
 /// Result type alias for MCP operations.
@@ -268,6 +304,21 @@ mod tests {
         let display = format!("{err}");
         assert!(display.contains("Security policy violation"));
         assert!(display.contains("Unauthorized"));
+    }
+
+    #[test]
+    fn test_resource_limit_exceeded_detection() {
+        let err = Error::ResourceLimitExceeded {
+            resource: "tool count".to_string(),
+            actual: 1500,
+            limit: 1000,
+        };
+        assert!(err.is_resource_limit_exceeded());
+        assert!(!err.is_security_error());
+        let display = format!("{err}");
+        assert!(display.contains("tool count"));
+        assert!(display.contains("1500"));
+        assert!(display.contains("1000"));
     }
 
     #[test]

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -52,7 +52,9 @@ pub use server_config::{ServerConfig, ServerConfigBuilder, TransportType};
 
 // Re-export command validation
 pub use command::{
-    forbidden_chars, forbidden_env_names, forbidden_env_prefix, validate_server_config,
+    MAX_ARG_COUNT, MAX_ARG_LEN, MAX_ENV_COUNT, MAX_ENV_VALUE_LEN, MAX_HEADER_COUNT,
+    MAX_HEADER_VALUE_LEN, MAX_URL_LEN, forbidden_chars, forbidden_env_names, forbidden_env_prefix,
+    validate_server_config,
 };
 
 // Re-export path helpers shared by confinement checks

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -98,6 +98,29 @@ use tempfile::TempDir;
 /// the rollback and permanently losing the target.
 const STALE_ARTIFACT_MIN_AGE: Duration = Duration::from_mins(5);
 
+/// Maximum number of files a single [`FileSystem::export_to_filesystem`] (or
+/// `export_to_filesystem_parallel`, behind the `parallel` feature) call will write
+/// (denial-of-service protection, CWE-400).
+///
+/// Equal to `mcp_execution_codegen::progressive::generator::MAX_GENERATED_FILES` (rather than
+/// chosen independently), since a `FileSystem` built via `FilesBuilder::from_generated_code`
+/// carries exactly the same files as the `GeneratedCode` it came from — no extra headroom is
+/// needed for that path, and equality means a `FileSystem` built from that crate's normal
+/// output can never be deterministically rejected here for simply being "as large as codegen
+/// already allows" (the same M1 consistency issue #198 identified between codegen and
+/// introspection, one layer down). This check remains meaningful defense-in-depth for a
+/// `FileSystem` built directly (e.g. via `FilesBuilder`) with an unbounded file count,
+/// bypassing that upstream cap.
+pub const MAX_EXPORT_FILES: usize =
+    mcp_execution_codegen::progressive::generator::MAX_GENERATED_FILES;
+
+/// Maximum total bytes across every file a single export call will write.
+///
+/// Equal to `mcp_execution_codegen::progressive::generator::MAX_GENERATED_BYTES` for the same
+/// consistency reason as [`MAX_EXPORT_FILES`].
+pub const MAX_EXPORT_BYTES: usize =
+    mcp_execution_codegen::progressive::generator::MAX_GENERATED_BYTES;
+
 /// An in-memory virtual filesystem for MCP tool definitions.
 ///
 /// `FileSystem` provides a read-only filesystem structure that stores generated
@@ -463,6 +486,8 @@ impl FileSystem {
         base_path: impl AsRef<Path>,
         options: &ExportOptions,
     ) -> Result<()> {
+        self.check_export_bounds()?;
+
         let target = base_path.as_ref();
 
         let parent = target.parent().ok_or_else(|| FilesError::InvalidPath {
@@ -558,6 +583,8 @@ impl FileSystem {
     pub fn export_to_filesystem_parallel(&self, base_path: impl AsRef<Path>) -> Result<()> {
         use rayon::prelude::*;
 
+        self.check_export_bounds()?;
+
         let base = base_path.as_ref();
         let canonical_base = base.canonicalize().map_err(|e| FilesError::InvalidPath {
             path: format!("Failed to canonicalize {}: {}", base.display(), e),
@@ -577,6 +604,36 @@ impl FileSystem {
                 let disk_path = Self::vfs_to_disk_path(vfs_path.as_str(), &canonical_base);
                 write_file_atomic(&disk_path, file.content(), options.atomic)
             })?;
+
+        Ok(())
+    }
+
+    /// Rejects an export whose file count or total byte size exceeds its configured bound
+    /// (denial-of-service protection, CWE-400), before any directory is created or file
+    /// written.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilesError::ResourceLimitExceeded`] if [`Self::file_count`] exceeds
+    /// [`MAX_EXPORT_FILES`], or the combined byte size of every file's content exceeds
+    /// [`MAX_EXPORT_BYTES`].
+    fn check_export_bounds(&self) -> Result<()> {
+        if self.file_count() > MAX_EXPORT_FILES {
+            return Err(FilesError::ResourceLimitExceeded {
+                resource: "export file count".to_string(),
+                actual: self.file_count(),
+                limit: MAX_EXPORT_FILES,
+            });
+        }
+
+        let total_bytes: usize = self.files().map(|(_, file)| file.size()).sum();
+        if total_bytes > MAX_EXPORT_BYTES {
+            return Err(FilesError::ResourceLimitExceeded {
+                resource: "export total size".to_string(),
+                actual: total_bytes,
+                limit: MAX_EXPORT_BYTES,
+            });
+        }
 
         Ok(())
     }
@@ -1525,5 +1582,75 @@ mod tests {
         let options = ExportOptions::new().with_atomic_writes(false);
 
         assert!(!options.atomic);
+    }
+
+    // ── Resource-exhaustion bounds (issue #198) ──────────────────────────────
+
+    #[test]
+    fn test_export_rejects_too_many_files() {
+        let temp = TempDir::new().unwrap();
+        let mut builder = FilesBuilder::new();
+        for i in 0..=MAX_EXPORT_FILES {
+            builder = builder.add_file(format!("/tool{i}.ts"), "export {}");
+        }
+        let vfs = builder.build().unwrap();
+
+        let result = vfs.export_to_filesystem(temp.path());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_export_accepts_max_file_count() {
+        let temp = TempDir::new().unwrap();
+        let mut builder = FilesBuilder::new();
+        for i in 0..MAX_EXPORT_FILES {
+            builder = builder.add_file(format!("/tool{i}.ts"), "export {}");
+        }
+        let vfs = builder.build().unwrap();
+
+        assert!(vfs.export_to_filesystem(temp.path()).is_ok());
+    }
+
+    #[test]
+    fn test_export_rejects_oversized_total_bytes() {
+        let temp = TempDir::new().unwrap();
+        let vfs = FilesBuilder::new()
+            .add_file("/big.ts", "a".repeat(MAX_EXPORT_BYTES + 1))
+            .build()
+            .unwrap();
+
+        let result = vfs.export_to_filesystem(temp.path());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_export_accepts_total_bytes_at_exact_max() {
+        let temp = TempDir::new().unwrap();
+        let vfs = FilesBuilder::new()
+            .add_file("/big.ts", "a".repeat(MAX_EXPORT_BYTES))
+            .build()
+            .unwrap();
+
+        assert!(vfs.export_to_filesystem(temp.path()).is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "parallel")]
+    fn test_export_parallel_rejects_too_many_files() {
+        let temp = TempDir::new().unwrap();
+        let mut builder = FilesBuilder::new();
+        for i in 0..=MAX_EXPORT_FILES {
+            builder = builder.add_file(format!("/tool{i}.ts"), "export {}");
+        }
+        let vfs = builder.build().unwrap();
+
+        let result = vfs.export_to_filesystem_parallel(temp.path());
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
     }
 }

--- a/crates/mcp-files/src/types.rs
+++ b/crates/mcp-files/src/types.rs
@@ -80,6 +80,18 @@ pub enum FilesError {
         /// The underlying I/O error
         source: std::io::Error,
     },
+
+    /// The virtual filesystem being exported exceeds a configured file-count or total-byte-size
+    /// limit (denial-of-service protection, CWE-400).
+    #[error("export exceeds resource limit for {resource}: {actual} exceeds limit of {limit}")]
+    ResourceLimitExceeded {
+        /// Human-readable name of the bounded resource (e.g. "export file count").
+        resource: String,
+        /// The actual observed size/count that triggered the rejection.
+        actual: usize,
+        /// The configured maximum allowed for this resource.
+        limit: usize,
+    },
 }
 
 impl FilesError {
@@ -160,6 +172,26 @@ impl FilesError {
     #[must_use]
     pub const fn is_io_error(&self) -> bool {
         matches!(self, Self::IoError { .. })
+    }
+
+    /// Returns `true` if this is a resource-limit-exceeded error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_files::FilesError;
+    ///
+    /// let error = FilesError::ResourceLimitExceeded {
+    ///     resource: "export file count".to_string(),
+    ///     actual: 3000,
+    ///     limit: 2000,
+    /// };
+    ///
+    /// assert!(error.is_resource_limit_exceeded());
+    /// ```
+    #[must_use]
+    pub const fn is_resource_limit_exceeded(&self) -> bool {
+        matches!(self, Self::ResourceLimitExceeded { .. })
     }
 }
 

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -1283,10 +1283,12 @@ mod tests {
 
         let result = build_server_info(
             &ServerId::new("test"),
-            "Test".to_string(),
-            "1.0.0".to_string(),
-            false,
-            false,
+            PeerMeta {
+                server_name: "Test".to_string(),
+                server_version: "1.0.0".to_string(),
+                has_resources: false,
+                has_prompts: false,
+            },
             tool_list,
         );
 
@@ -1302,10 +1304,12 @@ mod tests {
 
         let result = build_server_info(
             &ServerId::new("test"),
-            "Test".to_string(),
-            "1.0.0".to_string(),
-            false,
-            false,
+            PeerMeta {
+                server_name: "Test".to_string(),
+                server_version: "1.0.0".to_string(),
+                has_resources: false,
+                has_prompts: false,
+            },
             tool_list,
         );
 

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -56,6 +56,34 @@ use std::collections::HashMap;
 use std::process::Stdio;
 use tokio::process::Child;
 
+/// Maximum number of tools accepted from a single MCP server's `list_all_tools` response
+/// (denial-of-service protection, CWE-400).
+///
+/// An MCP server is untrusted input: without this cap, a malicious or misbehaving server
+/// could return an unbounded tool list, which downstream codegen turns into one `.ts` file
+/// per tool. 1000 is generous headroom over any real-world server's tool count while still
+/// bounding the worst case.
+pub const MAX_TOOL_COUNT: usize = 1000;
+
+/// Maximum byte length for a single tool's `name`, as reported by the server.
+pub const MAX_TOOL_NAME_LEN: usize = 256;
+
+/// Maximum byte length for a single tool's `description`, as reported by the server.
+pub const MAX_TOOL_DESCRIPTION_LEN: usize = 8 * 1024;
+
+/// Maximum serialized JSON byte size for a single tool's `input_schema`, as reported by the
+/// server.
+///
+/// Kept small deliberately (~10x any real MCP tool schema observed in practice) since this is
+/// the dominant term in every derived downstream budget (`mcp_execution_codegen`'s
+/// `MAX_GENERATED_BYTES`, `mcp_execution_files`'s `MAX_EXPORT_BYTES`, and
+/// `mcp_execution_server::state`'s `MAX_TOTAL_PENDING_BYTES`, per issue #198's M1 fix) — a
+/// single generous byte-size input here multiplies through every layer that derives its own
+/// budget from `MAX_TOOL_COUNT * MAX_SCHEMA_SIZE_BYTES`. Previously 256KB, which propagated
+/// out to a ~1GB pending-session budget and a ~541MB generate/export budget; shrinking this one
+/// source constant 4x shrinks all of those proportionally without any structural change.
+pub const MAX_SCHEMA_SIZE_BYTES: usize = 64 * 1024;
+
 /// Information about an MCP server.
 ///
 /// Contains metadata about the server including its name, version,
@@ -301,7 +329,7 @@ impl Introspector {
             }
         };
 
-        let info = build_server_info(&server_id, discovery.peer_meta, discovery.tools);
+        let info = build_server_info(&server_id, discovery.peer_meta, discovery.tools)?;
 
         self.servers.insert(server_id, info.clone());
 
@@ -551,6 +579,71 @@ async fn discover_via_stdio_process(
     discovery
 }
 
+/// Outcome of a single [`list_tools_bounded`] page fetch that isn't a plain success.
+enum ListToolsBoundedError {
+    /// The underlying rmcp request failed (connection, protocol, or server-side error).
+    Service(rmcp::ServiceError),
+    /// The accumulated tool count across pages fetched so far exceeded [`MAX_TOOL_COUNT`].
+    /// Carries the accumulated count purely for the error message.
+    TooMany(usize),
+}
+
+impl From<rmcp::ServiceError> for ListToolsBoundedError {
+    fn from(e: rmcp::ServiceError) -> Self {
+        Self::Service(e)
+    }
+}
+
+/// Fetches a server's tool list page by page via `list_tools`, bailing out as soon as the
+/// accumulated count exceeds [`MAX_TOOL_COUNT`] instead of buffering every page first the way
+/// `Peer::list_all_tools` does (issue #198 S4): a malicious or misbehaving server can return an
+/// arbitrarily large tool list across arbitrarily many pages, so checking the bound only after
+/// the whole (potentially huge) response has already been collected does not actually bound
+/// peak memory during discovery — only what gets kept afterward. This bails after the page
+/// that first pushes the running total over the limit, so at most one page's worth of tools
+/// beyond [`MAX_TOOL_COUNT`] is ever held at once.
+async fn list_tools_bounded(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+) -> std::result::Result<Vec<rmcp::model::Tool>, ListToolsBoundedError> {
+    let mut tools = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = client
+            .list_tools(Some(
+                rmcp::model::PaginatedRequestParams::default().with_cursor(cursor),
+            ))
+            .await?;
+        tools.extend(page.tools);
+
+        if tools.len() > MAX_TOOL_COUNT {
+            return Err(ListToolsBoundedError::TooMany(tools.len()));
+        }
+
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    Ok(tools)
+}
+
+/// Converts a [`ListToolsBoundedError`] (from a `tokio::time::timeout`-wrapped
+/// [`list_tools_bounded`] call) into this crate's [`Error`], given the `server_id` the
+/// discovery attempt was for.
+fn map_list_tools_bounded_error(server_id: &ServerId, error: ListToolsBoundedError) -> Error {
+    match error {
+        ListToolsBoundedError::Service(e) => Error::ConnectionFailed {
+            server: server_id.to_string(),
+            source: Box::new(e),
+        },
+        ListToolsBoundedError::TooMany(actual) => Error::ResourceLimitExceeded {
+            resource: format!("tool count from server '{server_id}'"),
+            actual,
+            limit: MAX_TOOL_COUNT,
+        },
+    }
+}
+
 /// Connects to an already-spawned MCP server over `transport` and lists its
 /// tools, with each step bounded by `config`'s configured timeouts.
 ///
@@ -579,17 +672,15 @@ async fn discover_via_stdio(
             source: Box::new(e),
         })?;
 
-    // List all tools from server, bounded by the discover timeout
-    let tool_list = tokio::time::timeout(config.discover_timeout(), client.list_all_tools())
+    // List tools page by page, bounded by the discover timeout overall and bailing out early
+    // if the accumulated count exceeds MAX_TOOL_COUNT (see `list_tools_bounded`'s docs).
+    let tool_list = tokio::time::timeout(config.discover_timeout(), list_tools_bounded(&client))
         .await
         .map_err(|_elapsed| Error::Timeout {
             operation: format!("list_all_tools for {server_id}"),
             duration_secs: config.discover_timeout().as_secs(),
         })?
-        .map_err(|e| Error::ConnectionFailed {
-            server: server_id.to_string(),
-            source: Box::new(e),
-        })?;
+        .map_err(|e| map_list_tools_bounded_error(server_id, e))?;
 
     // Extract name, version, and capabilities from the MCP handshake result.
     // Falls back to the command string / "unknown" if the server did not send peer info.
@@ -657,16 +748,13 @@ async fn discover_via_http(server_id: &ServerId, config: &ServerConfig) -> Resul
             source: Box::new(e),
         })?;
 
-    let tool_list = tokio::time::timeout(config.discover_timeout(), client.list_all_tools())
+    let tool_list = tokio::time::timeout(config.discover_timeout(), list_tools_bounded(&client))
         .await
         .map_err(|_elapsed| Error::Timeout {
             operation: format!("list_all_tools for {server_id}"),
             duration_secs: config.discover_timeout().as_secs(),
         })?
-        .map_err(|e| Error::ConnectionFailed {
-            server: server_id.to_string(),
-            source: Box::new(e),
-        })?;
+        .map_err(|e| map_list_tools_bounded_error(server_id, e))?;
 
     // Extract name, version, and capabilities from the MCP handshake result.
     // Dropping `client` here triggers `WorkerTransport`'s drop guard, which
@@ -684,29 +772,36 @@ async fn discover_via_http(server_id: &ServerId, config: &ServerConfig) -> Resul
 /// Assembles a [`ServerInfo`] from the raw tool list and handshake metadata
 /// returned by [`discover_server`](Introspector::discover_server)'s stdio or
 /// HTTP/SSE discovery path.
+///
+/// # Errors
+///
+/// Returns [`Error::ResourceLimitExceeded`] if `tool_list` exceeds [`MAX_TOOL_COUNT`], or if
+/// any individual tool's name, description, or input schema exceeds its own configured bound
+/// (see [`build_tool_info`]) — defense against a malicious or misbehaving MCP server
+/// returning an unbounded response (CWE-400).
 fn build_server_info(
     server_id: &ServerId,
     peer_meta: PeerMeta,
     tool_list: Vec<rmcp::model::Tool>,
-) -> ServerInfo {
+) -> Result<ServerInfo> {
     tracing::debug!(
         "Server {} responded with {} tools",
         server_id,
         tool_list.len()
     );
 
+    if tool_list.len() > MAX_TOOL_COUNT {
+        return Err(Error::ResourceLimitExceeded {
+            resource: format!("tool count from server '{server_id}'"),
+            actual: tool_list.len(),
+            limit: MAX_TOOL_COUNT,
+        });
+    }
+
     let tools = tool_list
         .into_iter()
-        .map(|tool| {
-            tracing::trace!("Found tool: {}", tool.name);
-            ToolInfo {
-                name: ToolName::new(tool.name),
-                description: tool.description.unwrap_or_default().to_string(),
-                input_schema: serde_json::Value::Object((*tool.input_schema).clone()),
-                output_schema: None, // rmcp doesn't provide output schema
-            }
-        })
-        .collect::<Vec<_>>();
+        .map(build_tool_info)
+        .collect::<Result<Vec<_>>>()?;
 
     let capabilities = ServerCapabilities {
         supports_tools: !tools.is_empty(),
@@ -714,13 +809,64 @@ fn build_server_info(
         supports_prompts: peer_meta.has_prompts,
     };
 
-    ServerInfo {
+    Ok(ServerInfo {
         id: server_id.clone(),
         name: peer_meta.server_name,
         version: peer_meta.server_version,
         tools,
         capabilities,
+    })
+}
+
+/// Converts a single raw [`rmcp::model::Tool`] into a [`ToolInfo`], bounding its `name`,
+/// `description`, and serialized `input_schema` size (denial-of-service protection, CWE-400)
+/// against a malicious or misbehaving MCP server.
+///
+/// # Errors
+///
+/// Returns [`Error::ResourceLimitExceeded`] if the tool's name exceeds [`MAX_TOOL_NAME_LEN`],
+/// its description exceeds [`MAX_TOOL_DESCRIPTION_LEN`], or its serialized input schema
+/// exceeds [`MAX_SCHEMA_SIZE_BYTES`].
+fn build_tool_info(tool: rmcp::model::Tool) -> Result<ToolInfo> {
+    let name = tool.name.to_string();
+    tracing::trace!("Found tool: {name}");
+
+    if name.len() > MAX_TOOL_NAME_LEN {
+        return Err(Error::ResourceLimitExceeded {
+            resource: "tool name length".to_string(),
+            actual: name.len(),
+            limit: MAX_TOOL_NAME_LEN,
+        });
     }
+
+    let description = tool.description.unwrap_or_default().to_string();
+    if description.len() > MAX_TOOL_DESCRIPTION_LEN {
+        return Err(Error::ResourceLimitExceeded {
+            resource: format!("description length for tool '{name}'"),
+            actual: description.len(),
+            limit: MAX_TOOL_DESCRIPTION_LEN,
+        });
+    }
+
+    let input_schema = serde_json::Value::Object((*tool.input_schema).clone());
+    // A `Value` built from a JSON schema can only fail to re-serialize in pathological cases
+    // (e.g. a non-finite float somewhere in the tree); treat that as exceeding the bound
+    // rather than let it panic or silently pass an unmeasured schema through.
+    let schema_size = serde_json::to_vec(&input_schema).map_or(usize::MAX, |bytes| bytes.len());
+    if schema_size > MAX_SCHEMA_SIZE_BYTES {
+        return Err(Error::ResourceLimitExceeded {
+            resource: format!("input_schema size for tool '{name}'"),
+            actual: schema_size,
+            limit: MAX_SCHEMA_SIZE_BYTES,
+        });
+    }
+
+    Ok(ToolInfo {
+        name: ToolName::new(name),
+        description,
+        input_schema,
+        output_schema: None, // rmcp doesn't provide output schema
+    })
 }
 
 /// Extracts server name, version, resource support, and prompt support from
@@ -1085,6 +1231,152 @@ mod tests {
 
         assert!(!meta.has_resources);
         assert!(!meta.has_prompts);
+    }
+
+    // ── Resource-exhaustion bounds (issue #198) ──────────────────────────────
+
+    /// Builds a raw tool whose serialized `input_schema` grows linearly with `padding_len`:
+    /// the `padding` property's string value always contributes exactly `padding_len` bytes,
+    /// so tests can hit `MAX_SCHEMA_SIZE_BYTES` at an exact boundary by first measuring the
+    /// fixed overhead at `padding_len == 0`.
+    fn make_raw_tool(name: &str, description: &str, padding_len: usize) -> rmcp::model::Tool {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "padding": "a".repeat(padding_len),
+            },
+        });
+        let serde_json::Value::Object(schema_obj) = schema else {
+            unreachable!()
+        };
+
+        serde_json::from_value(serde_json::json!({
+            "name": name,
+            "description": description,
+            "inputSchema": schema_obj,
+        }))
+        .expect("valid rmcp::model::Tool JSON")
+    }
+
+    /// Serialized byte size of the `input_schema` produced by [`make_raw_tool`] for a given
+    /// `padding_len`, used to compute exact-boundary test inputs.
+    fn schema_size_for_padding(padding_len: usize) -> usize {
+        let tool = make_raw_tool("tool", "d", padding_len);
+        serde_json::to_vec(&serde_json::Value::Object((*tool.input_schema).clone()))
+            .expect("schema serializes")
+            .len()
+    }
+
+    /// `build_server_info`'s own `tool_list.len() > MAX_TOOL_COUNT` check is no longer what
+    /// protects `discover_server` in practice — `list_tools_bounded` (see the integration test
+    /// `tests/tool_count_bound_test.rs`) now bails out mid-pagination before ever handing
+    /// `build_server_info` an over-limit `Vec`, so this branch is unreachable on the real
+    /// `discover_via_stdio`/`discover_via_http` paths. It remains real, reachable code via this
+    /// direct call, though (`build_server_info` is `pub(crate)`-callable independent of the
+    /// pagination helper), so this test still exercises a genuine defense-in-depth check —
+    /// just not the primary one (issue #198 N2).
+    #[test]
+    fn test_build_server_info_rejects_too_many_tools_via_direct_call() {
+        let tool_list: Vec<rmcp::model::Tool> = (0..=MAX_TOOL_COUNT)
+            .map(|i| make_raw_tool(&format!("tool{i}"), "d", 0))
+            .collect();
+
+        let result = build_server_info(
+            &ServerId::new("test"),
+            "Test".to_string(),
+            "1.0.0".to_string(),
+            false,
+            false,
+            tool_list,
+        );
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_build_server_info_accepts_max_tool_count() {
+        let tool_list: Vec<rmcp::model::Tool> = (0..MAX_TOOL_COUNT)
+            .map(|i| make_raw_tool(&format!("tool{i}"), "d", 0))
+            .collect();
+
+        let result = build_server_info(
+            &ServerId::new("test"),
+            "Test".to_string(),
+            "1.0.0".to_string(),
+            false,
+            false,
+            tool_list,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().tools.len(), MAX_TOOL_COUNT);
+    }
+
+    #[test]
+    fn test_build_tool_info_rejects_oversized_name() {
+        let long_name = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        let tool = make_raw_tool(&long_name, "d", 0);
+
+        let result = build_tool_info(tool);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_build_tool_info_accepts_name_at_max_len() {
+        let name_at_cap = "a".repeat(MAX_TOOL_NAME_LEN);
+        let tool = make_raw_tool(&name_at_cap, "d", 0);
+
+        let result = build_tool_info(tool);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().name.as_str().len(), MAX_TOOL_NAME_LEN);
+    }
+
+    #[test]
+    fn test_build_tool_info_rejects_oversized_description() {
+        let long_description = "a".repeat(MAX_TOOL_DESCRIPTION_LEN + 1);
+        let tool = make_raw_tool("tool", &long_description, 0);
+
+        let result = build_tool_info(tool);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_build_tool_info_accepts_description_at_max_len() {
+        let description_at_cap = "a".repeat(MAX_TOOL_DESCRIPTION_LEN);
+        let tool = make_raw_tool("tool", &description_at_cap, 0);
+
+        let result = build_tool_info(tool);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().description.len(), MAX_TOOL_DESCRIPTION_LEN);
+    }
+
+    #[test]
+    fn test_build_tool_info_rejects_schema_one_byte_over_max_size() {
+        let overhead = schema_size_for_padding(0);
+        let padding_len = MAX_SCHEMA_SIZE_BYTES - overhead + 1;
+        let tool = make_raw_tool("tool", "d", padding_len);
+
+        let result = build_tool_info(tool);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    #[test]
+    fn test_build_tool_info_accepts_schema_at_exact_max_size() {
+        let overhead = schema_size_for_padding(0);
+        let padding_len = MAX_SCHEMA_SIZE_BYTES - overhead;
+        assert_eq!(
+            schema_size_for_padding(padding_len),
+            MAX_SCHEMA_SIZE_BYTES,
+            "test setup should hit the cap exactly"
+        );
+        let tool = make_raw_tool("tool", "d", padding_len);
+
+        let result = build_tool_info(tool);
+        assert!(result.is_ok());
     }
 
     /// All four values are correct simultaneously when `peer_info` is fully populated

--- a/crates/mcp-introspector/tests/tool_count_bound_test.rs
+++ b/crates/mcp-introspector/tests/tool_count_bound_test.rs
@@ -1,0 +1,202 @@
+//! Integration tests proving `Introspector::discover_server`'s early-bailout pagination logic
+//! (`list_tools_bounded`, issue #198 S4) actually bails mid-pagination against a real `rmcp`
+//! transport, rather than only being covered indirectly through `build_server_info`'s
+//! post-collection check (issue #198 N2 — that check is now unreachable on the real discovery
+//! path, since `list_tools_bounded` bails before ever handing it an over-limit `Vec`).
+//!
+//! Reuses the in-process Streamable HTTP fixture pattern from `tests/http_transport_test.rs`,
+//! with a `ServerHandler` that serves `tools/list` page by page instead of all at once.
+//!
+//! Requires the `test-fixtures` feature (implied by `--all-features`, which is how CI and the
+//! project's preferred `cargo nextest` invocation run tests) so that
+//! `rmcp/transport-streamable-http-server` is enabled.
+
+#![cfg(feature = "test-fixtures")]
+
+use axum::Router;
+use mcp_execution_core::{ServerConfig, ServerId};
+use mcp_execution_introspector::{Introspector, MAX_TOOL_COUNT};
+use rmcp::model::{
+    Implementation, InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+    Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+};
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// Number of tools served per `list_tools` page by [`PaginatedFixtureHandler`]. Deliberately
+/// smaller than [`MAX_TOOL_COUNT`] so a single discovery run spans multiple pages.
+const PAGE_SIZE: usize = 300;
+
+/// A fixture MCP server whose `tools/list` handler serves tools [`PAGE_SIZE`] at a time,
+/// tracking how many pages were actually requested.
+#[derive(Clone)]
+struct PaginatedFixtureHandler {
+    /// Number of `list_tools` calls served so far; incremented on every call.
+    call_count: Arc<AtomicUsize>,
+    /// Total number of tools this fixture will ever serve before signaling completion via
+    /// `next_cursor: None`.
+    ///
+    /// `None` means the fixture never completes on its own — every page sets `next_cursor`
+    /// regardless of how many have already been served — so a test using it proves the client
+    /// bails out on its own initiative rather than merely reacting to the fixture running out
+    /// of data. `list_tools_bounded` is expected to stop pulling pages as soon as its running
+    /// total crosses `MAX_TOOL_COUNT`, which happens well before this fixture would ever
+    /// signal completion.
+    total_tools: Option<usize>,
+}
+
+impl ServerHandler for PaginatedFixtureHandler {
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("paginated-fixture-server", "1.0.0"))
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let page_index = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let start = page_index * PAGE_SIZE;
+
+        let (page_len, next_cursor) = self.total_tools.map_or_else(
+            || (PAGE_SIZE, Some("more".to_string())),
+            |total| {
+                let remaining = total.saturating_sub(start);
+                let page_len = remaining.min(PAGE_SIZE);
+                let next_cursor = if start + page_len >= total {
+                    None
+                } else {
+                    Some("more".to_string())
+                };
+                (page_len, next_cursor)
+            },
+        );
+
+        let tools = (0..page_len)
+            .map(|i| Tool::new(format!("tool{}", start + i), "d", serde_json::Map::new()))
+            .collect();
+
+        Ok(ListToolsResult {
+            meta: None,
+            next_cursor,
+            tools,
+        })
+    }
+}
+
+/// Spawns [`PaginatedFixtureHandler`] on a loopback TCP port.
+///
+/// Returns the base URL to connect to, a `CancellationToken` the caller must cancel to shut
+/// the server down, and a handle to the fixture's per-call counter.
+async fn spawn_fixture_server(
+    total_tools: Option<usize>,
+) -> (String, CancellationToken, Arc<AtomicUsize>) {
+    let ct = CancellationToken::new();
+    let server_config =
+        StreamableHttpServerConfig::default().with_cancellation_token(ct.child_token());
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let handler = PaginatedFixtureHandler {
+        call_count: call_count.clone(),
+        total_tools,
+    };
+    let service: StreamableHttpService<PaginatedFixtureHandler, LocalSessionManager> =
+        StreamableHttpService::new(
+            move || Ok(handler.clone()),
+            Arc::new(LocalSessionManager::default()),
+            server_config,
+        );
+
+    let router: Router = Router::new().nest_service("/mcp", service);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture listener");
+    let addr = listener
+        .local_addr()
+        .expect("fixture listener has a local addr");
+
+    let shutdown_ct = ct.clone();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled_owned().await })
+            .await;
+    });
+
+    (format!("http://{addr}/mcp"), ct, call_count)
+}
+
+/// The fixture never signals completion (`total_tools: None`) — every page always carries a
+/// `next_cursor` — so if `list_tools_bounded` did not bail out mid-pagination, this test would
+/// either hang until `discover_timeout` fires or (if some later stage caught it) would have
+/// fetched far more pages than the minimum needed to first cross `MAX_TOOL_COUNT`.
+#[tokio::test]
+async fn test_discover_server_bails_early_once_accumulated_tool_count_exceeds_max() {
+    let (url, ct, call_count) = spawn_fixture_server(None).await;
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .http_transport(url)
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    let result = introspector
+        .discover_server(ServerId::new("paginated-fixture-over"), &config)
+        .await;
+
+    ct.cancel();
+
+    let err = result.expect_err(
+        "discover_server must reject once accumulated tool count exceeds MAX_TOOL_COUNT",
+    );
+    assert!(err.is_resource_limit_exceeded());
+
+    // Smallest page count `k` such that `k * PAGE_SIZE > MAX_TOOL_COUNT` (integer division
+    // floors, so `+ 1` lands on the first page that pushes the running total over the cap).
+    let expected_pages = MAX_TOOL_COUNT / PAGE_SIZE + 1;
+    assert_eq!(
+        call_count.load(Ordering::SeqCst),
+        expected_pages,
+        "must bail on the page that first pushes the running total over MAX_TOOL_COUNT, not \
+         keep draining the (fixture-side, effectively infinite) stream"
+    );
+}
+
+/// Symmetric boundary case: exactly `MAX_TOOL_COUNT` tools spread across multiple pages must
+/// be accepted in full, with pagination running to its natural completion.
+#[tokio::test]
+async fn test_discover_server_accepts_exactly_max_tool_count_across_pages() {
+    let (url, ct, call_count) = spawn_fixture_server(Some(MAX_TOOL_COUNT)).await;
+
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .http_transport(url)
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    let result = introspector
+        .discover_server(ServerId::new("paginated-fixture-exact"), &config)
+        .await;
+
+    ct.cancel();
+
+    let info = result.expect(
+        "discover_server must accept exactly MAX_TOOL_COUNT tools spread across multiple pages",
+    );
+    assert_eq!(info.tools.len(), MAX_TOOL_COUNT);
+
+    let expected_pages = MAX_TOOL_COUNT.div_ceil(PAGE_SIZE);
+    assert_eq!(call_count.load(Ordering::SeqCst), expected_pages);
+}

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -36,7 +36,11 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 /// Maximum SKILL.md content size in bytes (100KB).
-const MAX_SKILL_CONTENT_SIZE: usize = 100 * 1024;
+///
+/// `pub(crate)` (rather than private) so `types.rs`'s schemars drift-guard test can assert the
+/// declared `SaveSkillParams::content` schema length against this real constant instead of a
+/// hardcoded literal (issue #198 S3).
+pub(crate) const MAX_SKILL_CONTENT_SIZE: usize = 100 * 1024;
 
 /// Maximum byte length for a [`CategorizedTool::name`] field.
 ///
@@ -57,21 +61,28 @@ const MAX_SKILL_CONTENT_SIZE: usize = 100 * 1024;
 /// bytes of headroom against the true 252-byte ceiling - kept well below it
 /// mainly so the check stays meaningful without depending on the exact
 /// shrink factor of that transform.
-const MAX_CATEGORIZED_TOOL_NAME_LEN: usize = 128;
+///
+/// `pub(crate)`: see [`MAX_SKILL_CONTENT_SIZE`]'s doc comment for why.
+pub(crate) const MAX_CATEGORIZED_TOOL_NAME_LEN: usize = 128;
 
 /// Maximum byte length for a [`CategorizedTool::category`] field.
-const MAX_CATEGORY_LEN: usize = 100;
+///
+/// `pub(crate)`: see [`MAX_SKILL_CONTENT_SIZE`]'s doc comment for why.
+pub(crate) const MAX_CATEGORY_LEN: usize = 100;
 
 /// Maximum byte length for a [`CategorizedTool::keywords`] field
 /// (a comma-separated list).
-const MAX_KEYWORDS_LEN: usize = 500;
+///
+/// `pub(crate)`: see [`MAX_SKILL_CONTENT_SIZE`]'s doc comment for why.
+pub(crate) const MAX_KEYWORDS_LEN: usize = 500;
 
 /// Maximum byte length for a [`CategorizedTool::short_description`] field.
 ///
 /// The field's doc comment targets 80 characters; this cap is 4x that (the
 /// maximum UTF-8 bytes per `char`) so legitimate multi-byte text is never
-/// rejected while the size is still bounded.
-const MAX_SHORT_DESCRIPTION_LEN: usize = 320;
+/// rejected while the size is still bounded. `pub(crate)`: see
+/// [`MAX_SKILL_CONTENT_SIZE`]'s doc comment for why.
+pub(crate) const MAX_SHORT_DESCRIPTION_LEN: usize = 320;
 
 /// MCP server for progressive loading generation.
 ///
@@ -434,7 +445,11 @@ impl GeneratorService {
             self.clock.as_ref(),
         );
 
-        let session_id = self.state.store(pending.clone()).await;
+        let session_id = self
+            .state
+            .store(pending.clone())
+            .await
+            .map_err(|e| capacity_error(e.to_string()))?;
 
         // Build result
         let result = IntrospectServerResult {
@@ -1149,6 +1164,19 @@ fn extract_parameter_names(schema: &serde_json::Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Builds an [`McpError`] using the JSON-RPC 2.0 "Server error" range (`-32000` to `-32099`,
+/// reserved by the spec for implementation-defined server errors) rather than
+/// [`McpError::internal_error`] (`-32603`, `INTERNAL_ERROR`).
+///
+/// Used for [`crate::state::StateError`] (a capacity/overload condition — the pending-session
+/// table or its aggregate memory budget is temporarily full), which is not an internal fault:
+/// distinguishing it from `INTERNAL_ERROR` gives a well-behaved client a signal that retrying
+/// later, once existing sessions complete or expire, may succeed — rather than looking
+/// identical to a persistent bug worth escalating or giving up on (issue #198 M3).
+fn capacity_error(message: String) -> McpError {
+    McpError::new(rmcp::model::ErrorCode(-32000), message, None)
+}
+
 /// Generates code with categorization metadata.
 ///
 /// Converts the categorization map to the format expected by the generator
@@ -1205,6 +1233,29 @@ mod tests {
         assert_eq!(params.len(), 2);
         assert!(params.contains(&"name".to_string()));
         assert!(params.contains(&"age".to_string()));
+    }
+
+    /// #198 S3 — `SaveSkillParams::content`'s declared schema length must track the real
+    /// `MAX_SKILL_CONTENT_SIZE` this crate enforces at runtime, not a literal copy of it.
+    /// `mcp-execution-skill` cannot assert this itself (the constant lives here, the other way
+    /// around the dependency), so this crate — which already depends on `mcp-execution-skill`
+    /// — is the drift-proof home for this specific assertion.
+    #[test]
+    fn test_save_skill_params_content_schema_matches_max_skill_content_size() {
+        let schema = schemars::schema_for!(mcp_execution_skill::SaveSkillParams);
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+
+        assert_eq!(props["content"]["maxLength"], MAX_SKILL_CONTENT_SIZE);
+    }
+
+    /// #198 M3 — capacity/overload conditions must be distinguishable from `INTERNAL_ERROR`.
+    #[test]
+    fn test_capacity_error_uses_server_error_range_not_internal_error() {
+        let err = capacity_error("at capacity".to_string());
+
+        assert_eq!(err.code, ErrorCode(-32000));
+        assert_ne!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert_eq!(err.message.as_ref(), "at capacity");
     }
 
     #[test]
@@ -2308,7 +2359,7 @@ mod tests {
             &SystemClock,
         );
 
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         // Try to save with tool2 (doesn't exist)
         let params = SaveCategorizedToolsParams {
@@ -2402,7 +2453,11 @@ mod tests {
     #[tokio::test]
     async fn test_save_categorized_tools_rejects_more_entries_than_introspected() {
         let service = GeneratorService::new();
-        let session_id = service.state.store(pending_with_tool_count(2)).await;
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(2))
+            .await
+            .unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2431,7 +2486,8 @@ mod tests {
         let session_id = service
             .state
             .store(pending_with_tool_count(MAX_TOOL_FILES + 10))
-            .await;
+            .await
+            .unwrap();
 
         let categorized_tools = (0..=MAX_TOOL_FILES)
             .map(|i| categorized_tool(&format!("tool{i}")))
@@ -2454,7 +2510,11 @@ mod tests {
     #[tokio::test]
     async fn test_save_categorized_tools_rejects_duplicate_name() {
         let service = GeneratorService::new();
-        let session_id = service.state.store(pending_with_tool_count(2)).await;
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(2))
+            .await
+            .unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2499,7 +2559,7 @@ mod tests {
             None,
             &SystemClock,
         );
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2516,7 +2576,11 @@ mod tests {
     #[tokio::test]
     async fn test_save_categorized_tools_rejects_oversized_category() {
         let service = GeneratorService::new();
-        let session_id = service.state.store(pending_with_tool_count(1)).await;
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(1))
+            .await
+            .unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2536,7 +2600,11 @@ mod tests {
     #[tokio::test]
     async fn test_save_categorized_tools_rejects_oversized_keywords() {
         let service = GeneratorService::new();
-        let session_id = service.state.store(pending_with_tool_count(1)).await;
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(1))
+            .await
+            .unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2556,7 +2624,11 @@ mod tests {
     #[tokio::test]
     async fn test_save_categorized_tools_rejects_oversized_short_description() {
         let service = GeneratorService::new();
-        let session_id = service.state.store(pending_with_tool_count(1)).await;
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(1))
+            .await
+            .unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2581,7 +2653,7 @@ mod tests {
         let service =
             GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
         let pending = pending_with_server_id_and_tool_count("test", 2);
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2635,7 +2707,7 @@ mod tests {
             None,
             &SystemClock,
         );
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2682,7 +2754,7 @@ mod tests {
         .unwrap();
 
         let pending = pending_with_server_id_and_tool_count("server-b", 1);
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2714,7 +2786,7 @@ mod tests {
 
         let mut pending = pending_with_server_id_and_tool_count("my-server", 1);
         pending.output_dir_override = Some(PathBuf::from("custom/nested"));
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2775,7 +2847,7 @@ mod tests {
             &past_clock,
         );
 
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         let params = SaveCategorizedToolsParams {
             session_id,
@@ -2828,7 +2900,7 @@ mod tests {
             clock.as_ref(),
         );
 
-        let session_id = service.state.store(pending).await;
+        let session_id = service.state.store(pending).await.unwrap();
 
         // Advance the service's own shared clock, not the real wall clock, past the TTL.
         clock.advance(

--- a/crates/mcp-server/src/state.rs
+++ b/crates/mcp-server/src/state.rs
@@ -8,8 +8,106 @@ use crate::clock::{Clock, SystemClock};
 use crate::types::PendingGeneration;
 use std::collections::HashMap;
 use std::sync::Arc;
+use thiserror::Error;
 use tokio::sync::RwLock;
 use uuid::Uuid;
+
+/// Maximum number of concurrent pending generation sessions (denial-of-service protection,
+/// CWE-400).
+///
+/// Sessions are only ever swept lazily (as a side effect of [`StateManager::store`]/
+/// [`StateManager::take`]), so without a hard ceiling a caller who repeatedly calls
+/// `introspect_server` without ever following up with `save_categorized_tools` could grow
+/// this table without bound. This is a structural backstop against unbounded `HashMap` growth
+/// (and the iteration cost of sweeping it) independent of session size; [`MAX_TOTAL_PENDING_BYTES`]
+/// below is what actually bounds memory, since a session's size can vary by orders of
+/// magnitude depending on the introspected server's tool count.
+pub const MAX_PENDING_SESSIONS: usize = 1000;
+
+/// Approximate upper bound on a single session's in-memory footprint: up to
+/// `mcp_execution_introspector::MAX_TOOL_COUNT` tools, each up to `MAX_TOOL_NAME_LEN` +
+/// `MAX_TOOL_DESCRIPTION_LEN` + `MAX_SCHEMA_SIZE_BYTES`. Used only to derive
+/// [`MAX_TOTAL_PENDING_BYTES`] below.
+const MAX_SINGLE_SESSION_BYTES: usize = mcp_execution_introspector::MAX_TOOL_COUNT
+    * (mcp_execution_introspector::MAX_TOOL_NAME_LEN
+        + mcp_execution_introspector::MAX_TOOL_DESCRIPTION_LEN
+        + mcp_execution_introspector::MAX_SCHEMA_SIZE_BYTES);
+
+/// Maximum combined approximate memory footprint of every pending session at once
+/// (denial-of-service protection, CWE-400).
+///
+/// [`MAX_PENDING_SESSIONS`] alone does not bound memory: per-item caps on tool count/size
+/// multiply into a per-session footprint that can itself be hundreds of megabytes (this
+/// module's `MAX_SINGLE_SESSION_BYTES`), so a count-only cap of 1000 sessions could still reach
+/// hundreds of gigabytes in the worst case (issue #198 S1). This budget is checked in
+/// addition to the count cap and is the one that actually matters for memory: set to four
+/// times `MAX_SINGLE_SESSION_BYTES`, generous enough for a few concurrent large introspections
+/// without silently capping realistic multi-server usage, while categorically ruling out the
+/// unbounded multiplication a pure count cap allows.
+pub const MAX_TOTAL_PENDING_BYTES: usize = MAX_SINGLE_SESSION_BYTES * 4;
+
+/// Errors from [`StateManager::store`].
+#[derive(Debug, Error)]
+pub enum StateError {
+    /// The pending-session table is already at its configured capacity.
+    #[error("too many pending generation sessions: at capacity limit of {limit}")]
+    AtCapacity {
+        /// The configured maximum (`MAX_PENDING_SESSIONS`).
+        limit: usize,
+    },
+
+    /// Storing this session would push the aggregate approximate memory footprint of all
+    /// pending sessions past [`MAX_TOTAL_PENDING_BYTES`].
+    #[error(
+        "pending generation sessions would exceed the aggregate memory budget of {limit} bytes"
+    )]
+    MemoryBudgetExceeded {
+        /// The configured maximum (`MAX_TOTAL_PENDING_BYTES`).
+        limit: usize,
+    },
+}
+
+/// Estimates a [`PendingGeneration`]'s in-memory footprint from its serialized
+/// [`ServerInfo`](mcp_execution_introspector::ServerInfo) size.
+///
+/// This is an approximation (it ignores `config`/`output_dir_override`, both small relative to
+/// `server_info`'s tool list), used only to enforce [`MAX_TOTAL_PENDING_BYTES`]. A serialization
+/// failure is treated as exceeding any bound, rather than silently under-counting a session
+/// that could not be measured.
+fn estimate_size_bytes(generation: &PendingGeneration) -> usize {
+    serde_json::to_vec(&generation.server_info).map_or(usize::MAX, |bytes| bytes.len())
+}
+
+/// The pending-session table itself, tracking a running approximate byte total alongside the
+/// entries so [`MAX_TOTAL_PENDING_BYTES`] can be checked in O(1) rather than re-measuring every
+/// session on each call.
+#[derive(Debug, Default)]
+struct PendingTable {
+    entries: HashMap<Uuid, PendingEntry>,
+    total_bytes: usize,
+}
+
+/// A single stored session alongside its precomputed size, so removing it can decrement
+/// [`PendingTable::total_bytes`] without re-measuring.
+#[derive(Debug)]
+struct PendingEntry {
+    generation: PendingGeneration,
+    size_bytes: usize,
+}
+
+impl PendingTable {
+    /// Removes every expired entry, keeping `total_bytes` consistent with what remains.
+    fn sweep_expired(&mut self, clock: &dyn Clock) {
+        let total_bytes = &mut self.total_bytes;
+        self.entries.retain(|_, entry| {
+            let keep = !entry.generation.is_expired(clock);
+            if !keep {
+                *total_bytes -= entry.size_bytes;
+            }
+            keep
+        });
+    }
+}
 
 /// State manager for pending generation sessions.
 ///
@@ -48,7 +146,7 @@ use uuid::Uuid;
 /// );
 ///
 /// // Store and get session ID
-/// let session_id = state.store(pending).await;
+/// let session_id = state.store(pending).await.unwrap();
 ///
 /// // Retrieve session data
 /// let retrieved = state.take(session_id).await;
@@ -57,7 +155,7 @@ use uuid::Uuid;
 /// ```
 #[derive(Debug)]
 pub struct StateManager {
-    pending: Arc<RwLock<HashMap<Uuid, PendingGeneration>>>,
+    pending: Arc<RwLock<PendingTable>>,
     clock: Arc<dyn Clock>,
 }
 
@@ -81,7 +179,7 @@ impl StateManager {
     #[must_use]
     pub(crate) fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
-            pending: Arc::new(RwLock::new(HashMap::new())),
+            pending: Arc::new(RwLock::new(PendingTable::default())),
             clock,
         }
     }
@@ -89,6 +187,13 @@ impl StateManager {
     /// Stores a pending generation and returns a session ID.
     ///
     /// This operation also performs lazy cleanup of expired sessions.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError::AtCapacity`] if the pending-session table is already at
+    /// [`MAX_PENDING_SESSIONS`] after expired sessions have been swept, or
+    /// [`StateError::MemoryBudgetExceeded`] if storing this session would push the aggregate
+    /// approximate memory footprint of all pending sessions past [`MAX_TOTAL_PENDING_BYTES`].
     ///
     /// # Examples
     ///
@@ -101,19 +206,40 @@ impl StateManager {
     ///
     /// # async fn example(pending: PendingGeneration) {
     /// let state = StateManager::new();
-    /// let session_id = state.store(pending).await;
+    /// let session_id = state.store(pending).await.unwrap();
     /// # }
     /// ```
-    pub async fn store(&self, generation: PendingGeneration) -> Uuid {
+    pub async fn store(&self, generation: PendingGeneration) -> Result<Uuid, StateError> {
         let session_id = Uuid::new_v4();
-        let mut pending = self.pending.write().await;
+        let size_bytes = estimate_size_bytes(&generation);
 
-        // Clean up expired sessions
-        let clock = self.clock.as_ref();
-        pending.retain(|_, g| !g.is_expired(clock));
+        {
+            let mut table = self.pending.write().await;
+            table.sweep_expired(self.clock.as_ref());
 
-        pending.insert(session_id, generation);
-        session_id
+            if table.entries.len() >= MAX_PENDING_SESSIONS {
+                return Err(StateError::AtCapacity {
+                    limit: MAX_PENDING_SESSIONS,
+                });
+            }
+
+            if table.total_bytes.saturating_add(size_bytes) > MAX_TOTAL_PENDING_BYTES {
+                return Err(StateError::MemoryBudgetExceeded {
+                    limit: MAX_TOTAL_PENDING_BYTES,
+                });
+            }
+
+            table.entries.insert(
+                session_id,
+                PendingEntry {
+                    generation,
+                    size_bytes,
+                },
+            );
+            table.total_bytes += size_bytes;
+        }
+
+        Ok(session_id)
     }
 
     /// Retrieves and removes a pending generation.
@@ -132,7 +258,7 @@ impl StateManager {
     ///
     /// # async fn example(pending: PendingGeneration) {
     /// let state = StateManager::new();
-    /// let session_id = state.store(pending).await;
+    /// let session_id = state.store(pending).await.unwrap();
     ///
     /// let retrieved = state.take(session_id).await;
     /// assert!(retrieved.is_some());
@@ -143,15 +269,13 @@ impl StateManager {
     /// # }
     /// ```
     pub async fn take(&self, session_id: Uuid) -> Option<PendingGeneration> {
-        let generation = {
-            let mut pending = self.pending.write().await;
+        let mut table = self.pending.write().await;
+        table.sweep_expired(self.clock.as_ref());
 
-            // Clean up expired sessions
-            let clock = self.clock.as_ref();
-            pending.retain(|_, g| !g.is_expired(clock));
-
-            pending.remove(&session_id)?
-        };
+        let entry = table.entries.remove(&session_id)?;
+        table.total_bytes -= entry.size_bytes;
+        drop(table);
+        let generation = entry.generation;
 
         // Verify not expired (lock already released)
         if generation.is_expired(self.clock.as_ref()) {
@@ -176,7 +300,7 @@ impl StateManager {
     ///
     /// # async fn example(pending: PendingGeneration) {
     /// let state = StateManager::new();
-    /// let session_id = state.store(pending).await;
+    /// let session_id = state.store(pending).await.unwrap();
     ///
     /// // Get without removing
     /// let peeked = state.get(session_id).await;
@@ -188,12 +312,13 @@ impl StateManager {
     /// # }
     /// ```
     pub async fn get(&self, session_id: Uuid) -> Option<PendingGeneration> {
-        let pending = self.pending.read().await;
+        let table = self.pending.read().await;
         let clock = self.clock.as_ref();
-        pending
+        table
+            .entries
             .get(&session_id)
-            .filter(|g| !g.is_expired(clock))
-            .cloned()
+            .filter(|entry| !entry.generation.is_expired(clock))
+            .map(|entry| entry.generation.clone())
     }
 
     /// Returns the current pending session count (excluding expired).
@@ -209,9 +334,13 @@ impl StateManager {
     /// # }
     /// ```
     pub async fn pending_count(&self) -> usize {
-        let pending = self.pending.read().await;
+        let table = self.pending.read().await;
         let clock = self.clock.as_ref();
-        pending.values().filter(|g| !g.is_expired(clock)).count()
+        table
+            .entries
+            .values()
+            .filter(|entry| !entry.generation.is_expired(clock))
+            .count()
     }
 
     /// Cleans up all expired sessions.
@@ -230,11 +359,10 @@ impl StateManager {
     /// # }
     /// ```
     pub async fn cleanup_expired(&self) -> usize {
-        let mut pending = self.pending.write().await;
-        let before = pending.len();
-        let clock = self.clock.as_ref();
-        pending.retain(|_, g| !g.is_expired(clock));
-        before - pending.len()
+        let mut table = self.pending.write().await;
+        let before = table.entries.len();
+        table.sweep_expired(self.clock.as_ref());
+        before - table.entries.len()
     }
 }
 
@@ -291,7 +419,7 @@ mod tests {
         let state = StateManager::new();
         let pending = create_test_pending();
 
-        let session_id = state.store(pending.clone()).await;
+        let session_id = state.store(pending.clone()).await.unwrap();
         let retrieved = state.take(session_id).await;
 
         assert!(retrieved.is_some());
@@ -304,7 +432,7 @@ mod tests {
         let state = StateManager::new();
         let pending = create_test_pending();
 
-        let session_id = state.store(pending).await;
+        let session_id = state.store(pending).await.unwrap();
 
         // First take succeeds
         let first = state.take(session_id).await;
@@ -320,7 +448,7 @@ mod tests {
         let state = StateManager::new();
         let pending = create_test_pending();
 
-        let session_id = state.store(pending).await;
+        let session_id = state.store(pending).await.unwrap();
 
         // Get multiple times
         let first = state.get(session_id).await;
@@ -339,7 +467,7 @@ mod tests {
         let state = StateManager::new();
         let pending = create_expired_pending();
 
-        let session_id = state.store(pending).await;
+        let session_id = state.store(pending).await.unwrap();
 
         // Should return None because expired
         let retrieved = state.take(session_id).await;
@@ -352,7 +480,7 @@ mod tests {
 
         assert_eq!(state.pending_count().await, 0);
 
-        let session_id = state.store(create_test_pending()).await;
+        let session_id = state.store(create_test_pending()).await.unwrap();
         assert_eq!(state.pending_count().await, 1);
 
         state.take(session_id).await;
@@ -364,10 +492,10 @@ mod tests {
         let state = StateManager::new();
 
         // Add valid session
-        state.store(create_test_pending()).await;
+        state.store(create_test_pending()).await.unwrap();
 
         // Add expired session
-        state.store(create_expired_pending()).await;
+        state.store(create_expired_pending()).await.unwrap();
 
         assert_eq!(state.pending_count().await, 1); // Only valid session counts
 
@@ -389,7 +517,7 @@ mod tests {
         let state = StateManager::with_clock(Arc::clone(&clock) as Arc<dyn Clock>);
 
         let pending = create_test_pending_with_clock(clock.as_ref());
-        let session_id = state.store(pending).await;
+        let session_id = state.store(pending).await.unwrap();
 
         // Fresh session is visible while the clock is still within the TTL window.
         assert!(state.get(session_id).await.is_some());
@@ -428,7 +556,7 @@ mod tests {
 
         // Wait for all operations to complete
         for handle in handles {
-            handle.await.unwrap();
+            handle.await.unwrap().unwrap();
         }
 
         assert_eq!(state.pending_count().await, 10);
@@ -440,14 +568,117 @@ mod tests {
 
         // Store expired session directly
         {
-            let mut pending = state.pending.write().await;
-            pending.insert(Uuid::new_v4(), create_expired_pending());
+            let generation = create_expired_pending();
+            let size_bytes = estimate_size_bytes(&generation);
+            let mut table = state.pending.write().await;
+            table.entries.insert(
+                Uuid::new_v4(),
+                PendingEntry {
+                    generation,
+                    size_bytes,
+                },
+            );
+            table.total_bytes += size_bytes;
         }
 
         // Store new session triggers cleanup
-        state.store(create_test_pending()).await;
+        state.store(create_test_pending()).await.unwrap();
 
         // Only the new session should remain
         assert_eq!(state.pending_count().await, 1);
+    }
+
+    // ── Resource-exhaustion bounds (issue #198) ──────────────────────────────
+
+    #[tokio::test]
+    async fn test_store_rejects_when_at_capacity() {
+        let state = StateManager::new();
+        for _ in 0..MAX_PENDING_SESSIONS {
+            state.store(create_test_pending()).await.unwrap();
+        }
+
+        let result = state.store(create_test_pending()).await;
+
+        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(StateError::AtCapacity { limit }) if limit == MAX_PENDING_SESSIONS)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_store_accepts_up_to_exact_capacity() {
+        let state = StateManager::new();
+        for _ in 0..MAX_PENDING_SESSIONS - 1 {
+            state.store(create_test_pending()).await.unwrap();
+        }
+
+        let result = state.store(create_test_pending()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(state.pending_count().await, MAX_PENDING_SESSIONS);
+    }
+
+    /// #198 S1 — the aggregate memory budget, not just the session count, must reject.
+    ///
+    /// Building enough real sessions to reach `MAX_TOTAL_PENDING_BYTES` (~1GB) would be a slow,
+    /// wasteful multi-hundred-MB allocation for every CI run, so this seeds `total_bytes`
+    /// directly to just below the cap instead — precisely exercising the same comparison
+    /// `store()` performs without materializing gigabytes of real session data.
+    #[tokio::test]
+    async fn test_store_rejects_when_would_exceed_memory_budget() {
+        let state = StateManager::new();
+        {
+            let mut table = state.pending.write().await;
+            table.total_bytes = MAX_TOTAL_PENDING_BYTES;
+        }
+
+        let result = state.store(create_test_pending()).await;
+
+        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(StateError::MemoryBudgetExceeded { limit }) if limit == MAX_TOTAL_PENDING_BYTES)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_store_accepts_at_exact_memory_budget() {
+        let state = StateManager::new();
+        let generation = create_test_pending();
+        let size_bytes = estimate_size_bytes(&generation);
+        {
+            let mut table = state.pending.write().await;
+            table.total_bytes = MAX_TOTAL_PENDING_BYTES - size_bytes;
+        }
+
+        let result = state.store(generation).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_take_decrements_total_bytes() {
+        let state = StateManager::new();
+        let generation = create_test_pending();
+        let size_bytes = estimate_size_bytes(&generation);
+        assert!(size_bytes > 0);
+
+        let session_id = state.store(generation).await.unwrap();
+        assert_eq!(state.pending.read().await.total_bytes, size_bytes);
+
+        state.take(session_id).await;
+        assert_eq!(state.pending.read().await.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn test_sweep_expired_decrements_total_bytes() {
+        let state = StateManager::new();
+        state.store(create_expired_pending()).await.unwrap();
+
+        // The expired session was counted at store time...
+        assert!(state.pending.read().await.total_bytes > 0);
+
+        // ...and swept back out once `cleanup_expired` runs.
+        state.cleanup_expired().await;
+        assert_eq!(state.pending.read().await.total_bytes, 0);
     }
 }

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -50,17 +50,37 @@ use uuid::Uuid;
 /// ```
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct IntrospectServerParams {
-    /// Unique identifier for the server (e.g., "github", "filesystem")
+    /// Unique identifier for the server (e.g., "github", "filesystem").
+    ///
+    /// Must be 1-64 lowercase letters, digits, or hyphens (see `validate_server_id`'s
+    /// `MAX_SERVER_ID_LENGTH`, mirrored here as a literal since schemars attributes cannot
+    /// reference a `const`).
+    #[schemars(length(max = 64), regex(pattern = r"^[a-z0-9-]+$"))]
     pub server_id: String,
 
-    /// Command to start the server (e.g., "npx", "docker")
+    /// Command to start the server (e.g., "npx", "docker").
+    ///
+    /// Capped at `mcp_execution_core::MAX_ARG_LEN` (4096 bytes) at runtime; mirrored here as a
+    /// literal since schemars attributes cannot reference a `const`.
+    #[schemars(length(max = 4096))]
     pub command: String,
 
-    /// Arguments to pass to the command
+    /// Arguments to pass to the command.
+    ///
+    /// Capped at `mcp_execution_core::MAX_ARG_COUNT` (256) entries at runtime (enforced when
+    /// this becomes part of the `ServerConfig` built from these params); mirrored here as a
+    /// literal since schemars attributes cannot reference a `const`.
     #[serde(default)]
+    #[schemars(length(max = 256))]
     pub args: Vec<String>,
 
-    /// Environment variables for the server process
+    /// Environment variables for the server process.
+    ///
+    /// Capped at `mcp_execution_core::MAX_ENV_COUNT` (256) entries and
+    /// `mcp_execution_core::MAX_ENV_VALUE_LEN` (32KB) per value at runtime. No schemars
+    /// attribute is set here: schemars' `length` validation only emits `minProperties`/
+    /// `maxProperties` for `object`-typed schemas via the `map`/`set` traits it does not yet
+    /// support for derived struct fields, so a map-size constraint would be a silent no-op.
     #[serde(default)]
     pub env: HashMap<String, String>,
 
@@ -151,7 +171,13 @@ pub struct SaveCategorizedToolsParams {
     /// Session ID from `introspect_server` call
     pub session_id: Uuid,
 
-    /// Tools with Claude's categorization
+    /// Tools with Claude's categorization.
+    ///
+    /// The session-specific cap enforced at runtime is `min(introspected tool count,
+    /// MAX_TOOL_FILES)`, tighter than the flat limit below in nearly all cases; `MAX_TOOL_FILES`
+    /// (`mcp_execution_skill`, 500) is still the absolute ceiling regardless of session, so it
+    /// is what's mirrored here as a literal (schemars attributes cannot reference a `const`).
+    #[schemars(length(max = 500))]
     pub categorized_tools: Vec<CategorizedTool>,
 }
 
@@ -163,16 +189,40 @@ pub struct SaveCategorizedToolsParams {
 /// - A concise description for file headers
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CategorizedTool {
-    /// Original tool name (must match introspected tool)
+    /// Original tool name (must match introspected tool).
+    ///
+    /// Capped at `MAX_CATEGORIZED_TOOL_NAME_LEN` (128 bytes) at runtime; mirrored here as a
+    /// literal since schemars attributes cannot reference a `const`. Note: JSON Schema's
+    /// `maxLength` counts Unicode code points, not bytes, so the two bounds only coincide
+    /// exactly for ASCII input — for legitimate multi-byte UTF-8 text, the runtime byte check
+    /// can reject a string the declared schema would still accept (never the reverse), since
+    /// bytes-per-char >= 1 (issue #198 M2).
+    #[schemars(length(max = 128))]
     pub name: String,
 
-    /// Category assigned by Claude (e.g., "issues", "repos", "users")
+    /// Category assigned by Claude (e.g., "issues", "repos", "users").
+    ///
+    /// Capped at `MAX_CATEGORY_LEN` (100 bytes) at runtime; mirrored here as a literal since
+    /// schemars attributes cannot reference a `const`. See [`CategorizedTool::name`]'s doc
+    /// comment for the bytes-vs-characters caveat.
+    #[schemars(length(max = 100))]
     pub category: String,
 
-    /// Comma-separated keywords for discovery
+    /// Comma-separated keywords for discovery.
+    ///
+    /// Capped at `MAX_KEYWORDS_LEN` (500 bytes) at runtime; mirrored here as a literal since
+    /// schemars attributes cannot reference a `const`. See [`CategorizedTool::name`]'s doc
+    /// comment for the bytes-vs-characters caveat.
+    #[schemars(length(max = 500))]
     pub keywords: String,
 
-    /// Concise description (max 80 chars) for header comment
+    /// Concise description (max 80 chars) for header comment.
+    ///
+    /// Capped at `MAX_SHORT_DESCRIPTION_LEN` (320 bytes — 4x the 80-char target, headroom for
+    /// multi-byte UTF-8) at runtime; mirrored here as a literal since schemars attributes
+    /// cannot reference a `const`. See [`CategorizedTool::name`]'s doc comment for the
+    /// bytes-vs-characters caveat.
+    #[schemars(length(max = 320))]
     pub short_description: String,
 }
 
@@ -457,6 +507,58 @@ mod tests {
             connect_timeout_secs: _,
             discover_timeout_secs: _,
         } = params;
+    }
+
+    // ── schemars bounds (issue #205) ──────────────────────────────────────
+
+    #[test]
+    fn test_categorized_tool_schema_declares_length_bounds() {
+        use crate::service::{
+            MAX_CATEGORIZED_TOOL_NAME_LEN, MAX_CATEGORY_LEN, MAX_KEYWORDS_LEN,
+            MAX_SHORT_DESCRIPTION_LEN,
+        };
+
+        let schema = schemars::schema_for!(CategorizedTool);
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+
+        // Asserted against the real runtime constants (not hardcoded literals), so bumping one
+        // without updating the matching `#[schemars(length(max = ..))]` literal fails this test
+        // instead of leaving the declared schema silently stale (issue #198 S3).
+        assert_eq!(props["name"]["maxLength"], MAX_CATEGORIZED_TOOL_NAME_LEN);
+        assert_eq!(props["category"]["maxLength"], MAX_CATEGORY_LEN);
+        assert_eq!(props["keywords"]["maxLength"], MAX_KEYWORDS_LEN);
+        assert_eq!(
+            props["short_description"]["maxLength"],
+            MAX_SHORT_DESCRIPTION_LEN
+        );
+    }
+
+    #[test]
+    fn test_save_categorized_tools_params_schema_declares_vec_length_bound() {
+        let schema = schemars::schema_for!(SaveCategorizedToolsParams);
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+
+        assert_eq!(
+            props["categorized_tools"]["maxItems"],
+            mcp_execution_skill::MAX_TOOL_FILES
+        );
+    }
+
+    #[test]
+    fn test_introspect_server_params_schema_declares_server_id_bounds() {
+        let schema = schemars::schema_for!(IntrospectServerParams);
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+
+        assert_eq!(
+            props["server_id"]["maxLength"],
+            mcp_execution_skill::MAX_SERVER_ID_LENGTH
+        );
+        assert_eq!(props["server_id"]["pattern"], "^[a-z0-9-]+$");
+        assert_eq!(props["args"]["maxItems"], mcp_execution_core::MAX_ARG_COUNT);
+        assert_eq!(
+            props["command"]["maxLength"],
+            mcp_execution_core::MAX_ARG_LEN
+        );
     }
 
     // Test helpers

--- a/crates/mcp-server/tests/integration_tests.rs
+++ b/crates/mcp-server/tests/integration_tests.rs
@@ -75,7 +75,7 @@ async fn test_state_manager_workflow() {
 
     // Store pending generation
     let pending = PendingGeneration::new(server_id, server_info, config, None, &SystemClock);
-    let session_id = state.store(pending.clone()).await;
+    let session_id = state.store(pending.clone()).await.unwrap();
 
     // Verify it's stored
     assert_eq!(state.pending_count().await, 1);
@@ -119,7 +119,7 @@ async fn test_multiple_concurrent_sessions() {
             .unwrap();
 
         let pending = PendingGeneration::new(server_id, server_info, config, None, &SystemClock);
-        let session_id = state.store(pending).await;
+        let session_id = state.store(pending).await.unwrap();
         sessions.push(session_id);
     }
 
@@ -151,7 +151,7 @@ async fn test_state_manager_handles_expiration() {
     let mut pending = PendingGeneration::new(server_id, server_info, config, None, &SystemClock);
     pending.expires_at = chrono::Utc::now() - Duration::hours(1);
 
-    let session_id = state.store(pending).await;
+    let session_id = state.store(pending).await.unwrap();
 
     // Should not be retrievable (expired)
     let retrieved = state.take(session_id).await;
@@ -170,12 +170,12 @@ async fn test_state_manager_lazy_cleanup() {
 
     // Create valid session
     let valid_pending = create_test_pending("valid-server");
-    state.store(valid_pending).await;
+    state.store(valid_pending).await.unwrap();
 
     // Create expired session
     let mut expired_pending = create_test_pending("expired-server");
     expired_pending.expires_at = chrono::Utc::now() - Duration::hours(1);
-    state.store(expired_pending).await;
+    state.store(expired_pending).await.unwrap();
 
     // Pending count should only include valid sessions
     assert_eq!(state.pending_count().await, 1);
@@ -190,7 +190,7 @@ async fn test_state_manager_get_without_consuming() {
     let state = StateManager::new();
 
     let pending = create_test_pending("test");
-    let session_id = state.store(pending).await;
+    let session_id = state.store(pending).await.unwrap();
 
     // Get without consuming
     let first = state.get(session_id).await;
@@ -283,7 +283,7 @@ async fn test_state_manager_concurrent_access() {
     // Wait for all operations to complete
     let mut session_ids = Vec::new();
     for handle in handles {
-        let session_id = handle.await.unwrap();
+        let session_id = handle.await.unwrap().unwrap();
         session_ids.push(session_id);
     }
 
@@ -304,7 +304,7 @@ async fn test_state_manager_concurrent_read_write() {
 
     // Store initial session
     let pending = create_test_pending("test");
-    let session_id = state.store(pending).await;
+    let session_id = state.store(pending).await.unwrap();
 
     let state_clone1 = Arc::clone(&state);
     let state_clone2 = Arc::clone(&state);

--- a/crates/mcp-skill/src/lib.rs
+++ b/crates/mcp-skill/src/lib.rs
@@ -37,6 +37,7 @@ pub use parser::{
 };
 pub use template::{TemplateError, render_generation_prompt, render_skill_md};
 pub use types::{
-    GenerateSkillParams, GenerateSkillResult, SaveSkillParams, SaveSkillResult, ServerIdError,
-    SkillCategory, SkillMetadata, SkillTool, ToolExample, validate_server_id,
+    GenerateSkillParams, GenerateSkillResult, MAX_SERVER_ID_LENGTH, SaveSkillParams,
+    SaveSkillResult, ServerIdError, SkillCategory, SkillMetadata, SkillTool, ToolExample,
+    validate_server_id,
 };

--- a/crates/mcp-skill/src/types.rs
+++ b/crates/mcp-skill/src/types.rs
@@ -12,7 +12,11 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 /// Maximum `server_id` length (denial-of-service protection).
-const MAX_SERVER_ID_LENGTH: usize = 64;
+///
+/// `pub` (rather than private) so downstream crates' schemars drift-guard tests — e.g.
+/// `mcp-execution-server`'s, for `IntrospectServerParams::server_id` — can assert the declared
+/// schema length against this real constant instead of a hardcoded literal (issue #198 S3).
+pub const MAX_SERVER_ID_LENGTH: usize = 64;
 
 // ============================================================================
 // generate_skill types
@@ -36,7 +40,10 @@ const MAX_SERVER_ID_LENGTH: usize = 64;
 pub struct GenerateSkillParams {
     /// Server identifier (e.g., "github").
     ///
-    /// Must contain only lowercase letters, digits, and hyphens.
+    /// Must be 1-64 lowercase letters, digits, or hyphens (see `validate_server_id`'s
+    /// `MAX_SERVER_ID_LENGTH`, mirrored here as a literal since schemars attributes cannot
+    /// reference a `const`).
+    #[schemars(length(max = 64), regex(pattern = r"^[a-z0-9-]+$"))]
     pub server_id: String,
 
     /// Base directory for generated servers.
@@ -165,9 +172,23 @@ pub struct ToolExample {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct SaveSkillParams {
     /// Server identifier.
+    ///
+    /// Must be 1-64 lowercase letters, digits, or hyphens (see `validate_server_id`'s
+    /// `MAX_SERVER_ID_LENGTH`, mirrored here as a literal since schemars attributes cannot
+    /// reference a `const`).
+    #[schemars(length(max = 64), regex(pattern = r"^[a-z0-9-]+$"))]
     pub server_id: String,
 
     /// SKILL.md content (markdown with YAML frontmatter).
+    ///
+    /// Capped at 100KB (`MAX_SKILL_CONTENT_SIZE` in `mcp_execution_server::service`) at
+    /// runtime; mirrored here as a literal since schemars attributes require literals and
+    /// this crate does not depend on `mcp-execution-server` (the dependency runs the other
+    /// way). Note: JSON Schema's `maxLength` counts Unicode code points, not bytes, so the two
+    /// bounds only coincide exactly for ASCII input — for legitimate multi-byte UTF-8 content,
+    /// the runtime byte check can reject content the declared schema would still accept
+    /// (never the reverse), since bytes-per-char >= 1 (issue #198 M2).
+    #[schemars(length(max = 102_400))]
     pub content: String,
 
     /// Custom output path.
@@ -308,6 +329,35 @@ pub fn validate_server_id(server_id: &str) -> Result<(), ServerIdError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── schemars bounds (issue #205) ──────────────────────────────────────
+
+    #[test]
+    fn test_generate_skill_params_schema_declares_server_id_bounds() {
+        let schema = schemars::schema_for!(GenerateSkillParams);
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+
+        // Asserted against the real runtime constant (not a hardcoded literal), so bumping
+        // `MAX_SERVER_ID_LENGTH` without updating the `#[schemars(length(max = ..))]` literal
+        // above fails this test instead of leaving the declared schema silently stale
+        // (issue #198 S3).
+        assert_eq!(props["server_id"]["maxLength"], MAX_SERVER_ID_LENGTH);
+        assert_eq!(props["server_id"]["pattern"], "^[a-z0-9-]+$");
+    }
+
+    #[test]
+    fn test_save_skill_params_schema_declares_bounds() {
+        let schema = schemars::schema_for!(SaveSkillParams);
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+
+        assert_eq!(props["server_id"]["maxLength"], MAX_SERVER_ID_LENGTH);
+        assert_eq!(props["server_id"]["pattern"], "^[a-z0-9-]+$");
+        // `content`'s bound (`MAX_SKILL_CONTENT_SIZE`) lives in `mcp-execution-server`, a
+        // reverse dependency this crate cannot reference — see
+        // `mcp-server::service::tests::test_save_skill_params_content_schema_matches_max_skill_content_size`
+        // for the drift-proof version of this specific assertion.
+        assert_eq!(props["content"]["maxLength"], 102_400);
+    }
 
     #[test]
     fn test_validate_server_id_valid() {


### PR DESCRIPTION
## Summary

Closes CWE-400 resource-exhaustion gaps (#198) where an untrusted or misbehaving MCP server, or a hand-edited `mcp.json`, could grow this process's memory/disk usage without bound, and reinforces the now-enforced bounds declaratively in the JSON Schema surfaced to MCP clients (#205).

- `validate_server_config` now caps `command`/`args`/`env`/`headers`/`url` element counts and per-string lengths, checked unconditionally regardless of declared transport (previously stdio-only for `command`/`args`/`env` and Http/Sse-only for `headers`/`url`, so either branch could bypass the other's checks).
- `Introspector::discover_server` bounds reported tool count and each tool's name/description/schema size, bailing out during pagination as soon as the cap is crossed instead of buffering the whole response first.
- `ProgressiveGenerator::generate` and `FileSystem::export_to_filesystem` reject a generated/exported file count or byte total past a cap derived from the introspector's own bounds (kept consistent so a `ServerInfo` that already cleared introspection is never rejected downstream purely for being as large as introspection already allows), checked incrementally per file rather than only at the end.
- `StateManager` caps concurrent pending-generation sessions by both count and combined approximate byte size, since a session's size can vary by orders of magnitude and a count-only cap could still reach hundreds of gigabytes in the worst case.
- `mcp-server`/`mcp-skill` types with a documented-but-previously-unenforced numeric bound now declare matching `schemars` `length`/`regex` attributes, cross-checked in tests against the real runtime constants so schema and enforcement can't silently drift apart.

## Breaking change

`StateManager::store` now returns `Result<Uuid, StateError>` instead of an infallible `Uuid`, since it can reject a new session once the pending-generation table is at capacity. All call sites updated.

## Review process

Implemented via the team-develop workflow: developer → adversarial critic (2 rounds — first found 4 significant gaps including an aggregate-memory gap and an http/sse bypass of the args/env caps, both since closed; second round found and closed one more residual bypass on headers plus added missing test coverage for the pagination bailout logic) → code review (1 minor finding, fixed) → approved.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (847/847 passing)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New unit/integration tests for every new bound (at-cap accepted, over-cap rejected), including a real in-process HTTP fixture proving the introspector's pagination bailout fires at the correct boundary rather than relying on the server terminating the stream.

Closes #198, #205