### PR TITLE
fix(codegen): attribute per-tool generation errors and stop mangling non-ASCII identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same "exited before responding" wording as the `close` handler, so the rejection a caller sees
   no longer depends on unpredictable event-loop timing.
 
+- **`mcp-execution-codegen`**: `sanitize_ts_identifier` replaced every non-ASCII-alphanumeric
+  character with its own `_`, so a run of several invalid characters (e.g. multiple
+  non-ASCII characters in a row, or an invalid character adjacent to a literal `_`) produced
+  one underscore per character instead of a single separator, needlessly widening generated
+  identifiers (#192). Any run of consecutive `_`-producing characters — invalid characters,
+  literal `_`s already in the input, or a mix — now collapses into a single `_`; a single
+  invalid character between other valid characters still becomes exactly one `_`, unchanged.
+  **Behavior change**: regenerating an existing server's tools can produce different
+  identifiers than before for any tool or property name that previously sanitized through a
+  run of two or more consecutive invalid/underscore characters (e.g. `a--b` sanitized to
+  `a__b`, now sanitizes to `a_b`, same as `a-b`); a resulting new collision is disambiguated
+  the same way any other sanitization collision already was (`a_b`, `a_b_2`, ...).
+
+- **`mcp-execution-codegen`**: `ProgressiveGenerator::create_tool_context`/`create_tool_metadata`
+  reported malformed schema properties as a generic `Error::ValidationError`, and a failure
+  while rendering a tool's template or tracking its generated file surfaced as a bare
+  `Error::SerializationError`/`Error::ResourceLimitExceeded` — in all three cases discarding the
+  name of the tool being generated even though the caller had it in scope (#185). All three call
+  sites, across both `generate` and `generate_with_categories`, now wrap the failure in
+  `Error::ScriptGenerationError`, attributing it to the specific tool and preserving the
+  original error as its `source`. `mcp-execution-cli`'s exit-code classifier now recurses into
+  that `source` so a wrapped `Error::ResourceLimitExceeded` still reports `ExitCode::SERVER_ERROR`
+  instead of the generic code every other `ScriptGenerationError` gets.
+
+- **`mcp-execution-server`**: `GeneratorService::save_categorized_tools` built its `McpError`
+  messages by interpolating `{e}` directly, which only prints an error's own `Display` text —
+  for a wrapping variant like `Error::ScriptGenerationError` (see above) that never repeats its
+  `#[source]`, so the underlying cause (e.g. which resource limit was exceeded) was silently
+  dropped from what an MCP client sees on the project's primary interface. The three call sites
+  that build code from categorized tools (generator construction, code generation, virtual
+  filesystem build) now walk the full `source()` chain when building the message.
+
 - **`mcp-execution-cli`**: `Cli`/`Commands` derived a plain `Debug`, so `Commands::Introspect`'s
   `env`/`headers` and `Commands::Generate`'s `server_env`/`server_headers` — raw `KEY=VALUE`
   strings straight from argv, routinely carrying secrets — were printed in full wherever the

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -226,33 +226,19 @@ pub fn report_and_classify(err: &anyhow::Error) -> ExitCode {
 /// semantic [`ExitCode`].
 ///
 /// Walks the error's cause chain looking for a [`CoreError`] — the concrete
-/// type every command handler ultimately produces via `?` — and maps its
-/// variant to the exit code that best communicates the failure category to
-/// scripts consuming this CLI. Falls back to checking for a [`FilesError`]
-/// (the `generate` command's `export_to_filesystem` errors are wrapped via `anyhow::Context`
-/// rather than converted to `CoreError`, so they would otherwise never match the first check
-/// and always fall through to the generic [`ExitCode::ERROR`] — issue #198 M6). Errors that
-/// match neither (e.g. CLI argument parsing, serialization) fall back to [`ExitCode::ERROR`].
+/// type every command handler ultimately produces via `?` — and delegates to
+/// [`classify_core_error`] for the variant-to-exit-code mapping. Falls back to checking for a
+/// [`FilesError`] (the `generate` command's `export_to_filesystem` errors are wrapped via
+/// `anyhow::Context` rather than converted to `CoreError`, so they would otherwise never match
+/// the first check and always fall through to the generic [`ExitCode::ERROR`] — issue #198 M6).
+/// Errors that match neither (e.g. CLI argument parsing, serialization) fall back to
+/// [`ExitCode::ERROR`].
 fn classify_exit_code(error: &anyhow::Error) -> ExitCode {
     if let Some(core_error) = error
         .chain()
         .find_map(|cause| cause.downcast_ref::<CoreError>())
     {
-        return match core_error {
-            CoreError::Timeout { .. } => ExitCode::TIMEOUT,
-            // A resource limit is exceeded by data the remote MCP server returned (tool
-            // count, schema size, etc.), not by the CLI caller's own arguments — same
-            // "the server is at fault" classification as `ConnectionFailed`.
-            CoreError::ConnectionFailed { .. } | CoreError::ResourceLimitExceeded { .. } => {
-                ExitCode::SERVER_ERROR
-            }
-            CoreError::ValidationError { .. }
-            | CoreError::SecurityViolation { .. }
-            | CoreError::InvalidArgument(_) => ExitCode::INVALID_INPUT,
-            CoreError::SerializationError { .. } | CoreError::ScriptGenerationError { .. } => {
-                ExitCode::ERROR
-            }
-        };
+        return classify_core_error(core_error);
     }
 
     if let Some(files_error) = error
@@ -274,6 +260,35 @@ fn classify_exit_code(error: &anyhow::Error) -> ExitCode {
     }
 
     ExitCode::ERROR
+}
+
+/// Classifies a single [`CoreError`] variant.
+///
+/// [`CoreError::ScriptGenerationError`] wraps an arbitrary underlying failure (schema
+/// extraction, template rendering, output tracking) behind one variant so a codegen error can
+/// always be attributed to the tool that caused it; that wrapping must not also collapse the
+/// wrapped cause's own exit-code classification (e.g. a wrapped
+/// [`CoreError::ResourceLimitExceeded`] should still report [`ExitCode::SERVER_ERROR`], not the
+/// generic code every other `ScriptGenerationError` gets). Recursing into `source` when it
+/// downcasts to another `CoreError` preserves that.
+fn classify_core_error(core_error: &CoreError) -> ExitCode {
+    match core_error {
+        CoreError::Timeout { .. } => ExitCode::TIMEOUT,
+        // A resource limit is exceeded by data the remote MCP server returned (tool
+        // count, schema size, etc.), not by the CLI caller's own arguments — same
+        // "the server is at fault" classification as `ConnectionFailed`.
+        CoreError::ConnectionFailed { .. } | CoreError::ResourceLimitExceeded { .. } => {
+            ExitCode::SERVER_ERROR
+        }
+        CoreError::ValidationError { .. }
+        | CoreError::SecurityViolation { .. }
+        | CoreError::InvalidArgument(_) => ExitCode::INVALID_INPUT,
+        CoreError::SerializationError { .. } => ExitCode::ERROR,
+        CoreError::ScriptGenerationError { source, .. } => source
+            .as_deref()
+            .and_then(|source| source.downcast_ref::<CoreError>())
+            .map_or(ExitCode::ERROR, classify_core_error),
+    }
 }
 
 #[cfg(test)]
@@ -374,6 +389,24 @@ mod tests {
             source: None,
         });
         assert_eq!(classify_exit_code(&err), ExitCode::ERROR);
+    }
+
+    /// `ScriptGenerationError` wraps its cause via `source` (see
+    /// `ProgressiveGenerator::wrap_tool_generation_error`) precisely so this recursion can
+    /// still find the original classification instead of collapsing every wrapped cause to the
+    /// generic exit code.
+    #[test]
+    fn test_classify_exit_code_script_generation_error_recurses_into_wrapped_source() {
+        let err = wrap(CoreError::ScriptGenerationError {
+            tool: "example_tool".to_string(),
+            message: "failed to track generated tool file".to_string(),
+            source: Some(Box::new(CoreError::ResourceLimitExceeded {
+                resource: "generated output size".to_string(),
+                actual: 10,
+                limit: 5,
+            })),
+        });
+        assert_eq!(classify_exit_code(&err), ExitCode::SERVER_ERROR);
     }
 
     #[test]

--- a/crates/mcp-codegen/src/common/typescript.rs
+++ b/crates/mcp-codegen/src/common/typescript.rs
@@ -77,10 +77,19 @@ pub fn to_pascal_case(snake_case: &str) -> String {
 /// Sanitizes a string for safe use as a TypeScript identifier (e.g. a function, export,
 /// or object property name).
 ///
-/// Replaces any character outside `[A-Za-z0-9_$]` with `_`, and prefixes the result with
-/// `_` if it would otherwise start with a digit or be empty. This prevents identifier-position
-/// injection of arbitrary TypeScript syntax from untrusted schema data (property keys, tool
-/// names, etc. sourced from an MCP server are not guaranteed to be valid identifiers).
+/// Characters in `[A-Za-z0-9$]` pass through unchanged; every other character — including a
+/// literal `_` already in the input — is treated as a separator and replaces its whole
+/// consecutive run with a single `_`, and the result is prefixed with `_` if it would
+/// otherwise start with a digit or be empty. This prevents identifier-position injection of
+/// arbitrary TypeScript syntax from untrusted schema data (property keys, tool names, etc.
+/// sourced from an MCP server are not guaranteed to be valid identifiers).
+///
+/// Collapsing an entire separator run — rather than emitting one `_` per invalid character —
+/// means e.g. a multi-byte non-ASCII run doesn't balloon into a wall of underscores that
+/// discards more information than a single separator already would. It also means a literal
+/// run like `"a__b"` collapses to `"a_b"`: once a separator has been emitted, further
+/// separator-producing characters are redundant regardless of why each one would have
+/// produced a `_`.
 ///
 /// # Examples
 ///
@@ -90,19 +99,21 @@ pub fn to_pascal_case(snake_case: &str) -> String {
 /// assert_eq!(sanitize_ts_identifier("valid_name"), "valid_name");
 /// assert_eq!(sanitize_ts_identifier("123abc"), "_123abc");
 /// assert_eq!(sanitize_ts_identifier("a-b c"), "a_b_c");
+/// assert_eq!(sanitize_ts_identifier("café_menu_日本語"), "caf_menu_");
 /// ```
 #[must_use]
 pub fn sanitize_ts_identifier(s: &str) -> String {
-    let mut result: String = s
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' || c == '$' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
+    let mut result = String::new();
+    let mut prev_was_underscore = false;
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || c == '$' {
+            result.push(c);
+            prev_was_underscore = false;
+        } else if !prev_was_underscore {
+            result.push('_');
+            prev_was_underscore = true;
+        }
+    }
 
     if result.is_empty() || result.starts_with(|c: char| c.is_ascii_digit()) {
         result.insert(0, '_');
@@ -468,6 +479,49 @@ mod tests {
     #[test]
     fn test_sanitize_ts_identifier_prefixes_empty_string() {
         assert_eq!(sanitize_ts_identifier(""), "_");
+    }
+
+    #[test]
+    fn test_sanitize_ts_identifier_collapses_consecutive_non_ascii_run() {
+        // Issue #192: each invalid char used to become its own `_`, so one accented
+        // letter plus a run of CJK characters produced four separate underscores. The
+        // literal `_`s between words must also collapse into the run rather than
+        // surviving as a second, adjacent separator (otherwise `sanitize_ts_identifier`
+        // alone — as used for property names, without `to_camel_case` first — still
+        // produces `caf__menu__`, the exact artifact the issue was filed about).
+        assert_eq!(sanitize_ts_identifier("café_menu_日本語"), "caf_menu_");
+    }
+
+    #[test]
+    fn test_sanitize_ts_identifier_collapses_mixed_invalid_run() {
+        assert_eq!(sanitize_ts_identifier("a---b"), "a_b");
+        assert_eq!(sanitize_ts_identifier("a- .b"), "a_b");
+    }
+
+    #[test]
+    fn test_sanitize_ts_identifier_collapses_literal_underscore_runs() {
+        // A run of literal `_`s in the input collapses too: once a separator has been
+        // emitted, further separator-producing characters (whether literal `_` or a
+        // substituted invalid character) are redundant regardless of which kind they are.
+        assert_eq!(sanitize_ts_identifier("a__b"), "a_b");
+        assert_eq!(sanitize_ts_identifier("日_本"), "_");
+        assert_eq!(sanitize_ts_identifier("_日_"), "_");
+    }
+
+    #[test]
+    fn test_sanitize_ts_identifier_preserves_isolated_invalid_chars() {
+        // A single invalid character separated from the next by a valid character must still
+        // become its own `_` — only *consecutive* separator-producing runs collapse.
+        assert_eq!(sanitize_ts_identifier("a-b-c"), "a_b_c");
+    }
+
+    #[test]
+    fn test_sanitize_ts_identifier_all_invalid_chars_collapses_to_bare_underscore() {
+        // The most extreme case of issue #192: an identifier made entirely of invalid
+        // characters must collapse to a single `_`, not one `_` per character. Distinct
+        // from the empty-string case (`""` never enters the loop at all).
+        assert_eq!(sanitize_ts_identifier("日本語"), "_");
+        assert_eq!(sanitize_ts_identifier("---"), "_");
     }
 
     #[test]

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -259,7 +259,12 @@ impl<'a> ProgressiveGenerator<'a> {
             let typescript_name = typescript_names.get(idx).cloned().unwrap_or_default();
             let tool_context =
                 self.create_tool_context(server_id, tool, None, typescript_name.clone())?;
-            let tool_code = self.engine.render("progressive/tool", &tool_context)?;
+            let tool_code = self
+                .engine
+                .render("progressive/tool", &tool_context)
+                .map_err(|source| {
+                    Self::wrap_tool_generation_error(tool, "render tool template", source)
+                })?;
 
             add_tracked(
                 &mut code,
@@ -268,7 +273,10 @@ impl<'a> ProgressiveGenerator<'a> {
                     path: format!("{}.ts", tool_context.typescript_name),
                     content: tool_code,
                 },
-            )?;
+            )
+            .map_err(|source| {
+                Self::wrap_tool_generation_error(tool, "track generated tool file", source)
+            })?;
 
             tracing::debug!("Generated tool file: {}.ts", tool_context.typescript_name);
 
@@ -433,7 +441,12 @@ impl<'a> ProgressiveGenerator<'a> {
             let typescript_name = typescript_names.get(idx).cloned().unwrap_or_default();
             let tool_context =
                 self.create_tool_context(server_id, tool, categorization, typescript_name.clone())?;
-            let tool_code = self.engine.render("progressive/tool", &tool_context)?;
+            let tool_code = self
+                .engine
+                .render("progressive/tool", &tool_context)
+                .map_err(|source| {
+                    Self::wrap_tool_generation_error(tool, "render tool template", source)
+                })?;
 
             add_tracked(
                 &mut code,
@@ -442,7 +455,10 @@ impl<'a> ProgressiveGenerator<'a> {
                     path: format!("{}.ts", tool_context.typescript_name),
                     content: tool_code,
                 },
-            )?;
+            )
+            .map_err(|source| {
+                Self::wrap_tool_generation_error(tool, "track generated tool file", source)
+            })?;
 
             tracing::debug!(
                 "Generated tool file: {}.ts (category: {:?})",
@@ -552,7 +568,11 @@ impl<'a> ProgressiveGenerator<'a> {
         typescript_name: String,
     ) -> Result<ToolContext> {
         // Extract properties from input schema
-        let properties = self.extract_property_infos(&tool.input_schema)?;
+        let properties = self
+            .extract_property_infos(&tool.input_schema)
+            .map_err(|source| {
+                Self::wrap_tool_generation_error(tool, "extract property schema", source)
+            })?;
 
         let description = sanitize_jsdoc(&tool.description, 256);
         // Falls back to the tool's own description when no LLM categorization is
@@ -643,6 +663,26 @@ impl<'a> ProgressiveGenerator<'a> {
             tools,
             categories: category_groups,
         })
+    }
+
+    /// Wraps a per-tool codegen failure — property-schema extraction, template rendering, or
+    /// output tracking — in [`Error::ScriptGenerationError`] so the failing tool's name
+    /// survives past the point where `tool` goes out of scope, instead of the generic
+    /// [`Error::ValidationError`]/[`Error::SerializationError`]/[`Error::ResourceLimitExceeded`]
+    /// each stage raises on its own. `stage` is a short, lower-case description of the failed
+    /// step (e.g. `"extract property schema"`) used to build `message`.
+    ///
+    /// Unlike [`TemplateEngine`]'s convention of embedding the source's `Display` text into
+    /// `message` and setting `source: None`, this
+    /// keeps `source` populated: `classify_exit_code` in `mcp-execution-cli` downcasts into it
+    /// so a wrapped [`Error::ResourceLimitExceeded`] still maps to `SERVER_ERROR` rather than
+    /// collapsing to the generic exit code for every wrapped cause.
+    fn wrap_tool_generation_error(tool: &ToolInfo, stage: &str, source: Error) -> Error {
+        Error::ScriptGenerationError {
+            tool: tool.name.as_str().to_string(),
+            message: format!("failed to {stage}"),
+            source: Some(Box::new(source)),
+        }
     }
 
     /// Extracts property information from JSON Schema.
@@ -757,7 +797,11 @@ impl<'a> ProgressiveGenerator<'a> {
         categorization: Option<&ToolCategorization>,
         typescript_name: String,
     ) -> Result<ToolMetadata> {
-        let properties = self.extract_property_data(&tool.input_schema)?;
+        let properties = self
+            .extract_property_data(&tool.input_schema)
+            .map_err(|source| {
+                Self::wrap_tool_generation_error(tool, "extract property schema", source)
+            })?;
 
         let description = (!tool.description.is_empty()).then(|| tool.description.clone());
         let category = categorization.map(|c| c.category.clone());
@@ -1382,6 +1426,97 @@ mod tests {
     }
 
     #[test]
+    fn test_wrap_tool_generation_error_preserves_tool_name_and_source() {
+        // The property-extraction error raised deep in `extract_property_data` is generic
+        // (`Error::ValidationError`) and has no `tool` field; this wrapper attributes the
+        // failure back to the specific tool being generated.
+        let tool = ToolInfo {
+            name: ToolName::new("send_message"),
+            description: String::new(),
+            input_schema: json!({}),
+            output_schema: None,
+        };
+        let source = Error::ValidationError {
+            field: "type".to_string(),
+            reason: "Property type is not a string".to_string(),
+        };
+
+        let wrapped = ProgressiveGenerator::wrap_tool_generation_error(
+            &tool,
+            "extract property schema",
+            source,
+        );
+
+        match wrapped {
+            Error::ScriptGenerationError {
+                tool: tool_name,
+                message,
+                source,
+            } => {
+                assert_eq!(tool_name, "send_message");
+                // `message` must not duplicate the source's Display text (only one of the two
+                // should carry it, per this crate's error-chain-printing convention).
+                assert_eq!(message, "failed to extract property schema");
+                let source = source.expect("source must be preserved for exit-code classification");
+                assert!(source.to_string().contains("Property type is not a string"));
+            }
+            other => panic!("expected ScriptGenerationError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wrap_tool_generation_error_covers_render_and_tracking_stages() {
+        // #185's real (reachable) attribution gap: a template-render failure or an
+        // output-tracking failure that happens while processing one tool out of many must
+        // still name that tool, not just the (structurally unreachable) schema-extraction path.
+        let tool = ToolInfo {
+            name: ToolName::new("send_message"),
+            description: String::new(),
+            input_schema: json!({}),
+            output_schema: None,
+        };
+
+        let render_failure = ProgressiveGenerator::wrap_tool_generation_error(
+            &tool,
+            "render tool template",
+            Error::SerializationError {
+                message: "Template rendering failed: boom".to_string(),
+                source: None,
+            },
+        );
+        assert!(render_failure.is_script_generation_error());
+
+        let tracking_failure = ProgressiveGenerator::wrap_tool_generation_error(
+            &tool,
+            "track generated tool file",
+            Error::ResourceLimitExceeded {
+                resource: "generated output size".to_string(),
+                actual: 10,
+                limit: 5,
+            },
+        );
+        match tracking_failure {
+            Error::ScriptGenerationError {
+                tool: tool_name,
+                source,
+                ..
+            } => {
+                assert_eq!(tool_name, "send_message");
+                let source = source.expect("source must be preserved for exit-code classification");
+                // The nested `ResourceLimitExceeded` must survive intact so
+                // `classify_exit_code` (mcp-cli) can still recurse into it.
+                assert!(
+                    source
+                        .downcast_ref::<Error>()
+                        .unwrap()
+                        .is_resource_limit_exceeded()
+                );
+            }
+            other => panic!("expected ScriptGenerationError, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_create_tool_context_without_categorization_falls_back_to_description() {
         let generator = ProgressiveGenerator::new().unwrap();
         let tool = ToolInfo {
@@ -1528,6 +1663,29 @@ mod tests {
             "properties": {
                 "a-b": {"type": "string"},
                 "a.b": {"type": "number"}
+            },
+            "required": []
+        });
+
+        let props = generator.extract_property_infos(&schema).unwrap();
+        let mut names: Vec<&str> = props.iter().map(|p| p.name.as_str()).collect();
+        names.sort_unstable();
+
+        assert_eq!(names, vec!["a_b", "a_b_2"]);
+    }
+
+    #[test]
+    fn test_extract_property_infos_disambiguates_collision_introduced_by_collapsing() {
+        // Before issue #192's collapsing fix, "a-b" -> "a_b" and "a--b" -> "a__b" were
+        // distinct identifiers; collapsing consecutive invalid runs now sanitizes both to
+        // "a_b", introducing a *new* collision that must still be disambiguated rather than
+        // producing a duplicate, non-compiling field.
+        let generator = ProgressiveGenerator::new().unwrap();
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a-b": {"type": "string"},
+                "a--b": {"type": "number"}
             },
             "required": []
         });
@@ -1927,6 +2085,48 @@ mod tests {
             "a reserved-word tool's fallback name must not collide with an unrelated tool that already claims it"
         );
         assert!(!RESERVED_WORDS.contains(&resolved[0].as_str()));
+    }
+
+    #[test]
+    fn test_resolve_typescript_names_collapses_non_ascii_run() {
+        // Issue #192: a non-ASCII tool name used to produce one `_` per invalid character
+        // (`café_menu_日本語` -> `caf_Menu___`), losing more information than necessary.
+        let tools = vec![ToolInfo {
+            name: ToolName::new("café_menu_日本語"),
+            description: String::new(),
+            input_schema: json!({}),
+            output_schema: None,
+        }];
+
+        let resolved = resolve_typescript_names(&tools);
+
+        assert_eq!(resolved[0], "caf_Menu_");
+    }
+
+    #[test]
+    fn test_resolve_typescript_names_disambiguates_collision_introduced_by_collapsing() {
+        // Same collapsing-introduced collision as
+        // `test_extract_property_infos_disambiguates_collision_introduced_by_collapsing`, but
+        // for tool names rather than property names: "a-b" and "a--b" used to sanitize to
+        // distinct identifiers and now both sanitize to "a_b".
+        let tools = vec![
+            ToolInfo {
+                name: ToolName::new("a-b"),
+                description: String::new(),
+                input_schema: json!({}),
+                output_schema: None,
+            },
+            ToolInfo {
+                name: ToolName::new("a--b"),
+                description: String::new(),
+                input_schema: json!({}),
+                output_schema: None,
+            },
+        ];
+
+        let resolved = resolve_typescript_names(&tools);
+
+        assert_eq!(resolved, vec!["a_b", "a_b_2"]);
     }
 
     #[test]

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -616,16 +616,29 @@ impl GeneratorService {
 
         // Generate code with categorization
         let generator = ProgressiveGenerator::new().map_err(|e| {
-            McpError::internal_error(format!("Failed to create generator: {e}"), None)
+            McpError::internal_error(
+                format!("Failed to create generator: {}", describe_with_causes(&e)),
+                None,
+            )
         })?;
 
         let code = generate_with_categorization(&generator, &pending.server_info, &categorization)
-            .map_err(|e| McpError::internal_error(format!("Failed to generate code: {e}"), None))?;
+            .map_err(|e| {
+                McpError::internal_error(
+                    format!("Failed to generate code: {}", describe_with_causes(&e)),
+                    None,
+                )
+            })?;
 
         // Build virtual filesystem
         let vfs = FilesBuilder::from_generated_code(code, "/")
             .build()
-            .map_err(|e| McpError::internal_error(format!("Failed to build VFS: {e}"), None))?;
+            .map_err(|e| {
+                McpError::internal_error(
+                    format!("Failed to build VFS: {}", describe_with_causes(&e)),
+                    None,
+                )
+            })?;
 
         // Capture file count before moving vfs
         let files_generated = vfs.file_count();
@@ -1198,6 +1211,25 @@ fn capacity_error(message: String) -> McpError {
     McpError::new(rmcp::model::ErrorCode(-32000), message, None)
 }
 
+/// Formats `err`'s `Display` text followed by every cause in its `source()` chain, joined by
+/// `": "`.
+///
+/// A bare `{err}` interpolation only shows the top-level `Display`, which for a wrapping
+/// variant like `Error::ScriptGenerationError` never repeats its `#[source]` (see
+/// `ProgressiveGenerator::wrap_tool_generation_error`) — so building an `McpError` message with
+/// `{err}` alone silently drops the underlying cause from what the MCP client sees. Walking the
+/// chain here keeps that diagnostic detail on the primary interface most callers hit first.
+fn describe_with_causes(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut message = err.to_string();
+    let mut cause = err.source();
+    while let Some(source) = cause {
+        message.push_str(": ");
+        message.push_str(&source.to_string());
+        cause = source.source();
+    }
+    message
+}
+
 /// Generates code with categorization metadata.
 ///
 /// Converts the categorization map to the format expected by the generator
@@ -1254,6 +1286,42 @@ mod tests {
         assert_eq!(params.len(), 2);
         assert!(params.contains(&"name".to_string()));
         assert!(params.contains(&"age".to_string()));
+    }
+
+    #[test]
+    fn test_describe_with_causes_walks_full_source_chain() {
+        // `Error::ScriptGenerationError`'s `Display` never repeats its `#[source]` text, so a
+        // bare `{err}` would silently drop the wrapped `ResourceLimitExceeded` cause from the
+        // message an MCP client sees.
+        let err = mcp_execution_core::Error::ScriptGenerationError {
+            tool: "send_message".to_string(),
+            message: "failed to track generated tool file".to_string(),
+            source: Some(Box::new(mcp_execution_core::Error::ResourceLimitExceeded {
+                resource: "generated output size".to_string(),
+                actual: 10,
+                limit: 5,
+            })),
+        };
+
+        let described = describe_with_causes(&err);
+
+        assert!(described.contains("failed to track generated tool file"));
+        assert!(described.contains("resource limit exceeded for generated output size"));
+    }
+
+    #[test]
+    fn test_describe_with_causes_no_source_returns_bare_display() {
+        let err = mcp_execution_core::Error::ScriptGenerationError {
+            tool: "send_message".to_string(),
+            message: "failed to render tool template".to_string(),
+            source: None,
+        };
+
+        assert_eq!(
+            describe_with_causes(&err),
+            err.to_string(),
+            "no source chain to append, so the description must equal the bare Display"
+        );
     }
 
     /// #198 S3 — `SaveSkillParams::content`'s declared schema length must track the real


### PR DESCRIPTION
## Summary

- Wires the previously-dead `Error::ScriptGenerationError` variant into `ProgressiveGenerator`'s actually-reachable per-tool failure paths (template rendering, file tracking) so a failure while generating one tool among many reports which tool caused it. Exit code classification is preserved through the wrapper (`classify_exit_code` recurses through wrapped sources), and `mcp-server`'s `save_categorized_tools` now propagates the full error cause chain instead of dropping it via `Display`-only formatting.
- Rewrites `sanitize_ts_identifier` to collapse a run of consecutive invalid characters (including literal underscores) into a single separator, instead of emitting one underscore per invalid character. Non-ASCII tool and property names now produce readable identifiers (e.g. `café_menu_日本語` → `caf_menu_` instead of `caf__menu____`).

Closes #185, closes #192

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (905 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New unit tests cover: tool-generation error attribution and exit-code classification through the wrapper, non-ASCII identifier collapsing on both the tool-name and property-name paths, and the newly-introduced identifier collision (`a-b`/`a--b`) documented in CHANGELOG.md