### PR TITLE
docs(codegen): document tsconfig.json leaf-configuration behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backfilled `# Examples` doc-test sections for ~50 public types and functions across the workspace that previously lacked runnable examples, including `ServerConfig` getters, CLI formatters, command structs, and resource limit constants (#189).
 - Added justification comments to 3 undocumented `#[allow(...)]` clippy attributes explaining the tradeoff for each (#186).
 - Documented that `ServerConfig`'s `Serialize` output is a separate code path from its redacting `Debug` impl and is not covered by that guarantee — serialized output must never be logged or printed directly (#247).
+- Documented `tsconfig.json` leaf-configuration behavior in `mcp-codegen` crate docs and README: generated `tsconfig.json` is not intended to be `extends`-ed (silent `noEmit` inheritance), is regenerated on every `generate` run, and the generated package should be executed or type-checked as a separate process rather than merged into the consumer's own TypeScript compilation (#258).
 
 ### Breaking
 

--- a/crates/mcp-codegen/README.md
+++ b/crates/mcp-codegen/README.md
@@ -55,6 +55,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 > [!TIP]
 > Generated files include: one `.ts` file per tool, `index.ts` re-exports, and `_runtime/mcp-bridge.ts` helper.
 
+### Generated Files: `tsconfig.json` is a Leaf Configuration
+
+The generator produces `package.json`, `tsconfig.json`, and one `.ts` file per tool. Both JSON files are regenerated on every `generate` call — **manual edits will be lost.**
+
+**Important:** The generated `tsconfig.json` is a **leaf configuration** not intended to be `extends`-ed by other TypeScript configs. If your own `tsconfig.json` extends the generated one, `"noEmit": true` will be inherited, which silently prevents your TypeScript build from emitting output.
+
+**Do not extend the generated `tsconfig.json`.** The generated TypeScript files are a standalone package meant to be executed or type-checked separately from your own build:
+
+- Execute directly via a TS-aware runtime: `tsx`, `deno`, or Node.js's native type-stripping.
+- Or type-check independently: run `tsc -p <generated-dir>` as a separate build step.
+- If using a bundler (esbuild, swc, Vite, etc.) that doesn't enforce TypeScript's `noEmit` constraint, consult your bundler's documentation for mixing `noEmit` and emitting configurations.
+
 ### Token Savings
 
 | Approach | Tokens | Savings |

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -109,6 +109,8 @@ const PACKAGE_JSON: &str = "{\"type\":\"module\",\"devDependencies\":{\"@types/n
 
 /// Contents of the generated `tsconfig.json`.
 ///
+/// ## Implementation rationale (for maintainers)
+///
 /// Tool files import the runtime bridge with an explicit `.ts` extension (see
 /// `tool.ts.hbs`), which requires `allowImportingTsExtensions`. TypeScript requires `noEmit`
 /// (or a declaration/emit setting) whenever `allowImportingTsExtensions` is set, since that
@@ -121,6 +123,29 @@ const PACKAGE_JSON: &str = "{\"type\":\"module\",\"devDependencies\":{\"@types/n
 /// --noEmit` fails with `TS2591`/`TS2503` under TS 7 even with `@types/node` correctly
 /// installed, unless `types` names it explicitly. Listing it explicitly works identically
 /// under both major versions.
+///
+/// ## Consumer guidance (intended behavior for users)
+///
+/// **This is a leaf configuration, not intended to be extended.** If a consumer's own
+/// `tsconfig.json` uses `"extends"` to reference the generated one, `"noEmit": true` will be
+/// inherited silently, preventing their own build from emitting output. **Do not extend this
+/// file.**
+///
+/// **This file is regenerated on every `generate` call.** Any manual edits are lost when
+/// `mcp-execution generate` runs again, the same as `package.json`. Treat the generated
+/// `tsconfig.json` as read-only.
+///
+/// **How to use the generated package:** The generated TypeScript files are a standalone
+/// package meant to be executed or type-checked as a separate process, not merged into your
+/// own TypeScript compilation:
+/// - Execute the generated code directly via a TS-aware runtime: `tsx` (for Node.js),
+///   `deno`, or Node.js's native type-stripping (when available).
+/// - Or type-check it independently: run `tsc -p <generated-dir>` as a separate build step,
+///   without merging it into your own `include`-based program.
+/// - If your own build uses a bundler (esbuild, swc, Vite, etc.) that doesn't enforce
+///   TypeScript's `noEmit` constraint, you may be able to bundle the generated files
+///   alongside your code (consult your bundler's documentation for mixing `noEmit`
+///   and emitting configurations).
 const TSCONFIG_JSON: &str = r#"{
   "compilerOptions": {
     "target": "ES2022",


### PR DESCRIPTION
## Summary
- Document that the generated `tsconfig.json` is a leaf configuration not intended to be `extends`-ed: doing so silently inherits `noEmit: true` and prevents a consumer's own build from emitting output
- Clarify that `tsconfig.json` (like `package.json`) is regenerated on every `generate` run, so manual edits are lost
- Provide working guidance for consumers: run or type-check the generated package as a separate process (a TS-aware runtime, a standalone `tsc -p`, or a bundler that doesn't enforce `noEmit`) rather than merging it into their own TypeScript compilation

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo test --doc -p mcp-execution-codegen`
- [x] `cargo +stable clippy --all-targets --all-features -p mcp-execution-codegen -- -D warnings`
- [x] Documentation-only change verified against the actual generated `tsconfig.json`/`.ts` content with `tsc`, `tsx`, and `esbuild`

Closes #258