### PR TITLE
refactor(cli,server): extract pipeline-stage helpers, add npm-install hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the default `fmt` subscriber, log lines emitted inside an instrumented call now carry a
   `generate{server_id=... tool_count=...}:` span-context prefix that was not there before
   (#211).
+- **`mcp-execution-cli`**, **`mcp-execution-server`**: extracted the pipeline stages of
+  `generate::run`, `skill::run`, `runner::execute_command`, and
+  `GeneratorService::introspect_server` into named private helper functions (e.g.
+  `resolve_server_config` in `common.rs`, now shared by `generate`/`introspect` instead of
+  each duplicating the same `--from-config` branch), so each entry point reads as a short,
+  linear pipeline instead of one long function. No behavior change beyond the #257 addition
+  (see the Added entry for #257 below); existing log call sites, error classification, and
+  lock/eviction ordering are unchanged (#179).
 
 ### Fixed
 
@@ -744,6 +752,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `internal_error`, misreporting a hostile caller-supplied parameter as a server-side fault.
 
 ### Added
+
+- **`mcp-execution-cli`**: `generate` now prints a "Next step: run 'npm install' in the
+  output directory before type-checking the generated package" hint after a successful
+  export, in the text and pretty output formats and as a new `next_step` field in the JSON
+  result. Not emitted in `--dry-run`, since nothing has been written to disk yet (#257).
 
 - **`mcp-execution-introspector`**: new `test-fixtures`-gated dependency on
   `rmcp/transport-streamable-http-server` and dev-dependencies on `axum` and `tokio-util`,

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tracing::warn;
+use tracing::{debug, warn};
 use url::Url;
 
 /// Fallback slug used when a URL sanitizes down to nothing (e.g. no host).
@@ -868,6 +868,47 @@ pub fn build_server_config(
     }
 
     Ok((server_id, builder.build()?))
+}
+
+/// Resolves a server's [`ServerId`] and [`ServerConfig`], either from
+/// `~/.claude/mcp.json` (when `from_config` is set) or from CLI transport
+/// flags.
+///
+/// The single place `generate` and `introspect` share for this "config file
+/// vs. CLI flags" branch, since both commands accept the identical flag
+/// surface.
+///
+/// # Errors
+///
+/// Returns an error if `from_config` is set and the named server is missing
+/// from the config file or the file is malformed, or if the CLI transport
+/// flags fail [`TransportArgs::from_flags`] validation or the resulting
+/// [`ServerConfig`] fails security validation.
+// One argument per CLI flag; clap already destructures flags for us, and
+// grouping them into a struct would only benefit this function, not caller ergonomics.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_server_config(
+    from_config: Option<String>,
+    server: Option<String>,
+    args: Vec<String>,
+    env: Vec<String>,
+    cwd: Option<String>,
+    http: Option<String>,
+    sse: Option<String>,
+    headers: Vec<String>,
+    connect_timeout_secs: Option<u64>,
+    discover_timeout_secs: Option<u64>,
+) -> Result<(ServerId, ServerConfig)> {
+    if let Some(config_name) = from_config {
+        debug!(
+            "Loading server configuration from ~/.claude/mcp.json: {}",
+            config_name
+        );
+        load_server_from_config(&config_name)
+    } else {
+        let transport = TransportArgs::from_flags(server, args, env, cwd, http, sse, headers)?;
+        build_server_config(transport, connect_timeout_secs, discover_timeout_secs)
+    }
 }
 
 /// Derives a filesystem- and `validate_server_id`-safe [`ServerId`] slug from

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -6,15 +6,17 @@
 //! 2. Generates TypeScript files for progressive loading (one file per tool)
 //! 3. Saves files to `~/.claude/servers/{server-id}/` directory
 
-use super::common::{TransportArgs, build_server_config, load_server_from_config};
+use super::common::resolve_server_config;
 use anyhow::{Context, Result};
+use mcp_execution_codegen::GeneratedCode;
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
+use mcp_execution_core::{ServerConfig, ServerId};
 use mcp_execution_files::FilesBuilder;
-use mcp_execution_introspector::Introspector;
+use mcp_execution_introspector::{Introspector, ServerInfo};
 use serde::Serialize;
-use std::path::PathBuf;
-use tracing::{debug, info, warn};
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
 
 /// Result of progressive loading code generation.
 #[derive(Debug, Serialize)]
@@ -27,7 +29,13 @@ struct GenerationResult {
     tool_count: usize,
     /// Path where files were saved
     output_path: String,
+    /// Hint describing the required post-export step (issue #257).
+    next_step: String,
 }
+
+/// Post-export step required before the generated package type-checks.
+const NPM_INSTALL_HINT: &str =
+    "run 'npm install' in the output directory before type-checking the generated package";
 
 /// Preview of a file that would be generated in dry-run mode.
 #[derive(Debug, Serialize)]
@@ -127,22 +135,57 @@ pub async fn run(
     discover_timeout_secs: Option<u64>,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
-    let (server_id, server_config) = if let Some(config_name) = from_config {
-        debug!(
-            "Loading server configuration from ~/.claude/mcp.json: {}",
-            config_name
-        );
-        load_server_from_config(&config_name)?
-    } else {
-        let transport = TransportArgs::from_flags(server, args, env, cwd, http, sse, headers)?;
-        build_server_config(transport, connect_timeout_secs, discover_timeout_secs)?
-    };
+    let (server_id, server_config) = resolve_server_config(
+        from_config,
+        server,
+        args,
+        env,
+        cwd,
+        http,
+        sse,
+        headers,
+        connect_timeout_secs,
+        discover_timeout_secs,
+    )?;
 
+    let server_info = discover_server_info(server_id, &server_config, name.as_deref()).await?;
+
+    if server_info.tools.is_empty() {
+        warn!("Server has no tools to generate code for");
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let server_dir_name = server_info.id.to_string();
+    let generated_code = generate_code(&server_info)?;
+
+    let base_dir = resolve_base_dir(output_dir)?;
+    let output_path = base_dir.join(&server_dir_name);
+
+    if dry_run {
+        return render_dry_run(&server_info, &generated_code, &output_path, output_format);
+    }
+
+    export_generated_code(generated_code, &base_dir, &output_path)?;
+
+    render_success(&server_info, &output_path, output_format)
+}
+
+/// Connects to the target server, discovers its tools, and applies the
+/// `--name` override to [`ServerInfo::id`] if one was given.
+///
+/// # Errors
+///
+/// Returns an error if the connection or tool discovery fails.
+async fn discover_server_info(
+    server_id: ServerId,
+    server_config: &ServerConfig,
+    name: Option<&str>,
+) -> Result<ServerInfo> {
     info!("Connecting to MCP server: {}", server_id);
 
     let mut introspector = Introspector::new();
-    let server_info = introspector
-        .discover_server(server_id, &server_config)
+    let mut server_info = introspector
+        .discover_server(server_id, server_config)
         .await
         .context("failed to introspect MCP server")?;
 
@@ -152,23 +195,24 @@ pub async fn run(
         server_info.name
     );
 
-    if server_info.tools.is_empty() {
-        warn!("Server has no tools to generate code for");
-        return Ok(ExitCode::SUCCESS);
-    }
-
     // Override server_info.id with custom name if provided
     // This ensures generated code uses the correct server_id that matches mcp.json
-    let mut server_info = server_info;
-    if let Some(ref custom_name) = name {
-        server_info.id = mcp_execution_core::ServerId::new(custom_name);
+    if let Some(custom_name) = name {
+        server_info.id = ServerId::new(custom_name);
     }
 
-    let server_dir_name = server_info.id.to_string();
+    Ok(server_info)
+}
 
+/// Generates progressive-loading TypeScript code for `server_info`.
+///
+/// # Errors
+///
+/// Returns an error if the code generator fails to initialize or generate code.
+fn generate_code(server_info: &ServerInfo) -> Result<GeneratedCode> {
     let generator = ProgressiveGenerator::new().context("failed to create code generator")?;
     let generated_code = generator
-        .generate(&server_info)
+        .generate(server_info)
         .context("failed to generate TypeScript code")?;
 
     info!(
@@ -176,71 +220,99 @@ pub async fn run(
         generated_code.file_count()
     );
 
-    let base_dir = if let Some(custom_dir) = output_dir {
-        custom_dir
+    Ok(generated_code)
+}
+
+/// Resolves the base directory generated servers are exported under, defaulting to
+/// `~/.claude/servers` when `output_dir` is not set.
+///
+/// # Errors
+///
+/// Returns an error if `output_dir` is `None` and the home directory cannot be determined.
+fn resolve_base_dir(output_dir: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(custom_dir) = output_dir {
+        Ok(custom_dir)
     } else {
-        dirs::home_dir()
+        Ok(dirs::home_dir()
             .context("failed to get home directory")?
             .join(".claude")
-            .join("servers")
+            .join("servers"))
+    }
+}
+
+/// Renders a dry-run preview of the files that would be generated, without writing anything.
+fn render_dry_run(
+    server_info: &ServerInfo,
+    generated_code: &GeneratedCode,
+    output_path: &Path,
+    output_format: OutputFormat,
+) -> Result<ExitCode> {
+    let server_dir_name = server_info.id.to_string();
+    let files: Vec<FilePreview> = generated_code
+        .files
+        .iter()
+        .map(|f| FilePreview {
+            path: format!("{}/{}", server_dir_name, f.path),
+            size: f.content.len(),
+        })
+        .collect();
+    let total_size: usize = files.iter().map(|f| f.size).sum();
+    let total_files = files.len();
+
+    let result = DryRunResult {
+        server_id: server_info.id.to_string(),
+        server_name: server_info.name.clone(),
+        output_path: output_path.display().to_string(),
+        files,
+        total_files,
+        total_size,
     };
-    let output_path = base_dir.join(&server_dir_name);
 
-    if dry_run {
-        let files: Vec<FilePreview> = generated_code
-            .files
-            .iter()
-            .map(|f| FilePreview {
-                path: format!("{}/{}", server_dir_name, f.path),
-                size: f.content.len(),
-            })
-            .collect();
-        let total_size: usize = files.iter().map(|f| f.size).sum();
-        let total_files = files.len();
-
-        let result = DryRunResult {
-            server_id: server_info.id.to_string(),
-            server_name: server_info.name,
-            output_path: output_path.display().to_string(),
-            files,
-            total_files,
-            total_size,
-        };
-
-        match output_format {
-            OutputFormat::Json => {
-                println!("{}", serde_json::to_string_pretty(&result)?);
-            }
-            OutputFormat::Text => {
-                println!("Server: {} ({})", result.server_name, result.server_id);
-                println!(
-                    "Would generate {} files ({}) to {}/",
-                    result.total_files,
-                    format_size(result.total_size),
-                    result.output_path
-                );
-            }
-            OutputFormat::Pretty => {
-                println!(
-                    "Would generate {} files to {}/:",
-                    result.total_files, result.output_path
-                );
-                println!();
-                for f in &result.files {
-                    println!("  - {} ({})", f.path, format_size(f.size));
-                }
-                println!();
-                println!(
-                    "Total: {} files, ~{}",
-                    result.total_files,
-                    format_size(result.total_size)
-                );
-            }
+    match output_format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
         }
-
-        return Ok(ExitCode::SUCCESS);
+        OutputFormat::Text => {
+            println!("Server: {} ({})", result.server_name, result.server_id);
+            println!(
+                "Would generate {} files ({}) to {}/",
+                result.total_files,
+                format_size(result.total_size),
+                result.output_path
+            );
+        }
+        OutputFormat::Pretty => {
+            println!(
+                "Would generate {} files to {}/:",
+                result.total_files, result.output_path
+            );
+            println!();
+            for f in &result.files {
+                println!("  - {} ({})", f.path, format_size(f.size));
+            }
+            println!();
+            println!(
+                "Total: {} files, ~{}",
+                result.total_files,
+                format_size(result.total_size)
+            );
+        }
     }
 
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Builds the VFS from `generated_code` and exports it to `output_path` under `base_dir`.
+///
+/// # Errors
+///
+/// Returns an error if VFS construction fails, `base_dir` cannot be created, or the export to
+/// the filesystem fails.
+fn export_generated_code(
+    generated_code: GeneratedCode,
+    base_dir: &Path,
+    output_path: &Path,
+) -> Result<()> {
     // Build VFS with base_path="/" since generated files already have flat structure;
     // server_dir_name will be used when exporting to filesystem
     let vfs = FilesBuilder::from_generated_code(generated_code, "/")
@@ -253,15 +325,25 @@ pub async fn run(
     // `output_path` itself atomically (single rename on first generate,
     // stage-then-swap on regeneration), so pre-creating it here would just
     // force the slower regeneration path even on a brand-new server.
-    std::fs::create_dir_all(&base_dir).context("failed to create output directory")?;
-    vfs.export_to_filesystem(&output_path)
+    std::fs::create_dir_all(base_dir).context("failed to create output directory")?;
+    vfs.export_to_filesystem(output_path)
         .context("failed to export files to filesystem")?;
 
+    Ok(())
+}
+
+/// Renders the success output for a completed export, including the #257 npm-install hint.
+fn render_success(
+    server_info: &ServerInfo,
+    output_path: &Path,
+    output_format: OutputFormat,
+) -> Result<ExitCode> {
     let result = GenerationResult {
         server_id: server_info.id.to_string(),
         server_name: server_info.name.clone(),
         tool_count: server_info.tools.len(),
         output_path: output_path.display().to_string(),
+        next_step: NPM_INSTALL_HINT.to_string(),
     };
 
     match output_format {
@@ -272,12 +354,14 @@ pub async fn run(
             println!("Server: {} ({})", result.server_name, result.server_id);
             println!("Generated {} tool files", result.tool_count);
             println!("Output: {}", result.output_path);
+            println!("Next step: {NPM_INSTALL_HINT}");
         }
         OutputFormat::Pretty => {
             println!("✓ Successfully generated progressive loading files");
             println!("  Server: {} ({})", result.server_name, result.server_id);
             println!("  Tools: {}", result.tool_count);
             println!("  Location: {}", result.output_path);
+            println!("  Next step: {NPM_INSTALL_HINT}");
         }
     }
 
@@ -322,11 +406,13 @@ mod tests {
             server_name: "Test Server".to_string(),
             tool_count: 5,
             output_path: "/path/to/output".to_string(),
+            next_step: NPM_INSTALL_HINT.to_string(),
         };
 
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"server_id\":\"test\""));
         assert!(json.contains("\"tool_count\":5"));
+        assert!(json.contains(NPM_INSTALL_HINT));
     }
 
     #[test]

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -2,12 +2,12 @@
 //!
 //! Connects to an MCP server and displays its capabilities, tools, and metadata.
 
-use super::common::{TransportArgs, build_server_config, load_server_from_config};
+use super::common::resolve_server_config;
 use anyhow::{Context, Result};
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use mcp_execution_introspector::{Introspector, ServerInfo, ToolInfo};
 use serde::Serialize;
-use tracing::{debug, info};
+use tracing::info;
 
 /// Result of server introspection.
 ///
@@ -178,16 +178,18 @@ pub async fn run(
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
     // Build server config: either from mcp.json or from CLI arguments
-    let (server_id, config) = if let Some(config_name) = from_config {
-        debug!(
-            "Loading server configuration from ~/.claude/mcp.json: {}",
-            config_name
-        );
-        load_server_from_config(&config_name)?
-    } else {
-        let transport = TransportArgs::from_flags(server, args, env, cwd, http, sse, headers)?;
-        build_server_config(transport, connect_timeout_secs, discover_timeout_secs)?
-    };
+    let (server_id, config) = resolve_server_config(
+        from_config,
+        server,
+        args,
+        env,
+        cwd,
+        http,
+        sse,
+        headers,
+        connect_timeout_secs,
+        discover_timeout_secs,
+    )?;
 
     info!("Introspecting server: {}", server_id);
     info!("Transport: {:?}", config.transport());

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -11,7 +11,8 @@ use anyhow::{Context, Result, bail};
 use mcp_execution_core::Error as CoreError;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use mcp_execution_skill::{
-    build_skill_context, render_skill_md, scan_tools_directory, validate_server_id,
+    GenerateSkillResult, ParsedToolFile, ScanResult, build_skill_context, render_skill_md,
+    scan_tools_directory, validate_server_id,
 };
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -118,69 +119,12 @@ pub async fn run(
         .map_err(|e| CoreError::InvalidArgument(format!("Invalid server ID: {e}")))?;
     info!("Server ID validated: {}", server);
 
-    // Step 2: Resolve servers directory
-    let servers_base = resolve_servers_dir(servers_dir.as_deref())?;
-    debug!("Servers base directory: {}", servers_base.display());
+    let tool_dir = resolve_tool_dir(&server, servers_dir.as_deref())?;
 
-    // Step 3: Build and validate server path
-    let tool_dir = servers_base.join(&server);
-    let tool_dir = validate_path_security(&tool_dir, &servers_base)?;
-    debug!("Server directory: {}", tool_dir.display());
+    let scan_result = scan_server_tools(&tool_dir, &server).await?;
 
-    // Step 4: Check server directory exists
-    if !tool_dir.exists() {
-        bail!(
-            "Server directory not found: {}\n\
-             Run 'mcp-execution-cli generate --from-config {}' first to generate TypeScript files.",
-            tool_dir.display(),
-            server
-        );
-    }
-
-    // Step 5: Scan TypeScript files
-    info!("Scanning TypeScript files in {}", tool_dir.display());
-    let scan_result = scan_tools_directory(&tool_dir)
-        .await
-        .context("Failed to scan tools directory")?;
-
-    if scan_result.tools.is_empty() {
-        bail!(
-            "No TypeScript tool files found in {}\n\
-             Run 'mcp-execution-cli generate --from-config {}' first.",
-            tool_dir.display(),
-            server
-        );
-    }
-
-    // `tools.len()` reflects sidecar entries that were cross-checked against an
-    // actual `.ts` file on disk by `scan_tools_directory` (issue #154) — not a
-    // raw sidecar entry count.
-    info!(
-        "Verified {} tool files against sidecar",
-        scan_result.tools.len()
-    );
-
-    // Step 6: Build skill context
-    let hints_ref: Option<Vec<String>> = if hints.is_empty() { None } else { Some(hints) };
-
-    let mut context = build_skill_context(&server, &scan_result.tools, hints_ref.as_deref());
-
-    // Apply custom skill name if provided
-    if let Some(name) = skill_name {
-        context.skill_name = name;
-    }
-
-    // Apply custom output path if provided
-    if let Some(path) = output_path {
-        // Validate output path for path traversal
-        validate_output_path(&path)?;
-        context.output_path = path.display().to_string();
-    } else {
-        // Use default skills directory
-        let skills_dir = resolve_skills_dir()?;
-        let default_output = skills_dir.join(&server).join("SKILL.md");
-        context.output_path = default_output.display().to_string();
-    }
+    let context =
+        prepare_skill_context(&server, &scan_result.tools, hints, skill_name, output_path)?;
 
     // Check if output file exists and overwrite flag
     let output_path = PathBuf::from(&context.output_path);
@@ -195,18 +139,7 @@ pub async fn run(
     // Step 7: Render SKILL.md and write atomically.
     let rendered = render_skill_md(&context).context("failed to render SKILL.md template")?;
 
-    if let Some(parent) = output_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create directory: {}", parent.display()))?;
-    }
-
-    // Atomic write: write to a temp file in the same directory, then rename.
-    // `with_added_extension` appends `.tmp` without removing `.md` (N1).
-    let tmp_path = output_path.with_added_extension("tmp");
-    std::fs::write(&tmp_path, &rendered)
-        .with_context(|| format!("failed to write temp file: {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, &output_path)
-        .with_context(|| format!("failed to rename to: {}", output_path.display()))?;
+    write_skill_md(&rendered, &output_path)?;
 
     let bytes_written = rendered.len();
     info!(
@@ -228,6 +161,128 @@ pub async fn run(
     println!("{output}");
 
     Ok(ExitCode::SUCCESS)
+}
+
+/// Resolves and validates the server's tool directory under `servers_dir` (or its default).
+///
+/// # Errors
+///
+/// Returns an error if the home directory cannot be determined, the resolved path escapes
+/// its base via a symlink, or the server directory does not exist.
+fn resolve_tool_dir(server: &str, servers_dir: Option<&Path>) -> Result<PathBuf> {
+    // Step 2: Resolve servers directory
+    let servers_base = resolve_servers_dir(servers_dir)?;
+    debug!("Servers base directory: {}", servers_base.display());
+
+    // Step 3: Build and validate server path
+    let tool_dir = servers_base.join(server);
+    let tool_dir = validate_path_security(&tool_dir, &servers_base)?;
+    debug!("Server directory: {}", tool_dir.display());
+
+    // Step 4: Check server directory exists
+    if !tool_dir.exists() {
+        bail!(
+            "Server directory not found: {}\n\
+             Run 'mcp-execution-cli generate --from-config {}' first to generate TypeScript files.",
+            tool_dir.display(),
+            server
+        );
+    }
+
+    Ok(tool_dir)
+}
+
+/// Scans `tool_dir` for generated TypeScript tool files.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be scanned or no tool files are found.
+async fn scan_server_tools(tool_dir: &Path, server: &str) -> Result<ScanResult> {
+    // Step 5: Scan TypeScript files
+    info!("Scanning TypeScript files in {}", tool_dir.display());
+    let scan_result = scan_tools_directory(tool_dir)
+        .await
+        .context("Failed to scan tools directory")?;
+
+    if scan_result.tools.is_empty() {
+        bail!(
+            "No TypeScript tool files found in {}\n\
+             Run 'mcp-execution-cli generate --from-config {}' first.",
+            tool_dir.display(),
+            server
+        );
+    }
+
+    // `tools.len()` reflects sidecar entries that were cross-checked against an
+    // actual `.ts` file on disk by `scan_tools_directory` (issue #154) — not a
+    // raw sidecar entry count.
+    info!(
+        "Verified {} tool files against sidecar",
+        scan_result.tools.len()
+    );
+
+    Ok(scan_result)
+}
+
+/// Builds the skill generation context, applying custom skill name and output path overrides.
+///
+/// # Errors
+///
+/// Returns an error if a custom `output_path` fails traversal validation, or if the default
+/// skills directory cannot be resolved (home directory not determinable).
+fn prepare_skill_context(
+    server: &str,
+    tools: &[ParsedToolFile],
+    hints: Vec<String>,
+    skill_name: Option<String>,
+    output_path: Option<PathBuf>,
+) -> Result<GenerateSkillResult> {
+    // Step 6: Build skill context
+    let hints_ref: Option<Vec<String>> = if hints.is_empty() { None } else { Some(hints) };
+
+    let mut context = build_skill_context(server, tools, hints_ref.as_deref());
+
+    // Apply custom skill name if provided
+    if let Some(name) = skill_name {
+        context.skill_name = name;
+    }
+
+    // Apply custom output path if provided
+    if let Some(path) = output_path {
+        // Validate output path for path traversal
+        validate_output_path(&path)?;
+        context.output_path = path.display().to_string();
+    } else {
+        // Use default skills directory
+        let skills_dir = resolve_skills_dir()?;
+        let default_output = skills_dir.join(server).join("SKILL.md");
+        context.output_path = default_output.display().to_string();
+    }
+
+    Ok(context)
+}
+
+/// Writes `rendered` SKILL.md content to `output_path` atomically (write-temp then rename).
+///
+/// # Errors
+///
+/// Returns an error if the parent directory cannot be created, the temp file cannot be
+/// written, or the rename fails.
+fn write_skill_md(rendered: &str, output_path: &Path) -> Result<()> {
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory: {}", parent.display()))?;
+    }
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    // `with_added_extension` appends `.tmp` without removing `.md` (N1).
+    let tmp_path = output_path.with_added_extension("tmp");
+    std::fs::write(&tmp_path, rendered)
+        .with_context(|| format!("failed to write temp file: {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, output_path)
+        .with_context(|| format!("failed to rename to: {}", output_path.display()))?;
+
+    Ok(())
 }
 
 /// Resolve servers directory from provided path or default.

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -88,7 +88,19 @@ pub fn init_logging(verbose: bool) -> Result<()> {
 /// # }
 /// ```
 pub async fn execute_command(command: Commands, output_format: OutputFormat) -> Result<ExitCode> {
-    let result = match command {
+    Ok(match dispatch(command, output_format).await {
+        Ok(code) => code,
+        Err(err) => report_and_classify(&err),
+    })
+}
+
+/// Routes `command` to its handler and returns the handler's result unclassified.
+///
+/// # Errors
+///
+/// Returns whatever error the dispatched command handler produces.
+async fn dispatch(command: Commands, output_format: OutputFormat) -> Result<ExitCode> {
+    match command {
         Commands::Introspect {
             from_config,
             server,
@@ -172,18 +184,17 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
         }
         Commands::Server { action } => commands::server::run(action, output_format).await,
         Commands::Setup => commands::setup::run(output_format).await,
-        Commands::Completions { shell } => {
-            use crate::cli::Cli;
-            use clap::CommandFactory;
-            let mut cmd = Cli::command();
-            commands::completions::run(shell, &mut cmd).await
-        }
-    };
+        Commands::Completions { shell } => run_completions(shell).await,
+    }
+}
 
-    Ok(match result {
-        Ok(code) => code,
-        Err(err) => report_and_classify(&err),
-    })
+/// Runs the `completions` subcommand: builds the clap command tree and generates the shell
+/// completion script for it.
+async fn run_completions(shell: clap_complete::Shell) -> Result<ExitCode> {
+    use crate::cli::Cli;
+    use clap::CommandFactory;
+    let mut cmd = Cli::command();
+    commands::completions::run(shell, &mut cmd).await
 }
 
 /// Prints `err` to stderr (matching anyhow's default `main`-error format) and

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -16,7 +16,7 @@ use crate::types::{
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::{ServerConfig, ServerId, sanitize_path_for_error};
 use mcp_execution_files::FilesBuilder;
-use mcp_execution_introspector::Introspector;
+use mcp_execution_introspector::{Introspector, ToolInfo};
 use mcp_execution_skill::{
     GenerateSkillParams, MAX_TOOL_FILES, OutputPathError, SaveSkillParams, SaveSkillResult,
     ScanError, build_skill_context, extract_skill_metadata, resolve_skill_output_path,
@@ -299,6 +299,49 @@ impl GeneratorService {
             entry.remove();
         }
     }
+
+    /// Connects to and introspects `server_id`, observing cancellation.
+    ///
+    /// Deliberately not `#[tracing::instrument]`-annotated: `introspect_server`'s span already
+    /// records `server_id` for the whole call, and a second span field here would make
+    /// `test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id`'s "exactly 2
+    /// `server_id` values" assertion see 3 instead, breaking it.
+    async fn discover_with_cancellation(
+        &self,
+        server_id: &ServerId,
+        config: &ServerConfig,
+        ct: &CancellationToken,
+    ) -> Result<mcp_execution_introspector::ServerInfo, McpError> {
+        // Connect and introspect, holding only the lock for this server_id. A
+        // tokio::select! against `ct.cancelled()` lets a client-issued
+        // `notifications/cancelled` interrupt the (potentially up-to-600s)
+        // discovery round trip instead of always running it to completion.
+        // `biased;` prefers noticing cancellation over starting/continuing
+        // discovery, making the cancelled path deterministic rather than
+        // depending on `tokio::select!`'s (default-randomised) poll order.
+        let introspector_handle = self.introspector_for(server_id).await;
+        let mut introspector = introspector_handle.lock().await;
+        let discover_outcome = tokio::select! {
+            biased;
+            () = ct.cancelled() => None,
+            result = introspector.discover_server(server_id.clone(), config) => Some(result),
+        };
+        drop(introspector);
+
+        // Evict the per-server-id handle regardless of outcome (including
+        // cancellation), so caller-supplied server_id values can't grow the
+        // introspectors map without bound. Only removes the entry if it is
+        // still this exact handle (see `evict_introspector` docs for why
+        // identity matters here).
+        self.evict_introspector(server_id, &introspector_handle)
+            .await;
+
+        let discover_result = discover_outcome.ok_or_else(|| {
+            McpError::internal_error("introspect_server cancelled by client", None)
+        })?;
+
+        discover_result.map_err(|e| caller_or_internal_error(&e, "Failed to introspect server"))
+    }
 }
 
 impl Default for GeneratorService {
@@ -372,69 +415,16 @@ impl GeneratorService {
             params.connect_timeout_secs,
             params.discover_timeout_secs,
         )
-        .map_err(|e| {
-            // A `SecurityViolation` here (shell metacharacters, forbidden env var, etc.) is
-            // caused by the caller's own params, same as a `ValidationError` — not an
-            // internal server fault — so both map to `invalid_params`.
-            if e.is_validation_error() || e.is_security_error() {
-                McpError::invalid_params(e.to_string(), None)
-            } else {
-                McpError::internal_error(format!("Failed to build server config: {e}"), None)
-            }
-        })?;
+        .map_err(|e| caller_or_internal_error(&e, "Failed to build server config"))?;
 
-        // Connect and introspect, holding only the lock for this server_id. A
-        // tokio::select! against `ct.cancelled()` lets a client-issued
-        // `notifications/cancelled` interrupt the (potentially up-to-600s)
-        // discovery round trip instead of always running it to completion.
-        // `biased;` prefers noticing cancellation over starting/continuing
-        // discovery, making the cancelled path deterministic rather than
-        // depending on `tokio::select!`'s (default-randomised) poll order.
-        let introspector_handle = self.introspector_for(&server_id).await;
-        let mut introspector = introspector_handle.lock().await;
-        let discover_outcome = tokio::select! {
-            biased;
-            () = ct.cancelled() => None,
-            result = introspector.discover_server(server_id.clone(), &config) => Some(result),
-        };
-        drop(introspector);
-
-        // Evict the per-server-id handle regardless of outcome (including
-        // cancellation), so caller-supplied server_id values can't grow the
-        // introspectors map without bound. Only removes the entry if it is
-        // still this exact handle (see `evict_introspector` docs for why
-        // identity matters here).
-        self.evict_introspector(&server_id, &introspector_handle)
-            .await;
-
-        let discover_result = discover_outcome.ok_or_else(|| {
-            McpError::internal_error("introspect_server cancelled by client", None)
-        })?;
-
-        let server_info = discover_result.map_err(|e| {
-            // See the matching comment above `config_builder.build()`: a `SecurityViolation`
-            // is a caller-param problem too, not an internal fault.
-            if e.is_validation_error() || e.is_security_error() {
-                McpError::invalid_params(e.to_string(), None)
-            } else {
-                McpError::internal_error(format!("Failed to introspect server: {e}"), None)
-            }
-        })?;
+        // See `discover_with_cancellation` for the cancellation/locking rationale, and
+        // `caller_or_internal_error` for the error-classification rule it applies.
+        let server_info = self
+            .discover_with_cancellation(&server_id, &config, &ct)
+            .await?;
 
         // Extract tool metadata for Claude
-        let tools: Vec<IntrospectedToolSummary> = server_info
-            .tools
-            .iter()
-            .map(|tool| {
-                let parameters = extract_parameter_names(&tool.input_schema);
-
-                IntrospectedToolSummary {
-                    name: tool.name.as_str().to_string(),
-                    description: tool.description.clone(),
-                    parameters,
-                }
-            })
-            .collect();
+        let tools = build_introspected_summaries(&server_info.tools);
 
         // Store pending generation
         let pending = PendingGeneration::new(
@@ -1153,6 +1143,37 @@ async fn resolve_list_base_dir(
         });
     }
     Ok(canonical_joined)
+}
+
+/// Classifies an [`mcp_execution_core::Error`] from the introspection pipeline into an
+/// [`McpError`].
+///
+/// A `ValidationError` or `SecurityViolation` reflects a problem with the caller's own
+/// params (shell metacharacters, forbidden env var, malformed field, etc.), not an internal
+/// server fault, so both map to `invalid_params`; anything else is `internal_error`, prefixed
+/// with `internal_prefix` for context.
+fn caller_or_internal_error(err: &mcp_execution_core::Error, internal_prefix: &str) -> McpError {
+    if err.is_validation_error() || err.is_security_error() {
+        McpError::invalid_params(err.to_string(), None)
+    } else {
+        McpError::internal_error(format!("{internal_prefix}: {err}"), None)
+    }
+}
+
+/// Builds the per-tool summaries `introspect_server` returns to Claude for categorization.
+fn build_introspected_summaries(tools: &[ToolInfo]) -> Vec<IntrospectedToolSummary> {
+    tools
+        .iter()
+        .map(|tool| {
+            let parameters = extract_parameter_names(&tool.input_schema);
+
+            IntrospectedToolSummary {
+                name: tool.name.as_str().to_string(),
+                description: tool.description.clone(),
+                parameters,
+            }
+        })
+        .collect()
 }
 
 /// Extracts parameter names from a JSON Schema.


### PR DESCRIPTION
## Summary
- Extracts pipeline-stage helper functions from four long command handlers (`generate::run`, `skill::run`, `GeneratorService::introspect_server`, `runner::execute_command`) so each reads as a short orchestration instead of a single function mixing config resolution, network I/O, codegen, filesystem writes, and presentation.
- Adds a shared `common::resolve_server_config` helper, replacing a byte-identical block previously duplicated in `generate.rs` and `introspect.rs`.
- Adds a "Next step: run 'npm install'" hint to `generate`'s success output (text, pretty, and a new `next_step` JSON field), not emitted in `--dry-run`, since the exported package now needs a dependency install before it type-checks (following the `tsconfig.json`/`@types/node` generation that landed in #253).
- Behavior is otherwise unchanged: log call sites, error classification, and lock/eviction ordering are preserved exactly.

Closes #179
Closes #257

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (897/897 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Verified the four refactor-safety invariants: no behavioral drift in the concurrent-discovery span-count test, `execute_command` still never returns `Err`, export/write ordering preserved, all log calls survive verbatim
- [x] Added a test assertion pinning the new `next_step` field's presence in generate's JSON output