### PR TITLE
cli: bundle resolve_server_config's positional args into RawServerArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `generate::run` keep their existing flat parameter lists and build `TransportArgs`
   internally.
 
+- **`mcp-execution-cli`**: `resolve_server_config`'s ten same-typed positional parameters
+  (`from_config`, `server`, `args`, `env`, `cwd`, `http`, `sse`, `headers`,
+  `connect_timeout_secs`, `discover_timeout_secs`) are now bundled into a single
+  `RawServerArgs` struct, which `introspect::run`/`generate::run` also take instead of
+  forwarding the same ten values positionally — superseding the "keep their existing flat
+  parameter lists" note above; `runner::dispatch` now builds `RawServerArgs` from each
+  `Commands` variant's already-named fields instead of re-listing them positionally. Several
+  of these parameters share a type and sit adjacent in the old signatures (`http`/`sse` most
+  notably), so a future reorder or insertion could previously compile cleanly while silently
+  swapping which transport a value was routed to; the struct's named-field construction removes
+  that risk. `RawServerArgs` is `pub`, not `pub(crate)`, because `introspect::run`/
+  `generate::run` are themselves `pub` in the `pub mod commands` — this widens the crate's
+  public API surface, though `mcp-execution-cli` is pre-1.0 with no known downstream library
+  consumers depending on this shape (#286).
+
 - **`mcp-execution-server`**: `introspect_server`'s `output_dir` parameter changed meaning from
   an absolute target directory (any path the caller supplied was used verbatim) to a directory
   *relative to* `~/.claude/servers/{server_id}/`, as part of the path-confinement fix below

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -835,8 +835,89 @@ pub(crate) fn build_server_config(
     Ok((server_id, builder.build()?))
 }
 
+/// Raw, same-typed server transport/timeout arguments as accepted from the CLI.
+///
+/// Bundles the fields shared by `introspect` and `generate` (config-file
+/// selector, transport flags, and timeout overrides) into a single named
+/// struct so callers can't accidentally transpose two `Option<String>` or
+/// `Vec<String>` fields (e.g. `http`/`sse`) by passing them in the wrong
+/// positional order — see issue #286.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_cli::commands::common::RawServerArgs;
+///
+/// let raw = RawServerArgs {
+///     from_config: None,
+///     server: Some("github-mcp-server".to_string()),
+///     args: vec!["stdio".to_string()],
+///     env: vec![],
+///     cwd: None,
+///     http: None,
+///     sse: None,
+///     headers: vec![],
+///     connect_timeout_secs: None,
+///     discover_timeout_secs: None,
+/// };
+///
+/// assert_eq!(raw.server.as_deref(), Some("github-mcp-server"));
+/// ```
+#[derive(Default)]
+pub struct RawServerArgs {
+    /// Load server config from `~/.claude/mcp.json` by name.
+    pub from_config: Option<String>,
+    /// Server command (binary name or path), `None` for HTTP/SSE.
+    pub server: Option<String>,
+    /// Arguments to pass to the server command.
+    pub args: Vec<String>,
+    /// Environment variables in `KEY=VALUE` format.
+    pub env: Vec<String>,
+    /// Working directory for the server process.
+    pub cwd: Option<String>,
+    /// HTTP transport URL.
+    pub http: Option<String>,
+    /// SSE transport URL.
+    pub sse: Option<String>,
+    /// HTTP headers in `KEY=VALUE` format.
+    pub headers: Vec<String>,
+    /// Connection (handshake) timeout override, in seconds.
+    pub connect_timeout_secs: Option<u64>,
+    /// Tool discovery timeout override, in seconds.
+    pub discover_timeout_secs: Option<u64>,
+}
+
+impl fmt::Debug for RawServerArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RawServerArgs")
+            .field("from_config", &self.from_config)
+            .field(
+                "server",
+                &self
+                    .server
+                    .as_deref()
+                    .map(|s| sanitize_path_for_error(Path::new(s))),
+            )
+            .field("args", &RedactedItems(&self.args))
+            .field("env", &RedactedItems(&self.env))
+            .field(
+                "cwd",
+                &self
+                    .cwd
+                    .as_deref()
+                    .map(|cwd| sanitize_path_for_error(Path::new(cwd))),
+            )
+            .field("http", &self.http.as_deref().map(RedactedUrl))
+            .field("sse", &self.sse.as_deref().map(RedactedUrl))
+            .field("headers", &RedactedItems(&self.headers))
+            .field("connect_timeout_secs", &self.connect_timeout_secs)
+            .field("discover_timeout_secs", &self.discover_timeout_secs)
+            .finish()
+    }
+}
+
 /// Resolves a server's [`ServerId`] and [`ServerConfig`], either from
