### PR TITLE
fix(files): make export paths atomic and drop dead FilesError predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **`mcp-execution-files`**: `FilesError::is_not_found()`, `is_not_directory()`,
+  `is_invalid_path()`, and `is_io_error()`, and `FilePath::is_dir_path()` removed — none had any
+  real (non-test/non-doctest) call site anywhere in the workspace; `mcp-cli` and `mcp-server`
+  both propagate `FilesError` opaquely via `anyhow`, without ever naming it. Mirrors the
+  resolution of the identical dead-predicate pattern in `mcp_execution_core::Error` (#199).
+  `FilesError::is_resource_limit_exceeded()` is unaffected (#202).
+
 - **`mcp-execution-core`**: `ServerConfigBuilder::build()` now returns
   `Result<ServerConfig, Error>` instead of an infallible `ServerConfig` (#177). Security
   validation (shell metacharacters, forbidden environment variables, URL scheme, header
@@ -54,8 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their `is_not_found()`/`is_config_error()` predicates removed — never constructed by
   production code; each crate owns its own error type for these conditions
   (`mcp_files::FilesError::FileNotFound`, rmcp's `McpError` in `mcp-server`, `anyhow` in
-  `mcp-cli`), and `ServerConfigBuilder` uses the more precise `ValidationError` (#199). Note
-  `mcp_files::FilesError::is_not_found()` is a different type and is unchanged.
+  `mcp-cli`), and `ServerConfigBuilder` uses the more precise `ValidationError` (#199).
+  `mcp_files::FilesError` is a different type; its own analogous dead predicates were removed
+  separately, see the `mcp-execution-files` entry above (#202).
 
 - **`mcp-execution-server`**: `StateManager::store` now returns `Result<Uuid, StateError>`
   instead of an infallible `Uuid`, rejecting new sessions once the pending-generation table is
@@ -377,6 +385,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lock/eviction ordering are unchanged (#179).
 
 ### Fixed
+
+- **`mcp-execution-files`**: `FileSystem::export_to_filesystem_parallel` and
+  `FilesBuilder::build_and_export` were not directory-atomic — a process interrupted mid-export
+  (or a parallel write failing partway through) could leave a torn mix of old and new files
+  visible, the same interrupted-export bug already fixed for `FileSystem::export_to_filesystem`.
+  `export_to_filesystem_parallel` now shares `export_to_filesystem`'s
+  staging/atomic-rename mechanism (both are built on a new shared `stage_export` helper), giving
+  it identical guarantees; as a side effect it now also replaces `base_path` wholesale rather
+  than merging into it, so pre-existing files under `base_path` absent from the `FileSystem`
+  being exported are deleted — consistent with `export_to_filesystem`, but a behavior change for
+  any caller relying on the previous merge semantics. `build_and_export` is used for exporting
+  independent batches (e.g. one per MCP server) into one *shared* root such as
+  `~/.claude/servers/`, where a whole-directory swap would delete every sibling batch already
+  published there, so it instead publishes each top-level group in the batch (e.g. `/github/...`
+  files, grouped under `github`) atomically via `export_to_filesystem`, while a bare top-level
+  file with no subdirectory (already independently atomic) is written directly — giving
+  per-top-level-group atomicity and bounding the whole batch's size up front, rather than the
+  previous unbounded, non-atomic per-file write loop. For the same reason as
+  `export_to_filesystem_parallel` above, re-exporting the same top-level group now replaces
+  rather than merges into that one group (e.g. re-exporting `/github/...` with a smaller tool set
+  deletes files from the previous export of that group absent from the new batch); sibling groups
+  and bare top-level files elsewhere under `base_path` are unaffected (#178).
+
+- **`mcp-execution-files`**: `FilePath::new` accepted empty and `.` path components (e.g.
+  `"//x.ts"`, `"/./x.ts"`, or a trailing slash like `"/github/"`), which could make
+  `FilesBuilder::build_and_export`'s new per-group publish (above) resolve an empty top-level
+  group name to `base_path` itself and swap the entire shared root, deleting every sibling batch
+  already published there — reachable via the public `FilesBuilder::add_file` (and latently via
+  `from_generated_code` if a `GeneratedFile.path` ever began with `/`; no in-tree codegen output
+  does today). `FilePath::new` now rejects empty and `.` components; the root path `/` itself
+  still has none and remains valid (#178).
 
 - **`mcp-execution-codegen`**: the generated `index.ts` re-exported every tool file and the
   runtime bridge with a `.js` specifier (e.g. `from './createIssue.js'`), while `tool.ts.hbs`

--- a/crates/mcp-files/src/builder.rs
+++ b/crates/mcp-files/src/builder.rs
@@ -20,6 +20,7 @@
 use crate::filesystem::FileSystem;
 use crate::types::{FilesError, Result};
 use mcp_execution_codegen::GeneratedCode;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -201,10 +202,45 @@ impl FilesBuilder {
 
     /// Builds the VFS and exports all files to the real filesystem.
     ///
-    /// Files are written to disk at the specified base path with atomic
-    /// operations (write to temp file, then rename). Parent directories
-    /// are created automatically. The tilde (`~`) is expanded to the
-    /// user's home directory.
+    /// Unlike [`FileSystem::export_to_filesystem`], `base_path` here is not a
+    /// directory this call owns exclusively — callers routinely export
+    /// multiple independent batches (e.g. one per MCP server) into the same
+    /// shared root, such as `~/.claude/servers/`, so a whole-`base_path`
+    /// staging swap would delete every sibling batch already published
+    /// there (see [`Self::from_generated_code`], whose files all share one
+    /// top-level directory per call).
+    ///
+    /// Files are grouped by their top-level path component. A group with a
+    /// real subdirectory (e.g. `/github/createIssue.ts` and
+    /// `/github/getIssue.ts`, grouped under `github`) is published as a
+    /// whole via [`FileSystem::export_to_filesystem`] — the same
+    /// staging/atomic-rename mechanism `export_to_filesystem` gives its own
+    /// target — so that entire subtree lands under `base_path` atomically,
+    /// without disturbing sibling groups already there. Because that
+    /// publish reuses `export_to_filesystem`'s directory swap, it also
+    /// inherits its replace-not-merge semantics *for that one group*: a
+    /// second `build_and_export` call for the same top-level group (e.g.
+    /// re-exporting `/github/...` with a smaller tool set) deletes any file
+    /// previously under `base_path/github` that is absent from the new
+    /// batch, rather than only adding/updating what the new batch contains.
+    /// Sibling groups and bare top-level files elsewhere under `base_path`
+    /// are unaffected either way. A bare file with no subdirectory (e.g.
+    /// `/manifest.json`) is written directly with its own atomic
+    /// temp-file-then-rename, which is already a complete atomic unit on its
+    /// own and is unconditionally additive/overwriting, never deleting
+    /// unrelated files. This gives per-top-level-group atomicity, not
+    /// whole-batch atomicity: if a batch spans multiple groups and one
+    /// group's publish fails partway through processing the batch, groups
+    /// already published (or bare files already written) are unaffected and
+    /// remain in place, but the batch as a whole is not rolled back.
+    ///
+    /// As with [`FileSystem::export_to_filesystem`], concurrent calls that
+    /// publish the *same* group into the *same* `base_path` from different
+    /// processes are not locked against each other and can race on the
+    /// final swap (a lost update); concurrent calls publishing different
+    /// groups are safe. `base_path` is created (via `create_dir_all`) even
+    /// for an empty VFS. The tilde (`~`) is expanded to the user's home
+    /// directory before export.
     ///
     /// # Arguments
     ///
@@ -215,6 +251,10 @@ impl FilesBuilder {
     /// Returns an error if:
     /// - Any file path is invalid
     /// - Home directory cannot be determined (when using `~`)
+    /// - The batch's file count or total byte size exceeds
+    ///   [`crate::filesystem::MAX_EXPORT_FILES`] /
+    ///   [`crate::filesystem::MAX_EXPORT_BYTES`]
+    /// - `base_path` cannot be created
     /// - I/O operations fail (permissions, disk space, etc.)
     ///
     /// # Examples
@@ -229,21 +269,47 @@ impl FilesBuilder {
     /// // Files are now at: ~/.claude/servers/github/createIssue.ts
     /// # Ok::<(), mcp_execution_files::FilesError>(())
     /// ```
-    // TODO(critic): not directory-atomic — needs staging treatment before any
-    // production caller is wired up (currently unused outside this crate's
-    // own tests, so the interrupted-export bug fixed in
-    // `FileSystem::export_to_filesystem` does not apply here yet).
     pub fn build_and_export(self, base_path: impl AsRef<Path>) -> Result<FileSystem> {
         // First, build the VFS to check for errors
         let vfs = self.build()?;
 
+        // Bound the whole batch up front (not just each group below), so a
+        // payload crafted as many small groups can't bypass the per-group
+        // check each `export_to_filesystem` call below performs on its own.
+        vfs.check_export_bounds()?;
+
         // Expand tilde in path
         let base = expand_tilde(base_path.as_ref())?;
 
-        // Export all files to disk
+        fs::create_dir_all(&base).map_err(|e| FilesError::IoError {
+            path: base.display().to_string(),
+            source: e,
+        })?;
+
+        // Split the batch into per-top-level-group sub-filesystems (relative
+        // to their group root) plus a list of bare top-level files. A
+        // `BTreeMap` gives deterministic (alphabetical) publish order, which
+        // doesn't affect correctness but makes a partial-batch outcome
+        // reproducible.
+        let mut groups: BTreeMap<String, FileSystem> = BTreeMap::new();
+
         for path in vfs.all_paths() {
             let content = vfs.read_file(path)?;
-            write_file_atomic(&base, path.as_str(), content)?;
+            let relative = path.as_str().strip_prefix('/').unwrap_or(path.as_str());
+
+            match relative.split_once('/') {
+                Some((root, rest)) => {
+                    groups
+                        .entry(root.to_string())
+                        .or_default()
+                        .add_file(format!("/{rest}"), content)?;
+                }
+                None => write_file_atomic(&base, path.as_str(), content)?,
+            }
+        }
+
+        for (root, group_vfs) in groups {
+            group_vfs.export_to_filesystem(base.join(root))?;
         }
 
         Ok(vfs)
@@ -334,13 +400,13 @@ fn expand_tilde(path: &Path) -> Result<PathBuf> {
     }
 }
 
-/// Writes file content to disk atomically using temp file + rename.
+/// Writes file content to disk atomically, creating parent directories
+/// automatically.
 ///
-/// Creates parent directories automatically. Uses atomic write pattern:
-/// 1. Write to temporary file
-/// 2. Rename temp file to final path
-///
-/// This ensures no partial files are visible if write fails.
+/// Delegates the actual write to [`crate::filesystem::write_file_atomic`]
+/// (temp file + `fsync` + rename) for durability parity with every other
+/// export path in this crate, after resolving `vfs_path` against `base_path`
+/// and validating it.
 ///
 /// # Security
 ///
@@ -350,7 +416,8 @@ fn expand_tilde(path: &Path) -> Result<PathBuf> {
 ///
 /// # Errors
 ///
-/// Returns an error if I/O operations fail.
+/// Returns an error if `vfs_path` contains a `..` component, or if I/O
+/// operations fail.
 fn write_file_atomic(base_path: &Path, vfs_path: &str, content: &str) -> Result<()> {
     // Remove leading slash and validate
     let relative_path = vfs_path.strip_prefix('/').unwrap_or(vfs_path);
@@ -373,27 +440,13 @@ fn write_file_atomic(base_path: &Path, vfs_path: &str, content: &str) -> Result<
         })?;
     }
 
-    // Atomic write: write to temp file, then rename
-    let temp_path = disk_path.with_added_extension("tmp");
-
-    fs::write(&temp_path, content).map_err(|e| FilesError::IoError {
-        path: temp_path.display().to_string(),
-        source: e,
-    })?;
-
-    fs::rename(&temp_path, &disk_path).map_err(|e| FilesError::IoError {
-        path: disk_path.display().to_string(),
-        source: e,
-    })?;
-
-    Ok(())
+    crate::filesystem::write_file_atomic(&disk_path, content, true)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use mcp_execution_codegen::GeneratedFile;
-    use std::fs;
     use tempfile::TempDir;
 
     #[test]
@@ -427,8 +480,7 @@ mod tests {
             .add_file("relative/path", "content")
             .build();
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_path());
+        assert!(matches!(result, Err(FilesError::PathNotAbsolute { .. })));
     }
 
     #[test]
@@ -623,6 +675,41 @@ mod tests {
     }
 
     #[test]
+    fn test_build_and_export_group_replaces_not_merges_on_re_export() {
+        // Unlike `test_build_and_export_overwrites_existing` (a bare
+        // top-level file, always additive/overwriting), a re-export of the
+        // same top-level *group* goes through `FileSystem::export_to_filesystem`'s
+        // directory swap and replaces the whole group: a file present in the
+        // first export but absent from the second must be deleted, not just
+        // left alone.
+        let temp_dir = TempDir::new().unwrap();
+
+        let vfs1 = FilesBuilder::new()
+            .add_file("/github/createIssue.ts", "create v1")
+            .add_file("/github/getIssue.ts", "get v1")
+            .build_and_export(temp_dir.path())
+            .unwrap();
+        assert_eq!(vfs1.file_count(), 2);
+        assert!(temp_dir.path().join("github/getIssue.ts").exists());
+
+        let vfs2 = FilesBuilder::new()
+            .add_file("/github/createIssue.ts", "create v2")
+            .build_and_export(temp_dir.path())
+            .unwrap();
+        assert_eq!(vfs2.file_count(), 1);
+
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("github/createIssue.ts")).unwrap(),
+            "create v2"
+        );
+        assert!(
+            !temp_dir.path().join("github/getIssue.ts").exists(),
+            "a file present in the first export but absent from the second must be deleted, \
+             not merged/left behind"
+        );
+    }
+
+    #[test]
     fn test_build_and_export_returns_vfs() {
         let temp_dir = TempDir::new().unwrap();
 
@@ -649,9 +736,7 @@ mod tests {
             .add_file("invalid/relative", "content")
             .build_and_export(temp_dir.path());
 
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.is_invalid_path());
+        assert!(matches!(result, Err(FilesError::PathNotAbsolute { .. })));
     }
 
     #[test]
@@ -691,6 +776,118 @@ mod tests {
     }
 
     #[test]
+    fn test_build_and_export_group_replaces_file_collision_without_losing_siblings() {
+        // Regression test for a real bug found during review: a batch spanning
+        // a bare top-level file plus a group whose name collides with a
+        // pre-existing plain file at that path (e.g. `base/sub` already exists
+        // as a file, but this batch wants to publish `/sub/nested.ts`). The
+        // group publish goes through `FileSystem::export_to_filesystem`, which
+        // displaces the existing file and replaces it with the new directory —
+        // this must succeed as a whole, and must never leave bare sibling
+        // files (already written directly, before the group publish runs)
+        // missing or corrupted.
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("sub"), "not a directory").unwrap();
+
+        let vfs = FilesBuilder::new()
+            .add_file("/first.ts", "first")
+            .add_file("/second.ts", "second")
+            .add_file("/sub/nested.ts", "nested")
+            .build_and_export(temp_dir.path())
+            .unwrap();
+
+        assert_eq!(vfs.file_count(), 3);
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("first.ts")).unwrap(),
+            "first"
+        );
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("second.ts")).unwrap(),
+            "second"
+        );
+        assert!(temp_dir.path().join("sub").is_dir());
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("sub/nested.ts")).unwrap(),
+            "nested"
+        );
+
+        // Regression check: displacing a *file* (rather than a directory)
+        // used to leave an unremovable `.sub.stale-*` artifact behind forever,
+        // since `remove_dir_all` always fails on a plain file and the error
+        // was silently discarded. Nothing but the three published entries
+        // should remain in `base_path`.
+        let mut children: Vec<String> = fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        children.sort();
+        assert_eq!(children, vec!["first.ts", "second.ts", "sub"]);
+    }
+
+    #[test]
+    fn test_build_and_export_rejects_empty_top_level_component() {
+        // Regression test for a real bug found during review: `"//x.ts"` used
+        // to pass `FilePath` validation and split into an *empty* top-level
+        // group name, so `base.join("")` resolved to `base` itself — the
+        // group publish would then swap `base_path` wholesale via
+        // `FileSystem::export_to_filesystem`, deleting every sibling batch
+        // already published there. `FilePath::new` now rejects this at
+        // `add_file` time, well before grouping.
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("existing-sibling.ts"), "keep").unwrap();
+
+        let result = FilesBuilder::new()
+            .add_file("//x.ts", "malicious")
+            .build_and_export(temp_dir.path());
+
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+        // Rejected during `build()`, before any group ever touches `base_path`.
+        assert!(temp_dir.path().join("existing-sibling.ts").exists());
+    }
+
+    #[test]
+    fn test_build_and_export_rejects_dot_component() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let result = FilesBuilder::new()
+            .add_file("/./x.ts", "content")
+            .build_and_export(temp_dir.path());
+
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+    }
+
+    #[test]
+    fn test_build_and_export_rejects_oversized_batch_before_touching_base() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut builder = FilesBuilder::new();
+        // Each file lives in its own group, so no single group's own
+        // `export_to_filesystem` bound check would catch this — only the
+        // whole-batch check in `build_and_export` itself can.
+        for i in 0..=crate::filesystem::MAX_EXPORT_FILES {
+            builder = builder.add_file(format!("/group{i}/tool.ts"), "export {}");
+        }
+
+        let target = temp_dir.path().join("out");
+        let result = builder.build_and_export(&target);
+
+        assert!(matches!(
+            result,
+            Err(FilesError::ResourceLimitExceeded { .. })
+        ));
+        // Rejected before any per-group publish ran, so the target directory
+        // (which build_and_export would otherwise create unconditionally)
+        // must never have been created.
+        assert!(!target.exists());
+    }
+
+    #[test]
     fn test_expand_tilde_expands_home() {
         let path = Path::new("~/test/path");
         let expanded = expand_tilde(path).unwrap();
@@ -726,8 +923,10 @@ mod tests {
 
         let result = write_file_atomic(temp_dir.path(), "/../etc/passwd", "malicious");
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_path());
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
     }
 
     #[test]

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -593,7 +593,7 @@ impl FileSystem {
     /// publishing — mid-write, or by a parallel write failing partway
     /// through — leaves `base_path` exactly as it was before this call; this
     /// does not cover a kill during the publish step itself, which carries
-    /// the same narrow window [`Self::swap_into_place`] documents. As a
+    /// the same narrow window `swap_into_place` documents. As a
     /// consequence of sharing that mechanism, `base_path` is now replaced
     /// wholesale rather than merged into: any pre-existing file under
     /// `base_path` that is absent from this `FileSystem` is deleted, exactly

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -505,7 +505,34 @@ impl FileSystem {
         self.check_export_bounds()?;
 
         let target = base_path.as_ref();
+        let (staging, canonical_staging) = self.stage_export(target)?;
 
+        // Phase 3: Write all files into the staging directory. If this fails,
+        // `staging` is dropped here and its `Drop` impl removes the partial
+        // tree — `target` is never touched.
+        self.write_files(&canonical_staging, options)?;
+
+        // Every file landed successfully; publish by swapping the staged
+        // directory into place.
+        Self::publish_staged_export(staging, target)
+    }
+
+    /// Prepares a staging directory for an atomic export into `target`,
+    /// shared by [`Self::export_to_filesystem_with_options`] and
+    /// [`Self::export_to_filesystem_parallel`] so both publish through the
+    /// same staging/atomic-rename mechanism.
+    ///
+    /// Returns the [`TempDir`] guard (whose `Drop` removes the staging tree
+    /// if the caller never reaches [`Self::publish_staged_export`]) together
+    /// with its canonicalized path, ready for [`Self::collect_directories`]
+    /// and file writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `target` has no parent directory, the parent does
+    /// not exist, or the staging directory cannot be created or
+    /// canonicalized.
+    fn stage_export(&self, target: &Path) -> Result<(TempDir, PathBuf)> {
         let parent = target.parent().ok_or_else(|| FilesError::InvalidPath {
             path: format!("Target path has no parent directory: {}", target.display()),
         })?;
@@ -552,26 +579,35 @@ impl FileSystem {
         // Phase 2: Create all directories in one pass
         Self::create_directories(&dirs)?;
 
-        // Phase 3: Write all files into the staging directory. If this fails,
-        // `staging` is dropped here and its `Drop` impl removes the partial
-        // tree — `target` is never touched.
-        self.write_files(&canonical_staging, options)?;
-
-        // Every file landed successfully; publish by swapping the staged
-        // directory into place.
-        Self::publish_staged_export(staging, target)
+        Ok((staging, canonical_staging))
     }
 
     /// Exports VFS contents using parallel writes (requires 'parallel' feature).
     ///
     /// Faster for large numbers of files (>50), but may not preserve write order.
     ///
+    /// Shares [`Self::export_to_filesystem`]'s staging/atomic-rename
+    /// mechanism: the export is staged in a temporary sibling directory next
+    /// to `base_path` and published by renaming that directory into place
+    /// only once every file has landed. A process interrupted before
+    /// publishing — mid-write, or by a parallel write failing partway
+    /// through — leaves `base_path` exactly as it was before this call; this
+    /// does not cover a kill during the publish step itself, which carries
+    /// the same narrow window [`Self::swap_into_place`] documents. As a
+    /// consequence of sharing that mechanism, `base_path` is now replaced
+    /// wholesale rather than merged into: any pre-existing file under
+    /// `base_path` that is absent from this `FileSystem` is deleted, exactly
+    /// like [`Self::export_to_filesystem`]. See that method and the
+    /// [module-level docs](self) for the full atomicity and concurrency
+    /// guarantees.
+    ///
     /// # Errors
     ///
-    /// Returns error if:
-    /// - Base path doesn't exist or isn't a directory
+    /// Returns an error if:
+    /// - The parent directory of `base_path` does not exist
+    /// - The staging directory cannot be created or canonicalized
     /// - Permission denied during directory creation or file write
-    /// - I/O error during parallel write operations
+    /// - I/O error during parallel write operations or the final publish step
     ///
     /// # Examples
     ///
@@ -591,37 +627,30 @@ impl FileSystem {
     /// vfs.export_to_filesystem_parallel(base).unwrap();
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    // TODO(critic): not directory-atomic — needs staging treatment before any
-    // production caller is wired up (currently unused outside this crate's
-    // own tests/benches, so the interrupted-export bug fixed in
-    // `export_to_filesystem` does not apply here yet).
     #[cfg(feature = "parallel")]
     pub fn export_to_filesystem_parallel(&self, base_path: impl AsRef<Path>) -> Result<()> {
         use rayon::prelude::*;
 
         self.check_export_bounds()?;
 
-        let base = base_path.as_ref();
-        let canonical_base = base.canonicalize().map_err(|e| FilesError::InvalidPath {
-            path: format!("Failed to canonicalize {}: {}", base.display(), e),
-        })?;
+        let target = base_path.as_ref();
+        let (staging, canonical_staging) = self.stage_export(target)?;
 
-        // Phase 1: Collect and create directories (must be sequential)
-        let dirs = self.collect_directories(&canonical_base);
-        Self::create_directories(&dirs)?;
-
-        // Phase 2: Write files in parallel
-        let files: Vec<_> = self.files().collect();
+        // Write files in parallel into the staging directory. If this fails,
+        // `staging` is dropped here and its `Drop` impl removes the partial
+        // tree — `target` is never touched.
         let options = ExportOptions::default();
+        self.files().collect::<Vec<_>>().par_iter().try_for_each(
+            |(vfs_path, file)| -> Result<()> {
+                let staging_disk_path =
+                    Self::vfs_to_disk_path(vfs_path.as_str(), &canonical_staging);
+                write_file_atomic(&staging_disk_path, file.content(), options.atomic)
+            },
+        )?;
 
-        files
-            .par_iter()
-            .try_for_each(|(vfs_path, file)| -> Result<()> {
-                let disk_path = Self::vfs_to_disk_path(vfs_path.as_str(), &canonical_base);
-                write_file_atomic(&disk_path, file.content(), options.atomic)
-            })?;
-
-        Ok(())
+        // Every file landed successfully; publish by swapping the staged
+        // directory into place.
+        Self::publish_staged_export(staging, target)
     }
 
     /// Rejects an export whose file count or total byte size exceeds its configured bound
@@ -633,7 +662,11 @@ impl FileSystem {
     /// Returns [`FilesError::ResourceLimitExceeded`] if [`Self::file_count`] exceeds
     /// [`MAX_EXPORT_FILES`], or the combined byte size of every file's content exceeds
     /// [`MAX_EXPORT_BYTES`].
-    fn check_export_bounds(&self) -> Result<()> {
+    ///
+    /// `pub(crate)` so [`crate::builder::FilesBuilder::build_and_export`] can bound its
+    /// whole batch up front, before splitting it into the per-group sub-filesystems that
+    /// each perform this same check independently.
+    pub(crate) fn check_export_bounds(&self) -> Result<()> {
         if self.file_count() > MAX_EXPORT_FILES {
             return Err(FilesError::ResourceLimitExceeded {
                 resource: "export file count".to_string(),
@@ -757,7 +790,7 @@ impl FileSystem {
             });
         }
 
-        let _ = fs::remove_dir_all(&displaced);
+        Self::remove_artifact_best_effort(&displaced);
         Ok(())
     }
 
@@ -801,10 +834,22 @@ impl FileSystem {
     /// removed. Best-effort like [`Self::sweep_stale_artifacts`]: failure
     /// (e.g. a read-only directory) is silently ignored rather than failing
     /// the export.
+    ///
+    /// `dir` (despite the name, matching [`Self::displace_existing_target`]'s
+    /// caller) may also be a plain file — e.g. a bare top-level file being
+    /// displaced by a same-named subdirectory in
+    /// [`crate::builder::FilesBuilder::build_and_export`]'s per-group
+    /// publish. The marker-file trick above does not apply to a file, so
+    /// that case opens `dir` for writing and calls
+    /// [`std::fs::File::set_modified`] directly instead.
     fn touch_dir(dir: &Path) {
-        let marker = dir.join(format!(".mtime-touch-{}", std::process::id()));
-        if fs::File::create(&marker).is_ok() {
-            let _ = fs::remove_file(&marker);
+        if dir.is_dir() {
+            let marker = dir.join(format!(".mtime-touch-{}", std::process::id()));
+            if fs::File::create(&marker).is_ok() {
+                let _ = fs::remove_file(&marker);
+            }
+        } else if let Ok(file) = fs::OpenOptions::new().write(true).open(dir) {
+            let _ = file.set_modified(SystemTime::now());
         }
     }
 
@@ -898,8 +943,28 @@ impl FileSystem {
                 });
 
             if old_enough {
-                let _ = fs::remove_dir_all(entry.path());
+                Self::remove_artifact_best_effort(&entry.path());
             }
+        }
+    }
+
+    /// Best-effort removal of a displaced or stale artifact, which is
+    /// usually a directory (a previous export's published output) but can
+    /// also be a plain file — e.g. after
+    /// [`crate::builder::FilesBuilder::build_and_export`] displaces a bare
+    /// top-level file to make way for a same-named subdirectory.
+    /// `fs::remove_dir_all` always fails with `NotADirectory` on a plain
+    /// file, so this falls back to [`fs::remove_file`] when that happens.
+    /// Used by both [`Self::swap_into_place`]'s immediate cleanup and
+    /// [`Self::sweep_stale_artifacts_older_than`]'s periodic sweep, so
+    /// neither permanently leaks a displaced file the way both did before —
+    /// every future sweep would otherwise re-attempt (and silently fail) the
+    /// same `remove_dir_all` on it forever. Errors from either removal are
+    /// silently discarded, matching every other call site that manages
+    /// these artifacts: this is hygiene, not part of export correctness.
+    fn remove_artifact_best_effort(path: &Path) {
+        if fs::remove_dir_all(path).is_err() {
+            let _ = fs::remove_file(path);
         }
     }
 
@@ -980,9 +1045,13 @@ impl Default for ExportOptions {
 
 /// Writes file content to disk.
 ///
-/// If `atomic` is `true`, writes to a temp file then renames it into place.
-/// Otherwise, writes directly.
-fn write_file_atomic(path: &Path, content: &str, atomic: bool) -> Result<()> {
+/// If `atomic` is `true`, writes to a temp file, `fsync`s it for durability,
+/// then renames it into place. Otherwise, writes directly.
+///
+/// `pub(crate)` so [`crate::builder::FilesBuilder::build_and_export`] can reuse this for
+/// its own bare top-level files, rather than duplicating a weaker (no-`fsync`) atomic
+/// write helper.
+pub(crate) fn write_file_atomic(path: &Path, content: &str, atomic: bool) -> Result<()> {
     if atomic {
         // Atomic write: temp file + rename
         let temp_path = path.with_added_extension("tmp");
@@ -1066,8 +1135,7 @@ mod tests {
     fn test_read_file_not_found() {
         let vfs = FileSystem::new();
         let result = vfs.read_file("/missing.ts");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_not_found());
+        assert!(matches!(result, Err(FilesError::FileNotFound { .. })));
     }
 
     #[test]
@@ -1108,8 +1176,7 @@ mod tests {
         vfs.add_file("/file.ts", "").unwrap();
 
         let result = vfs.list_dir("/file.ts");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_not_directory());
+        assert!(matches!(result, Err(FilesError::NotADirectory { .. })));
     }
 
     #[test]
@@ -1455,6 +1522,29 @@ mod tests {
     }
 
     #[test]
+    fn displace_existing_target_refreshes_displaced_mtime_for_a_file() {
+        // Regression test: `touch_dir`'s marker-file trick only works on a
+        // directory `target`; before the fix it silently no-oped when
+        // `target` was a plain file (a bare top-level file being displaced
+        // by a same-named subdirectory), so the displaced file's mtime was
+        // never refreshed and it would look stale-eligible immediately.
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("out");
+        fs::write(&target, "not a directory").unwrap();
+        let target_created_at = fs::metadata(&target).unwrap().modified().unwrap();
+
+        std::thread::sleep(Duration::from_millis(1100));
+
+        let displaced = FileSystem::displace_existing_target(&target, tmp.path()).unwrap();
+        let displaced_modified = fs::metadata(&displaced).unwrap().modified().unwrap();
+
+        assert!(
+            displaced_modified > target_created_at,
+            "displaced file's mtime must be refreshed around the rename, not inherited from target"
+        );
+    }
+
+    #[test]
     fn sweep_stale_artifacts_skips_recent_orphans() {
         let tmp = TempDir::new().unwrap();
         let target = tmp.path().join("out");
@@ -1487,6 +1577,29 @@ mod tests {
         assert!(
             !staging_path.exists(),
             "an orphan past the age threshold must be swept"
+        );
+    }
+
+    #[test]
+    fn sweep_stale_artifacts_older_than_removes_a_displaced_file() {
+        // Regression test: a displaced artifact left over from a bare-file/
+        // subdirectory name collision is a plain file, not a directory.
+        // `fs::remove_dir_all` always fails on a file, so before
+        // `remove_artifact_best_effort` existed, this entry would never be
+        // swept — a permanent per-collision leak.
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("out");
+
+        let stale_file = tmp
+            .path()
+            .join(format!(".{}.stale-fake", FileSystem::target_stem(&target)));
+        fs::write(&stale_file, "displaced file content").unwrap();
+
+        FileSystem::sweep_stale_artifacts_older_than(tmp.path(), &target, Duration::ZERO);
+
+        assert!(
+            !stale_file.exists(),
+            "a displaced file, not just a displaced directory, must be swept"
         );
     }
 
@@ -1585,6 +1698,41 @@ mod tests {
             let path = temp.path().join(format!("file{i}.ts"));
             assert!(path.exists());
         }
+    }
+
+    #[test]
+    #[cfg(feature = "parallel")]
+    fn test_export_parallel_failure_leaves_existing_target_untouched() {
+        // Direct-entry-point counterpart to
+        // `test_export_failure_leaves_existing_target_untouched`: exercises the
+        // same staging-write failure through `export_to_filesystem_parallel`
+        // itself, rather than only through the shared helpers it delegates to.
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("out");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("keep.ts"), "keep").unwrap();
+
+        let vfs = FilesBuilder::new()
+            .add_file("/conflict", "file content")
+            .add_file("/conflict/child.ts", "child content")
+            .build()
+            .unwrap();
+
+        let result = vfs.export_to_filesystem_parallel(&target);
+        assert!(result.is_err());
+
+        // The previous export must be completely untouched by the failure.
+        assert!(target.join("keep.ts").exists());
+        assert_eq!(fs::read_to_string(target.join("keep.ts")).unwrap(), "keep");
+        assert!(!target.join("conflict").exists());
+
+        // No orphaned staging directory left behind by the failed export.
+        let siblings: Vec<_> = fs::read_dir(temp.path())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.path() != target)
+            .collect();
+        assert!(siblings.is_empty(), "unexpected siblings: {siblings:?}");
     }
 
     #[test]

--- a/crates/mcp-files/src/types.rs
+++ b/crates/mcp-files/src/types.rs
@@ -21,8 +21,7 @@ use thiserror::Error;
 
 /// Errors that can occur during VFS operations.
 ///
-/// All error variants include contextual information and implement
-/// `is_xxx()` methods for easy error classification.
+/// All error variants include contextual information for diagnostics.
 ///
 /// # Examples
 ///
@@ -33,7 +32,7 @@ use thiserror::Error;
 ///     path: "/missing.txt".to_string(),
 /// };
 ///
-/// assert!(error.is_not_found());
+/// assert!(matches!(error, FilesError::FileNotFound { .. }));
 /// ```
 #[derive(Error, Debug)]
 pub enum FilesError {
@@ -95,85 +94,6 @@ pub enum FilesError {
 }
 
 impl FilesError {
-    /// Returns `true` if this is a file not found error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_files::FilesError;
-    ///
-    /// let error = FilesError::FileNotFound {
-    ///     path: "/test.txt".to_string(),
-    /// };
-    ///
-    /// assert!(error.is_not_found());
-    /// ```
-    #[must_use]
-    pub const fn is_not_found(&self) -> bool {
-        matches!(self, Self::FileNotFound { .. })
-    }
-
-    /// Returns `true` if this is a not-a-directory error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_files::FilesError;
-    ///
-    /// let error = FilesError::NotADirectory {
-    ///     path: "/file.txt".to_string(),
-    /// };
-    ///
-    /// assert!(error.is_not_directory());
-    /// ```
-    #[must_use]
-    pub const fn is_not_directory(&self) -> bool {
-        matches!(self, Self::NotADirectory { .. })
-    }
-
-    /// Returns `true` if this is an invalid path error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_files::FilesError;
-    ///
-    /// let error = FilesError::InvalidPath {
-    ///     path: "".to_string(),
-    /// };
-    ///
-    /// assert!(error.is_invalid_path());
-    /// ```
-    #[must_use]
-    pub const fn is_invalid_path(&self) -> bool {
-        matches!(
-            self,
-            Self::InvalidPath { .. }
-                | Self::PathNotAbsolute { .. }
-                | Self::InvalidPathComponent { .. }
-        )
-    }
-
-    /// Returns `true` if this is an I/O error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_files::FilesError;
-    /// use std::io;
-    ///
-    /// let error = FilesError::IoError {
-    ///     path: "/test.ts".to_string(),
-    ///     source: io::Error::from(io::ErrorKind::PermissionDenied),
-    /// };
-    ///
-    /// assert!(error.is_io_error());
-    /// ```
-    #[must_use]
-    pub const fn is_io_error(&self) -> bool {
-        matches!(self, Self::IoError { .. })
-    }
-
     /// Returns `true` if this is a resource-limit-exceeded error.
     ///
     /// # Examples
@@ -221,6 +141,9 @@ impl FilesError {
 /// // Invalid paths are rejected
 /// assert!(FilePath::new("relative/path").is_err());
 /// assert!(FilePath::new("/parent/../escape").is_err());
+/// assert!(FilePath::new("//doubled-slash.ts").is_err());
+/// assert!(FilePath::new("/./dot-component.ts").is_err());
+/// assert!(FilePath::new("/trailing-slash/").is_err());
 /// ```
 ///
 /// On Windows, Unix-style paths like "/mcp-tools/servers/test" are accepted
@@ -231,8 +154,11 @@ pub struct FilePath(String);
 impl FilePath {
     /// Creates a new `FilePath` from a path-like type.
     ///
-    /// The path must be absolute (start with '/') and must not contain parent
-    /// directory references ('..').
+    /// The path must be absolute (start with '/'), must not contain parent
+    /// directory references ('..'), and must not contain empty or '.'
+    /// components (e.g. a doubled or trailing '/', or a literal `/./`
+    /// segment) — the root path `/` itself has no components and remains
+    /// valid.
     ///
     /// `FilePath` uses Unix-style path conventions on all platforms, ensuring
     /// consistent behavior on Linux, macOS, and Windows. Paths are validated
@@ -242,7 +168,8 @@ impl FilePath {
     /// # Errors
     ///
     /// Returns `FilesError::PathNotAbsolute` if the path does not start with '/'.
-    /// Returns `FilesError::InvalidPathComponent` if the path contains '..'.
+    /// Returns `FilesError::InvalidPathComponent` if the path contains '..', or an
+    /// empty or '.' component (e.g. `//`, a trailing `/`, or `/./`).
     /// Returns `FilesError::InvalidPath` if the path is empty or not UTF-8 valid.
     ///
     /// # Examples
@@ -291,6 +218,28 @@ impl FilePath {
 
         // Check for '..' components in the path string
         if normalized_str.contains("..") {
+            return Err(FilesError::InvalidPathComponent {
+                path: normalized_str,
+            });
+        }
+
+        // Reject empty or '.' path components (e.g. "//x.ts", "/./x.ts", "/github/"):
+        // an empty component from a doubled or trailing separator would make
+        // `Path::join`/`PathBuf::join` treat a later absolute-looking remainder
+        // as escaping its base, and both would let a single-file group name
+        // collide with (and in `FilesBuilder::build_and_export`'s per-group
+        // export, swap) an unintended target — including, for an empty root
+        // component, the shared `base_path` itself. `normalized_str[1..]` is a
+        // valid string slice because `normalized_str` is guaranteed to start
+        // with the single ASCII byte `/` by the check above; it is only
+        // inspected when non-empty; the root path `/` itself has no
+        // components to check and remains valid.
+        let remainder = &normalized_str[1..];
+        if !remainder.is_empty()
+            && remainder
+                .split('/')
+                .any(|component| component.is_empty() || component == ".")
+        {
             return Err(FilesError::InvalidPathComponent {
                 path: normalized_str,
             });
@@ -359,30 +308,6 @@ impl FilePath {
                 Self(self.0[..pos].to_string())
             }
         })
-    }
-
-    /// Checks if this path is a directory path.
-    ///
-    /// A path is considered a directory if it does not have a file extension.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_files::FilePath;
-    ///
-    /// let dir = FilePath::new("/mcp-tools/servers")?;
-    /// assert!(dir.is_dir_path());
-    ///
-    /// let file = FilePath::new("/mcp-tools/manifest.json")?;
-    /// assert!(!file.is_dir_path());
-    /// # Ok::<(), mcp_execution_files::FilesError>(())
-    /// ```
-    #[must_use]
-    pub fn is_dir_path(&self) -> bool {
-        // A path is a directory if it doesn't contain a '.' after the last '/'
-        self.0
-            .rfind('/')
-            .is_some_and(|last_slash| !self.0[last_slash..].contains('.'))
     }
 }
 
@@ -491,15 +416,56 @@ mod tests {
     #[test]
     fn test_vfs_path_new_relative_fails() {
         let result = FilePath::new("relative/path");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_path());
+        assert!(matches!(result, Err(FilesError::PathNotAbsolute { .. })));
     }
 
     #[test]
     fn test_vfs_path_new_parent_dir_fails() {
         let result = FilePath::new("/parent/../escape");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_invalid_path());
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+    }
+
+    #[test]
+    fn test_vfs_path_new_doubled_slash_fails() {
+        // Regression test: an empty top-level component (from a doubled
+        // leading slash) previously slipped through validation and made
+        // `base.join("")` resolve to `base` itself downstream, letting a
+        // single-file "group" swap the shared base directory.
+        let result = FilePath::new("//x.ts");
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+    }
+
+    #[test]
+    fn test_vfs_path_new_dot_component_fails() {
+        let result = FilePath::new("/./x.ts");
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+    }
+
+    #[test]
+    fn test_vfs_path_new_trailing_slash_fails() {
+        let result = FilePath::new("/github/");
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+    }
+
+    #[test]
+    fn test_vfs_path_new_root_is_valid() {
+        // The root path itself has no components to check and must remain valid
+        // even after rejecting empty/'.' components elsewhere in the path.
+        let result = FilePath::new("/");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "/");
     }
 
     #[test]
@@ -523,15 +489,6 @@ mod tests {
     }
 
     #[test]
-    fn test_vfs_path_is_dir_path() {
-        let dir = FilePath::new("/mcp-tools/servers").unwrap();
-        assert!(dir.is_dir_path());
-
-        let file = FilePath::new("/mcp-tools/test.ts").unwrap();
-        assert!(!file.is_dir_path());
-    }
-
-    #[test]
     fn test_vfs_path_display() {
         let path = FilePath::new("/test.ts").unwrap();
         assert_eq!(format!("{path}"), "/test.ts");
@@ -549,44 +506,6 @@ mod tests {
         let file = FileEntry::new("");
         assert_eq!(file.content(), "");
         assert_eq!(file.size(), 0);
-    }
-
-    #[test]
-    fn test_vfs_error_is_not_found() {
-        let error = FilesError::FileNotFound {
-            path: "/test".to_string(),
-        };
-        assert!(error.is_not_found());
-        assert!(!error.is_not_directory());
-        assert!(!error.is_invalid_path());
-    }
-
-    #[test]
-    fn test_vfs_error_is_not_directory() {
-        let error = FilesError::NotADirectory {
-            path: "/file.txt".to_string(),
-        };
-        assert!(!error.is_not_found());
-        assert!(error.is_not_directory());
-        assert!(!error.is_invalid_path());
-    }
-
-    #[test]
-    fn test_vfs_error_is_invalid_path() {
-        let error = FilesError::InvalidPath {
-            path: String::new(),
-        };
-        assert!(error.is_invalid_path());
-
-        let error = FilesError::PathNotAbsolute {
-            path: "relative".to_string(),
-        };
-        assert!(error.is_invalid_path());
-
-        let error = FilesError::InvalidPathComponent {
-            path: "../escape".to_string(),
-        };
-        assert!(error.is_invalid_path());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `FileSystem::export_to_filesystem_parallel` and `FilesBuilder::build_and_export` are now directory-atomic, matching the guarantee already in place for `FileSystem::export_to_filesystem`. `export_to_filesystem_parallel` shares the same staging/atomic-rename mechanism via a new `stage_export` helper. `build_and_export` publishes each top-level path group in a batch atomically (since its `base_path` is a shared root across independent batches, unlike `export_to_filesystem`'s exclusively-owned target), and gained an upfront whole-batch size bound.
- `FilePath::new` now rejects empty and `.` path components, closing a latent escape where an empty top-level group could resolve to `base_path` itself and swap the entire shared root.
- Removed `FilesError::is_not_found()/is_not_directory()/is_invalid_path()/is_io_error()` and `FilePath::is_dir_path()` — dead API with no real call site anywhere in the workspace, mirroring how the identical pattern was resolved in `mcp_execution_core::Error` (#199).

Both fixes went through three rounds of adversarial critique and independent test validation (rust-critic + rust-testing-engineer) before code review.

Closes #178, closes #202

## Breaking changes

`FilesError`/`FilePath` lose the five predicate methods above; callers should `matches!()` against the concrete `FilesError` variant instead. `export_to_filesystem_parallel`/`build_and_export` now replace rather than merge into previously-exported content at the paths they touch.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (927 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Benches compile (`cargo bench --no-run --profile bench-fast`)