### PR TITLE
fix(introspector): bound stdio discovery read path against unbounded memory growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   point — the bare username is scrubbed from the rendered path as a defense-in-depth fallback
   rather than the previous behavior of returning the path unredacted.
 
+- **`mcp-execution-introspector`**: `Introspector::discover_server`'s stdio discovery path read
+  each response line from a spawned MCP server's stdout via rmcp's default `(ChildStdout,
+  ChildStdin)` transport, which buffers via an unbounded `read_until` that bypasses
+  `JsonRpcMessageCodec`'s own `max_length` entirely — a malicious or misbehaving server could
+  grow a single unterminated line without limit, and this also bypassed this crate's own
+  `MAX_TOOL_COUNT`/`MAX_SCHEMA_SIZE_BYTES` bounds, since those only run after the line has
+  already been fully buffered (#225, raised from P3 to P2 during audit: reachable from the
+  long-running `mcp-execution-server` process, not just the CLI). Stdio discovery now wires
+  stdout through a size-bounded `FramedRead` (new private `bounded_response_stream` helper,
+  4 MiB cap, matching `mcp-execution-server`'s own request-line bound though not its
+  derivation — see the constant's doc comment) instead, dropping an oversized or malformed
+  line without ending the session — a malformed-JSON line is treated as recoverable, not
+  fatal, since real MCP servers commonly log free-form text to stdout alongside the protocol
+  stream and the previous transport already tolerated that. A genuine I/O error on the
+  underlying pipe still ends the session. Recovery itself goes through a new private
+  `BoundedResponseDecoder` wrapper, not the codec directly: `tokio_util`'s `FramedRead`
+  treats any decoder error (or a bare "needs more data" signal) as reason to stop re-scanning
+  its buffer and instead wait on another underlying read, which stranded a message that was
+  already fully buffered right behind a bad line whenever the peer had nothing further to send
+  — turning the "tolerate a noisy line" policy into a stall ending in `Error::Timeout` instead.
+  The wrapper folds recoverable errors into the decoded item type and keeps decoding the
+  residual buffer immediately, so `FramedRead` never leaves its normal readable state on a
+  recoverable error. The HTTP/SSE discovery path (#226) has no equivalent fix available: `rmcp` 2.2.0's Streamable HTTP
+  client transport buffers each response body and SSE event fully in memory with no size-limit
+  config knob, and adding one from this crate would mean reimplementing a large part of that
+  transport. `Introspector::discover_server` now documents this gap in a `# Security` doc
+  section; `rmcp` 3.0.0's `max_sse_event_size` (currently only in a beta release) is the
+  concrete condition to revisit it under.
+
 ### Testing
 
 - **`mcp-execution-introspector`**: added `tests/tool_count_bound_test.rs`, an integration test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ version = "0.8.0"
 dependencies = [
  "axum",
  "criterion",
+ "futures-util",
  "http",
  "mcp-execution-core",
  "rmcp",

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -35,6 +35,7 @@ test-fixtures = [
 ]
 
 [dependencies]
+futures-util.workspace = true
 http.workspace = true
 mcp-execution-core.workspace = true
 rmcp = { workspace = true, features = [
@@ -44,10 +45,16 @@ rmcp = { workspace = true, features = [
     # the `reqwest` dependency without a TLS backend.
     "reqwest",
     "transport-streamable-http-client-reqwest",
+    # Explicit rather than relying on the implicit `default -> server` path: this
+    # is a client-only crate, and `JsonRpcMessageCodec` (used to bound the stdio
+    # discovery read path, see `bounded_response_stream`) lives behind this
+    # feature.
+    "transport-async-rw",
 ] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time"] }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 
 [dev-dependencies]
@@ -55,4 +62,3 @@ axum.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util", "macros", "net"] }
-tokio-util.workspace = true

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -44,17 +44,26 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations)]
 
+use futures_util::StreamExt;
+use futures_util::stream::{self, Stream};
 use http::{HeaderName, HeaderValue};
 use mcp_execution_core::{
     Error, Result, ServerConfig, ServerId, ToolName, TransportType, validate_server_config,
 };
+use rmcp::RoleClient;
 use rmcp::ServiceExt;
+use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::transport::async_rw::{JsonRpcMessageCodec, JsonRpcMessageCodecError};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::process::Stdio;
+use std::task::Poll;
+use tokio::io::AsyncRead;
 use tokio::process::Child;
+use tokio_util::bytes::BytesMut;
+use tokio_util::codec::{Decoder, FramedRead, FramedWrite};
 
 /// Maximum number of tools accepted from a single MCP server's `list_all_tools` response
 /// (denial-of-service protection, CWE-400).
@@ -115,6 +124,34 @@ pub const MAX_TOOL_DESCRIPTION_LEN: usize = 8 * 1024;
 /// assert!(MAX_SCHEMA_SIZE_BYTES > 0);
 /// ```
 pub const MAX_SCHEMA_SIZE_BYTES: usize = 64 * 1024;
+
+/// Maximum size, in bytes, of a single newline-delimited JSON-RPC response line read from a
+/// stdio MCP server's stdout during introspection (issue #225). Lines exceeding this are
+/// discarded rather than buffered without bound.
+///
+/// `rmcp`'s default transport for a raw `(ChildStdout, ChildStdin)` pair (`AsyncRwTransport`)
+/// reads lines via an unbounded `read_until`, bypassing [`JsonRpcMessageCodec`]'s `max_length`
+/// entirely — see [`bounded_response_stream`], which wires stdout through the codec directly
+/// instead. No shared line-size constant exists elsewhere in the workspace to reuse, so this
+/// matches `mcp-execution-server`'s `MAX_REQUEST_LINE_SIZE` value for consistency — though not
+/// its derivation: that constant was sized from measured real payloads on a different trust
+/// boundary (inbound requests from an already-trusted local client). This one bounds an
+/// untrusted MCP server's responses and is deliberately *not* sized to the crate's own
+/// worst-case accepted `tools/list` response: [`MAX_TOOL_COUNT`] (1000) tools at up to
+/// [`MAX_SCHEMA_SIZE_BYTES`] (64 KiB) each for input and output schema, plus
+/// [`MAX_TOOL_DESCRIPTION_LEN`] (8 KiB), allows a single unpaginated response over 100 MB —
+/// setting the cap that high would defeat the point of bounding memory here. A conforming
+/// server is expected to paginate a tool list that large; one that instead sends it as a
+/// single line over this cap has that line dropped by [`bounded_response_stream`] (logged, not
+/// silently discarded), and the request it was answering then runs out its
+/// [`ServerConfig::discover_timeout`] with no reply, surfacing to the caller as
+/// [`Error::Timeout`] rather than a distinct size-limit error — there is no request id to
+/// correlate a dropped, unparsed line back to. `tokio_util`'s internal read buffer also grows
+/// by doubling and is only checked against this bound after a read fills whatever capacity it
+/// already reserved, so an attacker's oversized line can push peak buffer capacity to roughly
+/// 4x this value before it is rejected — still strictly bounded, just not 1:1 with the cap
+/// (mirrors `mcp-execution-server`'s own documented behavior for the same codec).
+const MAX_RESPONSE_LINE_SIZE: usize = 4 * 1024 * 1024;
 
 /// Information about an MCP server.
 ///
@@ -316,6 +353,27 @@ impl Introspector {
     /// - Connection to the server fails
     /// - Server does not respond to capability queries
     /// - Server response is malformed
+    ///
+    /// # Security
+    ///
+    /// The stdio transport ([`TransportType::Stdio`], handled by the private
+    /// `discover_via_stdio`) bounds every response line read from the server's stdout to a
+    /// fixed maximum size (issue #225). A line over that bound is dropped rather than
+    /// erroring loudly: since it was never fully parsed, there is no request id to
+    /// attribute a distinct error to, so the request it was answering instead runs out its
+    /// configured timeout below and surfaces as [`Error::Timeout`].
+    ///
+    /// The HTTP/SSE transport ([`TransportType::Http`], [`TransportType::Sse`], handled by
+    /// the private `discover_via_http`) has **no** such bound (issue #226): `rmcp` 2.2.0's Streamable
+    /// HTTP client transport buffers each JSON response body and each SSE event fully in
+    /// memory before this crate's own [`MAX_TOOL_COUNT`]/[`MAX_SCHEMA_SIZE_BYTES`] checks
+    /// ever run, with no size-limit config knob to bound that buffering. This is a known
+    /// upstream gap, not something fixable from this crate without re-implementing a large
+    /// part of `rmcp`'s HTTP transport. The only mitigation in place is
+    /// [`ServerConfig::discover_timeout`], which bounds how long an unbounded response can
+    /// be read for, not how large it can grow. rmcp 3.0.0-beta.2 adds the missing
+    /// `max_sse_event_size` config knob (still only for SSE events, not JSON response
+    /// bodies); revisit this gap once rmcp ships a 3.0.0 stable release with that fix.
     ///
     /// # Examples
     ///
@@ -676,6 +734,141 @@ fn map_list_tools_bounded_error(server_id: &ServerId, error: ListToolsBoundedErr
     }
 }
 
+/// [`Decoder`] wrapper around [`JsonRpcMessageCodec`] that folds a recoverable per-line
+/// error (oversized, malformed, or a skipped non-standard notification) into a decoded
+/// `Item` instead of a `Decoder::Error` (issue #225).
+///
+/// This is required for correctness, not just style. `tokio_util`'s `FramedImpl` treats
+/// *any* `Decoder::decode` `Err` as terminal for the current read: on the very next poll
+/// it sets `is_readable = false` and returns `None` without ever calling `decode` again
+/// on the buffer that error came from, instead going straight to another underlying
+/// `poll_read`. The same happens on a bare `Ok(None)` — including the "skip non-standard
+/// message" case inside [`JsonRpcMessageCodec::decode`], which still consumes the
+/// skipped line from the buffer before returning it. If a well-formed message is already
+/// sitting in the buffer right behind the bad or skipped line — realistic any time a
+/// server flushes `"log line\n{...valid response...}\n"` in one write, exactly the case
+/// the recoverable-error policy exists for — and the peer sends nothing further because
+/// it is waiting on us, that next `poll_read` blocks forever: the buffered message is
+/// never redelivered, and discovery stalls until [`Error::Timeout`] instead of the
+/// bounded-but-tolerant behavior intended. The `AsyncRwTransport`/`BufReader::read_until`
+/// this replaces did not have this failure mode, since it serves the next already-read
+/// line from its own buffer without another I/O read.
+///
+/// Wrapping the codec avoids this: `decode`/`decode_eof` here only ever return
+/// [`std::io::Error`] for a genuine I/O fault (never a plain `Ok(None)` after consuming
+/// bytes, and never an `Err` for a recoverable case), so `FramedImpl` never leaves its
+/// normal readable/framing state on a recoverable error — it keeps calling `decode`
+/// against the residual buffer exactly as it does for any other successfully decoded
+/// frame. The inner loop mirrors that: whenever [`JsonRpcMessageCodec::decode`] consumes
+/// bytes without producing an `Item` (the skip case), this decoder calls it again
+/// immediately rather than reporting "needs more data", since a further frame may
+/// already be sitting in what is left of the buffer.
+struct BoundedResponseDecoder {
+    inner: JsonRpcMessageCodec<RxJsonRpcMessage<RoleClient>>,
+}
+
+impl BoundedResponseDecoder {
+    /// Runs `decode_step` in a loop, following [`JsonRpcMessageCodec`]'s "skip and keep
+    /// scanning" behavior: an `Ok(None)` that consumed bytes may have a further frame
+    /// sitting right behind it, so `decode_step` is called again immediately; an `Ok(None)`
+    /// that made no progress genuinely means more input is needed, and a recoverable
+    /// [`JsonRpcMessageCodecError`] is reported as an `Item` rather than looped on, so the
+    /// caller can log it once per bad line instead of the underlying codec's own internal
+    /// discard loop being observed as a single opaque error.
+    fn drive(
+        buf: &mut BytesMut,
+        mut decode_step: impl FnMut(
+            &mut BytesMut,
+        ) -> std::result::Result<
+            Option<RxJsonRpcMessage<RoleClient>>,
+            JsonRpcMessageCodecError,
+        >,
+    ) -> std::io::Result<
+        Option<std::result::Result<RxJsonRpcMessage<RoleClient>, JsonRpcMessageCodecError>>,
+    > {
+        loop {
+            let before = buf.len();
+            return match decode_step(buf) {
+                Ok(Some(message)) => Ok(Some(Ok(message))),
+                Ok(None) => {
+                    if buf.len() < before {
+                        continue;
+                    }
+                    Ok(None)
+                }
+                Err(JsonRpcMessageCodecError::Io(error)) => Err(error),
+                Err(error) => Ok(Some(Err(error))),
+            };
+        }
+    }
+}
+
+impl Decoder for BoundedResponseDecoder {
+    type Item = std::result::Result<RxJsonRpcMessage<RoleClient>, JsonRpcMessageCodecError>;
+    type Error = std::io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> std::io::Result<Option<Self::Item>> {
+        Self::drive(buf, |buf| self.inner.decode(buf))
+    }
+
+    fn decode_eof(&mut self, buf: &mut BytesMut) -> std::io::Result<Option<Self::Item>> {
+        Self::drive(buf, |buf| self.inner.decode_eof(buf))
+    }
+}
+
+/// Wraps a size-bounded [`FramedRead`] over an MCP server's stdout so one oversized,
+/// malformed, or skipped response line is dropped without ending the introspection
+/// session (via [`BoundedResponseDecoder`]), while a genuine I/O error still ends it
+/// (issue #225).
+///
+/// Client-side counterpart to `mcp-execution-server`'s `bounded_request_stream`, but
+/// deliberately simpler — it must not be shared with that server-side helper:
+/// - No concurrency admission gate. `rmcp`'s `serve_inner` is role-generic and does spawn
+///   an unbounded `tokio::spawn` per inbound request for [`RoleClient`] too, the same
+///   mechanism the server-side gate defends against — so the omission here is not because
+///   the client "has no inbound requests to admit". It is safe for different reasons: the
+///   handler driving this stream is `()` (the unit `Service` impl), so each such spawned
+///   task is a trivial method-not-found reply rather than the server's own handlers (which
+///   can run for minutes and allocate hundreds of MB); the session as a whole is already
+///   bounded by `config`'s `connect_timeout`/`discover_timeout`; and the child process is
+///   killed unconditionally once discovery returns (see [`discover_via_stdio_process`]).
+/// - [`JsonRpcMessageCodecError::Serde`] is recoverable here, not just
+///   `MaxLineLengthExceeded`: the `AsyncRwTransport` this replaces already tolerated any
+///   unparsable stdout line, and real MCP servers commonly log free-form text to stdout
+///   alongside the protocol stream. Treating a parse failure as fatal here would regress
+///   introspection against servers that work fine today.
+fn bounded_response_stream<R>(
+    reader: R,
+    max_length: usize,
+) -> impl Stream<Item = RxJsonRpcMessage<RoleClient>> + Send + Unpin + 'static
+where
+    R: AsyncRead + Send + Unpin + 'static,
+{
+    let mut framed = FramedRead::new(
+        reader,
+        BoundedResponseDecoder {
+            inner: JsonRpcMessageCodec::new_with_max_length(max_length),
+        },
+    );
+    stream::poll_fn(move |cx| {
+        loop {
+            return match framed.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(Ok(message)))) => Poll::Ready(Some(message)),
+                Poll::Ready(Some(Ok(Err(error)))) => {
+                    tracing::warn!(%error, "dropping oversized or malformed response line from MCP server");
+                    continue;
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    tracing::error!(%error, "introspection stdout read failed; ending discovery session");
+                    Poll::Ready(None)
+                }
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+    })
+}
+
 /// Connects to an already-spawned MCP server over `transport` and lists its
 /// tools, with each step bounded by `config`'s configured timeouts.
 ///
@@ -692,8 +885,19 @@ async fn discover_via_stdio(
     config: &ServerConfig,
     transport: (tokio::process::ChildStdout, tokio::process::ChildStdin),
 ) -> Result<DiscoveryResult> {
+    // The default `(ChildStdout, ChildStdin)` transport (`AsyncRwTransport`) reads
+    // lines via an unbounded `read_until`, bypassing `JsonRpcMessageCodec`'s
+    // `max_length` entirely (issue #225). Building the sink/stream pair explicitly
+    // routes stdout through `bounded_response_stream` instead.
+    let (stdout, stdin) = transport;
+    let sink = FramedWrite::new(
+        stdin,
+        JsonRpcMessageCodec::<TxJsonRpcMessage<RoleClient>>::new(),
+    );
+    let stream = bounded_response_stream(stdout, MAX_RESPONSE_LINE_SIZE);
+
     // Create client using serve pattern, bounded by the connect timeout
-    let client = tokio::time::timeout(config.connect_timeout(), ().serve(transport))
+    let client = tokio::time::timeout(config.connect_timeout(), ().serve((sink, stream)))
         .await
         .map_err(|_elapsed| Error::Timeout {
             operation: format!("connect to {server_id}"),
@@ -731,6 +935,13 @@ async fn discover_via_stdio(
 /// has a single client transport for network MCP servers ("Streamable
 /// HTTP"), which superseded the standalone SSE transport in the 2025-03-26
 /// MCP spec revision. There is no legacy SSE-only client to fall back to.
+///
+/// Unlike stdio discovery, this path has no response-size bound (issue #226): `rmcp`
+/// 2.2.0's Streamable HTTP client transport buffers each JSON response body and SSE
+/// event fully in memory with no config knob to cap it, and this crate has no
+/// injection point to add one without re-implementing a large part of that transport.
+/// See [`Introspector::discover_server`]'s `# Security` docs for the full rationale and
+/// the upstream condition to revisit this under.
 ///
 /// # Errors
 ///
@@ -957,6 +1168,361 @@ fn fallback_server_name(config: &ServerConfig) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── bounded_response_stream (issue #225) ─────────────────────────────────
+
+    mod bounded_response_stream_tests {
+        use super::*;
+        use std::io;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::task::Context;
+        use tokio::io::ReadBuf;
+        use tokio_util::bytes::Buf;
+
+        const TEST_MAX: usize = 64;
+
+        fn oversized_line() -> Vec<u8> {
+            let mut line = vec![b'x'; TEST_MAX * 3];
+            line.push(b'\n');
+            line
+        }
+
+        fn valid_notification_line() -> Vec<u8> {
+            br#"{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}"#
+                .iter()
+                .copied()
+                .chain(std::iter::once(b'\n'))
+                .collect()
+        }
+
+        fn malformed_json_line() -> Vec<u8> {
+            b"{not valid json\n".to_vec()
+        }
+
+        /// `AsyncRead` that yields a fixed script of chunks in order, then a clean EOF.
+        struct Script {
+            chunks: Vec<Vec<u8>>,
+            idx: usize,
+        }
+
+        impl AsyncRead for Script {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                buf: &mut ReadBuf<'_>,
+            ) -> Poll<io::Result<()>> {
+                if self.idx < self.chunks.len() {
+                    let chunk = self.chunks[self.idx].clone();
+                    self.idx += 1;
+                    debug_assert!(
+                        chunk.len() <= buf.remaining(),
+                        "test fixture chunk exceeds the reader's spare buffer capacity"
+                    );
+                    buf.put_slice(&chunk);
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Ready(Ok(())) // 0 bytes read signals EOF
+            }
+        }
+
+        /// Number of times `ErrAfter` returns a real error before giving up and signaling
+        /// EOF. Bounds the fixture itself so that if a regression ever makes
+        /// `bounded_response_stream` treat an I/O error as recoverable again, the resulting
+        /// test fails its assertion instead of spinning forever with no `Poll::Pending`.
+        const MAX_ERR_AFTER_POLLS: usize = 8;
+
+        /// `AsyncRead` that yields a fixed script, then a persistent I/O error up to
+        /// `MAX_ERR_AFTER_POLLS` times, then a clean EOF; counts how many errors it returned.
+        struct ErrAfter {
+            chunks: Vec<Vec<u8>>,
+            idx: usize,
+            error_polls: Arc<AtomicUsize>,
+        }
+
+        impl AsyncRead for ErrAfter {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                buf: &mut ReadBuf<'_>,
+            ) -> Poll<io::Result<()>> {
+                if self.idx < self.chunks.len() {
+                    let chunk = self.chunks[self.idx].clone();
+                    self.idx += 1;
+                    debug_assert!(
+                        chunk.len() <= buf.remaining(),
+                        "test fixture chunk exceeds the reader's spare buffer capacity"
+                    );
+                    buf.put_slice(&chunk);
+                    return Poll::Ready(Ok(()));
+                }
+                if self.error_polls.fetch_add(1, Ordering::SeqCst) >= MAX_ERR_AFTER_POLLS {
+                    return Poll::Ready(Ok(())); // give up: signal EOF so a regression fails loudly
+                }
+                Poll::Ready(Err(io::Error::other("persistent read failure")))
+            }
+        }
+
+        #[tokio::test]
+        async fn recovers_from_oversized_lines_and_keeps_reading() {
+            let script = Script {
+                chunks: vec![
+                    oversized_line(),
+                    oversized_line(),
+                    valid_notification_line(),
+                ],
+                idx: 0,
+            };
+            let mut stream = bounded_response_stream(script, TEST_MAX);
+
+            assert!(
+                stream.next().await.is_some(),
+                "the trailing valid line must still decode after two oversized lines"
+            );
+            assert!(
+                stream.next().await.is_none(),
+                "stream ends cleanly at EOF after the valid message"
+            );
+        }
+
+        #[tokio::test]
+        async fn recovers_from_malformed_json_and_keeps_reading() {
+            // Diverges from mcp-server's request-side helper's threat model: a noisy
+            // third-party MCP server logging free-form text to stdout must not abort
+            // discovery, since `AsyncRwTransport` (the path this replaces) tolerated it.
+            let script = Script {
+                chunks: vec![malformed_json_line(), valid_notification_line()],
+                idx: 0,
+            };
+            let mut stream = bounded_response_stream(script, TEST_MAX);
+
+            assert!(
+                stream.next().await.is_some(),
+                "the trailing valid line must still decode after a malformed line"
+            );
+            assert!(stream.next().await.is_none());
+        }
+
+        #[tokio::test]
+        async fn ends_cleanly_on_unterminated_oversized_line_then_eof() {
+            let script = Script {
+                chunks: vec![vec![b'y'; TEST_MAX * 3]], // no trailing newline
+                idx: 0,
+            };
+            let mut stream = bounded_response_stream(script, TEST_MAX);
+            assert!(stream.next().await.is_none());
+        }
+
+        #[tokio::test]
+        async fn ends_session_on_persistent_io_error_without_spinning() {
+            let error_polls = Arc::new(AtomicUsize::new(0));
+            let reader = ErrAfter {
+                chunks: vec![valid_notification_line()],
+                idx: 0,
+                error_polls: error_polls.clone(),
+            };
+            let mut stream = bounded_response_stream::<ErrAfter>(reader, TEST_MAX);
+
+            assert!(
+                stream.next().await.is_some(),
+                "the valid line decodes before the reader starts failing"
+            );
+            assert!(
+                stream.next().await.is_none(),
+                "a persistent I/O error must end the session rather than recover"
+            );
+            assert_eq!(
+                error_polls.load(Ordering::SeqCst),
+                1,
+                "the I/O error must be surfaced on the first failing poll, not retried in a hot loop"
+            );
+        }
+
+        #[tokio::test]
+        async fn accepts_line_at_exact_cap_and_rejects_one_byte_over() {
+            // The codec's length check runs on raw byte count before any JSON parsing, so
+            // the rejected case doesn't need to be valid JSON — only the accepted case does.
+            let mut content = valid_notification_line();
+            assert_eq!(content.pop(), Some(b'\n'), "fixture must end in a newline");
+            let boundary_max = content.len();
+
+            let mut at_cap = content.clone();
+            at_cap.push(b'\n');
+            let mut stream = bounded_response_stream(
+                Script {
+                    chunks: vec![at_cap],
+                    idx: 0,
+                },
+                boundary_max,
+            );
+            assert!(
+                stream.next().await.is_some(),
+                "a line whose content is exactly max_length bytes must be accepted"
+            );
+            assert!(stream.next().await.is_none());
+
+            let mut one_over = content;
+            one_over.push(b' ');
+            one_over.push(b'\n');
+            let mut stream = bounded_response_stream(
+                Script {
+                    chunks: vec![one_over],
+                    idx: 0,
+                },
+                boundary_max,
+            );
+            assert!(
+                stream.next().await.is_none(),
+                "a line one byte over max_length must be dropped, not accepted"
+            );
+        }
+
+        // ── C1 regression: a message already buffered behind a bad line must not
+        // strand until another underlying read arrives (see `BoundedResponseDecoder`'s
+        // doc comment). `Script` above delivers each scripted chunk on its own
+        // `poll_read`, which never exercises this: it always gives `FramedRead` a
+        // fresh underlying read to recover on, masking the bug. `Idle` below instead
+        // delivers everything in one `poll_read` and then returns `Poll::Pending`
+        // forever — modeling a peer that flushed once and is now waiting on us, the
+        // scenario that actually stalled before this fix.
+
+        /// `AsyncRead` that delivers a fixed script of chunks, then returns
+        /// `Poll::Pending` forever — never EOF — modeling a peer that flushed once and
+        /// is now idle awaiting our next request.
+        struct Idle {
+            chunks: Vec<Vec<u8>>,
+            idx: usize,
+        }
+
+        impl AsyncRead for Idle {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                buf: &mut ReadBuf<'_>,
+            ) -> Poll<io::Result<()>> {
+                if self.idx < self.chunks.len() {
+                    let chunk = self.chunks[self.idx].clone();
+                    self.idx += 1;
+                    debug_assert!(
+                        chunk.len() <= buf.remaining(),
+                        "test fixture chunk exceeds the reader's spare buffer capacity"
+                    );
+                    buf.put_slice(&chunk);
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending
+            }
+        }
+
+        /// Polls `stream.next()` with a bounded timeout so a regression that strands a
+        /// buffered message (issue #225 C1) fails the test with a clear panic instead
+        /// of hanging.
+        async fn next_or_timeout<S>(stream: &mut S) -> Option<S::Item>
+        where
+            S: Stream + Unpin,
+        {
+            tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+                .await
+                .expect("stream.next() must resolve within 2s instead of stalling")
+        }
+
+        #[tokio::test]
+        async fn recovers_within_a_single_read_malformed_then_valid() {
+            let mut chunk = malformed_json_line();
+            chunk.extend(valid_notification_line());
+            let mut stream = bounded_response_stream(
+                Idle {
+                    chunks: vec![chunk],
+                    idx: 0,
+                },
+                TEST_MAX,
+            );
+
+            assert!(
+                next_or_timeout(&mut stream).await.is_some(),
+                "a valid message buffered right behind a malformed line in the same \
+                 read must still be delivered, not stall until the peer sends more"
+            );
+        }
+
+        #[tokio::test]
+        async fn recovers_within_a_single_read_oversized_then_valid() {
+            let mut chunk = oversized_line();
+            chunk.extend(valid_notification_line());
+            let mut stream = bounded_response_stream(
+                Idle {
+                    chunks: vec![chunk],
+                    idx: 0,
+                },
+                TEST_MAX,
+            );
+
+            assert!(
+                next_or_timeout(&mut stream).await.is_some(),
+                "a valid message buffered right behind an oversized line in the same \
+                 read must still be delivered, not stall until the peer sends more"
+            );
+        }
+
+        // `JsonRpcMessageCodec`'s "skip non-standard message" path (`Ok(None)` after
+        // consuming a line) is the third trigger for `BoundedResponseDecoder::drive`'s
+        // internal retry loop, alongside the malformed/oversized cases above — but it
+        // turns out to be unreachable through real JSON in this rmcp version: `rmcp` 2.2.0
+        // added `CustomNotification`/`CustomRequest` catch-all variants to
+        // `ServerNotification`/`ServerRequest` that structurally match any
+        // notification/request-shaped JSON regardless of its `method` string, so any input
+        // that would have hit the "skip" fallback in an older rmcp now just decodes
+        // successfully as a `Custom*` message on the first attempt (verified directly
+        // against `serde_json::from_str::<RxJsonRpcMessage<RoleClient>>`). `drive`'s retry
+        // loop is exercised directly instead, independent of whether the underlying codec
+        // can currently produce that shape — it is still part of `Decoder::decode`'s
+        // documented contract and could reactivate for a future rmcp version or role.
+        #[test]
+        fn drive_retries_immediately_after_a_step_that_consumed_without_producing_an_item() {
+            let message: RxJsonRpcMessage<RoleClient> = serde_json::from_slice(
+                &valid_notification_line()[..valid_notification_line().len() - 1],
+            )
+            .expect("fixture notification must parse");
+            let mut calls = 0u32;
+            let mut buf = BytesMut::from(&b"stand-in bytes, contents are irrelevant"[..]);
+
+            let result = BoundedResponseDecoder::drive(&mut buf, |buf| {
+                calls += 1;
+                if calls == 1 {
+                    // Mirrors the codec's own "skip" behavior: consumes bytes but
+                    // produces no item.
+                    let half = buf.len() / 2;
+                    buf.advance(half);
+                    Ok(None)
+                } else {
+                    Ok(Some(message.clone()))
+                }
+            });
+
+            assert!(
+                matches!(result, Ok(Some(Ok(_)))),
+                "a message must be delivered from the same `drive` call, not deferred to \
+                 the next poll, when the prior decode step consumed bytes without \
+                 producing an item"
+            );
+            assert_eq!(
+                calls, 2,
+                "decode_step must be retried immediately after it makes forward progress"
+            );
+        }
+
+        #[test]
+        fn drive_reports_needs_more_data_when_no_progress_is_made() {
+            let mut buf = BytesMut::from(&b"an incomplete line with no delimiter yet"[..]);
+            let result = BoundedResponseDecoder::drive(&mut buf, |_buf| Ok(None));
+
+            assert!(
+                matches!(result, Ok(None)),
+                "drive must not loop forever when decode_step makes no progress at all"
+            );
+        }
+    }
 
     #[test]
     fn test_introspector_new() {


### PR DESCRIPTION
## Summary

- Bounds `Introspector::discover_server`'s stdio discovery read path (#225): stdout now flows through a size-limited `FramedRead` (new `bounded_response_stream` helper, `MAX_RESPONSE_LINE_SIZE` = 4 MiB) instead of rmcp's default unbounded `(ChildStdout, ChildStdin)` transport, which bypassed both `JsonRpcMessageCodec`'s `max_length` and this crate's own `MAX_TOOL_COUNT`/`MAX_SCHEMA_SIZE_BYTES` bounds.
- A new `BoundedResponseDecoder` wrapper folds recoverable per-line outcomes (oversized line, malformed JSON) into the decoded item instead of returning a decoder error, so `FramedRead` never gets stuck re-polling I/O when a valid response is already buffered right behind a bad line — a real MCP server commonly interleaves free-form log text with the protocol stream on stdout, and the previous transport tolerated that.
- Documents the equivalent gap on the HTTP/SSE discovery path (#226) as a known, currently unfixable limitation: rmcp 2.2.0's Streamable HTTP transport has no body/frame size-limit configuration point, and no interim mitigation (delegating middleware) proved viable without reimplementing a large part of the transport.
- Relabels #225 from P3 to P2: this path is reachable from the long-running `mcp-execution-server` process, not just one-shot CLI usage, and it bypassed bounds this crate already pays for elsewhere.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (911/911 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`
- [x] New regression tests cover the single-`poll_read`-chunk-with-two-frames scenario that the fix specifically addresses (bad line + valid response delivered in one read)
- [x] `CHANGELOG.md` updated under `[Unreleased]`

Closes #225. #226 stays open, tracked as upstream-blocked pending a stable rmcp release exposing a size-limit configuration point.