-/// `~/.claude/mcp.json` (when `from_config` is set) or from CLI transport
+/// `~/.claude/mcp.json` (when `raw.from_config` is set) or from CLI transport
 /// flags.
 ///
 /// The single place `generate` and `introspect` share for this "config file
@@ -845,34 +926,32 @@ pub(crate) fn build_server_config(
 ///
 /// # Errors
 ///
-/// Returns an error if `from_config` is set and the named server is missing
-/// from the config file or the file is malformed, or if the CLI transport
-/// flags fail [`TransportArgs::from_flags`] validation or the resulting
-/// [`ServerConfig`] fails security validation.
-// One argument per CLI flag; clap already destructures flags for us, and
-// grouping them into a struct would only benefit this function, not caller ergonomics.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn resolve_server_config(
-    from_config: Option<String>,
-    server: Option<String>,
-    args: Vec<String>,
-    env: Vec<String>,
-    cwd: Option<String>,
-    http: Option<String>,
-    sse: Option<String>,
-    headers: Vec<String>,
-    connect_timeout_secs: Option<u64>,
-    discover_timeout_secs: Option<u64>,
-) -> Result<(ServerId, ServerConfig)> {
-    if let Some(config_name) = from_config {
+/// Returns an error if `raw.from_config` is set and the named server is
+/// missing from the config file or the file is malformed, or if the CLI
+/// transport flags fail [`TransportArgs::from_flags`] validation or the
+/// resulting [`ServerConfig`] fails security validation.
+pub(crate) fn resolve_server_config(raw: RawServerArgs) -> Result<(ServerId, ServerConfig)> {
+    if let Some(config_name) = raw.from_config {
         debug!(
             "Loading server configuration from ~/.claude/mcp.json: {}",
             config_name
         );
         load_server_from_config(&config_name)
     } else {
-        let transport = TransportArgs::from_flags(server, args, env, cwd, http, sse, headers)?;
-        build_server_config(transport, connect_timeout_secs, discover_timeout_secs)
+        let transport = TransportArgs::from_flags(
+            raw.server,
+            raw.args,
+            raw.env,
+            raw.cwd,
+            raw.http,
+            raw.sse,
+            raw.headers,
+        )?;
+        build_server_config(
+            transport,
+            raw.connect_timeout_secs,
+            raw.discover_timeout_secs,
+        )
     }
 }
 
@@ -1479,6 +1558,37 @@ mod tests {
         assert!(debug_output.contains("GITHUB_TOKEN"));
         assert!(debug_output.contains("someUnknownSecret"));
         assert!(debug_output.contains("node"));
+    }
+
+    #[test]
+    fn test_raw_server_args_debug_redacts_secret_shaped_fields() {
+        let secret = "sk-live-secret";
+        let home = dirs::home_dir().expect("home directory must be resolvable in test environment");
+        let server_path = home.join("tools").join("mcp-server");
+
+        let raw = RawServerArgs {
+            from_config: None,
+            server: Some(server_path.display().to_string()),
+            args: vec!["--api-key".to_string(), secret.to_string()],
+            env: vec![format!("GITHUB_TOKEN={secret}")],
+            cwd: None,
+            http: Some(format!(
+                "https://user:{secret}@api.example.com/mcp?token={secret}"
+            )),
+            sse: None,
+            headers: vec![format!("Authorization=Bearer {secret}")],
+            connect_timeout_secs: Some(30),
+            discover_timeout_secs: None,
+        };
+
+        let debug_output = format!("{raw:?}");
+        assert!(!debug_output.contains(secret));
+        // The server path's username component must be scrubbed, same as
+        // McpTransport::Stdio.command and TransportArgs::Stdio.command.
+        assert!(!debug_output.contains(&home.display().to_string()));
+        assert!(debug_output.contains('~'));
+        assert!(debug_output.contains("api.example.com/mcp"));
+        assert!(debug_output.contains("connect_timeout_secs: Some(30)"));
     }
 
     #[test]

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -6,7 +6,7 @@
 //! 2. Generates TypeScript files for progressive loading (one file per tool)
 //! 3. Saves files to `~/.claude/servers/{server-id}/` directory
 
-use super::common::resolve_server_config;
+use super::common::{RawServerArgs, resolve_server_config};
 use anyhow::{Context, Result};
 use mcp_execution_codegen::GeneratedCode;
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
@@ -88,23 +88,14 @@ fn format_size(bytes: usize) -> String {
 ///
 /// # Arguments
 ///
-/// * `from_config` - Load server config from ~/.claude/mcp.json by name
-/// * `server` - Server command (binary name or path), None for HTTP/SSE
-/// * `args` - Arguments to pass to the server command
-/// * `env` - Environment variables in KEY=VALUE format
-/// * `cwd` - Working directory for the server process
-/// * `http` - HTTP transport URL
-/// * `sse` - SSE transport URL
-/// * `headers` - HTTP headers in KEY=VALUE format
+/// * `raw` - Server config-file selector, transport flags, and timeout
+///   overrides. `connect_timeout_secs` is ignored when `raw.from_config` is
+///   set (the `mcp.json` entry's `connectTimeoutSecs` applies instead); both
+///   timeout overrides share `mcp.json`'s bounds (greater than zero, at most
+///   600 seconds).
 /// * `name` - Custom server name for directory (default: `server_id`)
 /// * `output_dir` - Custom output directory (default: ~/.claude/servers/)
 /// * `dry_run` - When true, preview files without writing to disk
-/// * `connect_timeout_secs` - Connection (handshake) timeout override, in
-///   seconds. Ignored when `from_config` is set (the `mcp.json` entry's
-///   `connectTimeoutSecs` applies instead). Same bounds as `mcp.json`: must
-///   be greater than zero and at most 600 seconds.
-/// * `discover_timeout_secs` - Tool discovery timeout override, in seconds.
-///   Same rules as `connect_timeout_secs`.
 /// * `output_format` - Output format (json, text, pretty)
 ///
 /// # Errors
@@ -116,37 +107,14 @@ fn format_size(bytes: usize) -> String {
 /// - Tool introspection fails
 /// - Code generation fails
 /// - File export fails (skipped in dry-run mode)
-// One argument per CLI flag; clap already destructures flags for us, and
-// grouping them into a struct would only benefit this function, not caller ergonomics.
-#[allow(clippy::too_many_arguments)]
 pub async fn run(
-    from_config: Option<String>,
-    server: Option<String>,
-    args: Vec<String>,
-    env: Vec<String>,
-    cwd: Option<String>,
-    http: Option<String>,
-    sse: Option<String>,
-    headers: Vec<String>,
+    raw: RawServerArgs,
     name: Option<String>,
     output_dir: Option<PathBuf>,
     dry_run: bool,
-    connect_timeout_secs: Option<u64>,
-    discover_timeout_secs: Option<u64>,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
-    let (server_id, server_config) = resolve_server_config(
-        from_config,
-        server,
-        args,
-        env,
-        cwd,
-        http,
-        sse,
-        headers,
-        connect_timeout_secs,
-        discover_timeout_secs,
-    )?;
+    let (server_id, server_config) = resolve_server_config(raw)?;
 
     let server_info = discover_server_info(server_id, &server_config, name.as_deref()).await?;
 
@@ -550,23 +518,12 @@ mod tests {
     async fn test_run_zero_connect_timeout_override_rejected_by_validation() {
         // A zero override must surface the same connect_timeout validation
         // error as the mcp.json path, not just a generic connection failure.
-        let result = run(
-            None,
-            Some("nonexistent-server-timeout-test".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            None,
-            None,
-            false,
-            Some(0),
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server-timeout-test".to_string()),
+            connect_timeout_secs: Some(0),
+            ..Default::default()
+        };
+        let result = run(raw, None, None, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -584,23 +541,13 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_valid_timeout_overrides_reaches_connection_attempt() {
         // Valid overrides must not be rejected before the connection attempt.
-        let result = run(
-            None,
-            Some("nonexistent-server-timeout-test-2".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            None,
-            None,
-            false,
-            Some(5),
-            Some(90),
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server-timeout-test-2".to_string()),
+            connect_timeout_secs: Some(5),
+            discover_timeout_secs: Some(90),
+            ..Default::default()
+        };
+        let result = run(raw, None, None, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -2,7 +2,7 @@
 //!
 //! Connects to an MCP server and displays its capabilities, tools, and metadata.
 
-use super::common::resolve_server_config;
+use super::common::{RawServerArgs, resolve_server_config};
 use anyhow::{Context, Result};
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use mcp_execution_introspector::{Introspector, ServerInfo, ToolInfo};
@@ -126,21 +126,12 @@ pub struct ToolDisplay {
 ///
 /// # Arguments
 ///
-/// * `from_config` - Load server config from ~/.claude/mcp.json by name
-/// * `server` - Server command (binary name or path), None for HTTP/SSE
-/// * `args` - Arguments to pass to the server command
-/// * `env` - Environment variables in KEY=VALUE format
-/// * `cwd` - Working directory for the server process
-/// * `http` - HTTP transport URL
-/// * `sse` - SSE transport URL
-/// * `headers` - HTTP headers in KEY=VALUE format
+/// * `raw` - Server config-file selector, transport flags, and timeout
+///   overrides. `connect_timeout_secs` is ignored when `raw.from_config` is
+///   set (the `mcp.json` entry's `connectTimeoutSecs` applies instead); both
+///   timeout overrides share `mcp.json`'s bounds (greater than zero, at most
+///   600 seconds).
 /// * `detailed` - Whether to show detailed tool schemas
-/// * `connect_timeout_secs` - Connection (handshake) timeout override, in
-///   seconds. Ignored when `from_config` is set (the `mcp.json` entry's
-///   `connectTimeoutSecs` applies instead). Same bounds as `mcp.json`: must
-///   be greater than zero and at most 600 seconds.
-/// * `discover_timeout_secs` - Tool discovery timeout override, in seconds.
-///   Same rules as `connect_timeout_secs`.
 /// * `output_format` - Output format (json, text, pretty)
 ///
 /// # Errors
@@ -154,74 +145,56 @@ pub struct ToolDisplay {
 /// # Examples
 ///
 /// ```no_run
+/// use mcp_execution_cli::commands::common::RawServerArgs;
 /// use mcp_execution_cli::commands::introspect;
 /// use mcp_execution_core::cli::OutputFormat;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// // Simple server
 /// let exit_code = introspect::run(
-///     None,
-///     Some("github-mcp-server".to_string()),
-///     vec!["stdio".to_string()],
-///     vec![],
-///     None,
-///     None,
-///     None,
-///     vec![],
+///     RawServerArgs {
+///         from_config: None,
+///         server: Some("github-mcp-server".to_string()),
+///         args: vec!["stdio".to_string()],
+///         env: vec![],
+///         cwd: None,
+///         http: None,
+///         sse: None,
+///         headers: vec![],
+///         connect_timeout_secs: None,
+///         discover_timeout_secs: None,
+///     },
 ///     false,
-///     None,
-///     None,
 ///     OutputFormat::Json
 /// ).await?;
 ///
 /// // HTTP transport with a shorter connect timeout
 /// let exit_code = introspect::run(
-///     None,
-///     None,
-///     vec![],
-///     vec![],
-///     None,
-///     Some("https://api.githubcopilot.com/mcp/".to_string()),
-///     None,
-///     vec!["Authorization=Bearer token".to_string()],
+///     RawServerArgs {
+///         from_config: None,
+///         server: None,
+///         args: vec![],
+///         env: vec![],
+///         cwd: None,
+///         http: Some("https://api.githubcopilot.com/mcp/".to_string()),
+///         sse: None,
+///         headers: vec!["Authorization=Bearer token".to_string()],
+///         connect_timeout_secs: Some(5),
+///         discover_timeout_secs: None,
+///     },
 ///     false,
-///     Some(5),
-///     None,
 ///     OutputFormat::Json
 /// ).await?;
 /// # Ok(())
 /// # }
 /// ```
-// One argument per CLI flag; clap already destructures flags for us, and
-// grouping them into a struct would only benefit this function, not caller ergonomics.
-#[allow(clippy::too_many_arguments)]
 pub async fn run(
-    from_config: Option<String>,
-    server: Option<String>,
-    args: Vec<String>,
-    env: Vec<String>,
-    cwd: Option<String>,
-    http: Option<String>,
-    sse: Option<String>,
-    headers: Vec<String>,
+    raw: RawServerArgs,
     detailed: bool,
-    connect_timeout_secs: Option<u64>,
-    discover_timeout_secs: Option<u64>,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
     // Build server config: either from mcp.json or from CLI arguments
-    let (server_id, config) = resolve_server_config(
-        from_config,
-        server,
-        args,
-        env,
-        cwd,
-        http,
-        sse,
-        headers,
-        connect_timeout_secs,
-        discover_timeout_secs,
-    )?;
+    let (server_id, config) = resolve_server_config(raw)?;
 
     info!("Introspecting server: {}", server_id);
     info!("Transport: {:?}", config.transport());
@@ -560,21 +533,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_server_connection_failure() {
-        let result = run(
-            None,
-            Some("nonexistent-server-xyz".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server-xyz".to_string()),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -671,21 +634,11 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_text_format() {
         // Test that Text format output works correctly (compact JSON)
-        let result = run(
-            None,
-            Some("nonexistent-server".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            None,
-            None,
-            OutputFormat::Text,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server".to_string()),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Text).await;
 
         // Connection should fail but format handling should not panic
         assert!(result.is_err());
@@ -694,21 +647,11 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_pretty_format() {
         // Test that Pretty format output works correctly (colorized)
-        let result = run(
-            None,
-            Some("nonexistent-server".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            None,
-            None,
-            OutputFormat::Pretty,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server".to_string()),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Pretty).await;
 
         // Connection should fail but format handling should not panic
         assert!(result.is_err());
@@ -717,21 +660,11 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_detailed_mode() {
         // Test that detailed mode doesn't cause crashes even with connection failure
-        let result = run(
-            None,
-            Some("nonexistent-server".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            true, // detailed mode
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server".to_string()),
+            ..Default::default()
+        };
+        let result = run(raw, true, OutputFormat::Json).await; // detailed mode
 
         assert!(result.is_err());
     }
@@ -741,21 +674,12 @@ mod tests {
     /// deterministic without a live server.
     #[tokio::test]
     async fn test_run_http_transport() {
-        let result = run(
-            None,
-            None,
-            vec![],
-            vec![],
-            None,
-            Some("https://localhost:99999/invalid".to_string()),
-            None,
-            vec!["Authorization=Bearer test".to_string()],
-            false,
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            http: Some("https://localhost:99999/invalid".to_string()),
+            headers: vec!["Authorization=Bearer test".to_string()],
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -782,21 +706,12 @@ mod tests {
     /// See `test_run_http_transport` — same deterministic-failure rationale.
     #[tokio::test]
     async fn test_run_sse_transport() {
-        let result = run(
-            None,
-            None,
-            vec![],
-            vec![],
-            None,
-            None,
-            Some("https://localhost:99999/sse".to_string()),
-            vec!["X-API-Key=test-key".to_string()],
-            false,
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            sse: Some("https://localhost:99999/sse".to_string()),
+            headers: vec!["X-API-Key=test-key".to_string()],
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -820,21 +735,11 @@ mod tests {
     async fn test_run_all_output_formats() {
         // Test all output formats don't cause panics
         for format in [OutputFormat::Json, OutputFormat::Text, OutputFormat::Pretty] {
-            let result = run(
-                None,
-                Some("nonexistent".to_string()),
-                vec![],
-                vec![],
-                None,
-                None,
-                None,
-                vec![],
-                false,
-                None,
-                None,
-                format,
-            )
-            .await;
+            let raw = RawServerArgs {
+                server: Some("nonexistent".to_string()),
+                ..Default::default()
+            };
+            let result = run(raw, false, format).await;
 
             assert!(result.is_err());
         }
@@ -844,21 +749,11 @@ mod tests {
     async fn test_run_detailed_with_all_formats() {
         // Test detailed mode with all output formats
         for format in [OutputFormat::Json, OutputFormat::Text, OutputFormat::Pretty] {
-            let result = run(
-                None,
-                Some("nonexistent".to_string()),
-                vec![],
-                vec![],
-                None,
-                None,
-                None,
-                vec![],
-                true, // detailed
-                None,
-                None,
-                format,
-            )
-            .await;
+            let raw = RawServerArgs {
+                server: Some("nonexistent".to_string()),
+                ..Default::default()
+            };
+            let result = run(raw, true, format).await; // detailed
 
             assert!(result.is_err());
         }
@@ -1060,21 +955,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_from_config_not_found() {
-        let result = run(
-            Some("nonexistent-server-xyz".to_string()),
-            None,
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            from_config: Some("nonexistent-server-xyz".to_string()),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -1090,21 +975,12 @@ mod tests {
     async fn test_run_from_config_takes_priority() {
         // When from_config is Some, it should be used for config loading
         // (server arg should be None due to clap conflicts, but we test the logic)
-        let result = run(
-            Some("test-server".to_string()),
-            None, // server is None when from_config is used
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            from_config: Some("test-server".to_string()),
+            server: None, // server is None when from_config is used
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         // Should fail because config doesn't exist, not because of server
         assert!(result.is_err());
@@ -1119,21 +995,11 @@ mod tests {
     #[tokio::test]
     async fn test_run_manual_mode_backward_compatible() {
         // Existing behavior: from_config = None, use server arg
-        let result = run(
-            None, // from_config
-            Some("test-server-direct".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            None,
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("test-server-direct".to_string()),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -1148,21 +1014,12 @@ mod tests {
     async fn test_run_zero_connect_timeout_override_rejected_by_validation() {
         // A zero override must surface the same connect_timeout validation
         // error as the mcp.json path, not just a generic connection failure.
-        let result = run(
-            None,
-            Some("nonexistent-server-timeout-test".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            Some(0),
-            None,
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server-timeout-test".to_string()),
+            connect_timeout_secs: Some(0),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -1180,21 +1037,13 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_valid_timeout_overrides_reaches_connection_attempt() {
         // Valid overrides must not be rejected before the connection attempt.
-        let result = run(
-            None,
-            Some("nonexistent-server-timeout-test-2".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-            false,
-            Some(5),
-            Some(90),
-            OutputFormat::Json,
-        )
-        .await;
+        let raw = RawServerArgs {
+            server: Some("nonexistent-server-timeout-test-2".to_string()),
+            connect_timeout_secs: Some(5),
+            discover_timeout_secs: Some(90),
+            ..Default::default()
+        };
+        let result = run(raw, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 
 use crate::cli::Commands;
 use crate::commands;
+use crate::commands::common::RawServerArgs;
 
 /// Initializes logging infrastructure.
 ///
@@ -114,7 +115,7 @@ async fn dispatch(command: Commands, output_format: OutputFormat) -> Result<Exit
             connect_timeout_secs,
             discover_timeout_secs,
         } => {
-            commands::introspect::run(
+            let raw = RawServerArgs {
                 from_config,
                 server,
                 args,
@@ -123,12 +124,10 @@ async fn dispatch(command: Commands, output_format: OutputFormat) -> Result<Exit
                 http,
                 sse,
                 headers,
-                detailed,
                 connect_timeout_secs,
                 discover_timeout_secs,
-                output_format,
-            )
-            .await
+            };
+            commands::introspect::run(raw, detailed, output_format).await
         }
         Commands::Skill {
             server,
@@ -164,23 +163,19 @@ async fn dispatch(command: Commands, output_format: OutputFormat) -> Result<Exit
             connect_timeout_secs,
             discover_timeout_secs,
         } => {
-            commands::generate::run(
+            let raw = RawServerArgs {
                 from_config,
                 server,
-                server_args,
-                server_env,
-                server_cwd,
-                http_url,
-                sse_url,
-                server_headers,
-                name,
-                progressive_output,
-                dry_run,
+                args: server_args,
+                env: server_env,
+                cwd: server_cwd,
+                http: http_url,
+                sse: sse_url,
+                headers: server_headers,
                 connect_timeout_secs,
                 discover_timeout_secs,
-                output_format,
-            )
-            .await
+            };
+            commands::generate::run(raw, name, progressive_output, dry_run, output_format).await
         }
         Commands::Server { action } => commands::server::run(action, output_format).await,
         Commands::Setup => commands::setup::run(output_format).await,


### PR DESCRIPTION
## Summary
- Introduces `RawServerArgs`, bundling the ten same-typed positional parameters previously forwarded through `dispatch` -> `{introspect,generate}::run` -> `resolve_server_config` (`from_config`, `server`, `args`, `env`, `cwd`, `http`, `sse`, `headers`, `connect_timeout_secs`, `discover_timeout_secs`).
- All construction sites use named-field literals with no `..Default::default()` fallthrough, so the `http`/`sse` transposition risk the issue calls out cannot silently reintroduce itself at these four call sites.
- `RawServerArgs` is `pub` (not `pub(crate)` as the issue's illustrative snippet showed) since `introspect::run`/`generate::run` are themselves `pub` inside a `pub mod commands`, which trips the `private_interfaces` lint otherwise. Pre-1.0, no known downstream library consumers.
- Its hand-written `Debug` impl redacts secret-shaped fields (env, headers, http/sse URLs) and sanitizes the `server` path via the file's existing `sanitize_path_for_error` helper, matching the sibling `McpTransport`/`TransportArgs` `Debug` impls in the same file.

## Deferred (fast-follow, not blockers for this PR)
- `resolve_server_config` still forwards a subset of `RawServerArgs`'s fields positionally into `TransportArgs::from_flags` and `build_server_config` one level down — the transposition risk is now confined to a single function instead of three layers, but not fully eliminated. Issue #286's own "After" snippet stops at `resolve_server_config`'s signature, so this is out of scope here.
- No test currently exercises `runner::dispatch`'s two `RawServerArgs { .. }` construction sites with distinct http/sse/timeout values; `Commands::Generate`'s dispatch site has no test coverage at all. The named-field syntax is a visual safeguard against transposition there, not a compiler/test-enforced one.

Closes #286

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (956 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`