### PR TITLE
fix(skill): propagate canonicalize I/O errors instead of masking as not-found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mcp-execution-skill`**: `scan_tools_directory` discarded the real `io::Error` from both of
+  its `canonicalize` calls (the server directory and the `_meta.json` sidecar) and mislabeled
+  every failure as `DirectoryNotFound`/`MissingMetadata` respectively, even when the underlying
+  cause was a permission error (e.g. a `chmod 000` directory) rather than a missing path. Both
+  call sites now distinguish `io::ErrorKind::NotFound` — which still reports the existing
+  `DirectoryNotFound`/`MissingMetadata` variants — from any other I/O error, which now propagates
+  the real cause via `ScanError::Io` instead of being discarded (#302).
+
 ### Documentation
 
 - Backfilled `# Examples` doc-test sections for ~50 public types and functions across the workspace that previously lacked runnable examples, including `ServerConfig` getters, CLI formatters, command structs, and resource limit constants (#189).
@@ -354,6 +364,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mcp-execution-skill`, `mcp-execution-server`, `mcp-execution-cli`**: enabled
+  `#![warn(missing_docs, missing_debug_implementations)]` at the crate root, matching the other
+  four workspace crates, and backfilled one-line field docs on every previously-undocumented
+  `ScanError` struct-variant field so the new lint has nothing to warn about (#290).
 - **`mcp-execution-server`**: `save_categorized_tools` collapsed its four copy-pasted per-field
   byte-length checks (`name`, `category`, `keywords`, `short_description`) into a single private
   `check_categorized_field_length` helper, called once per field. No behavior change: the exact

--- a/crates/mcp-cli/src/lib.rs
+++ b/crates/mcp-cli/src/lib.rs
@@ -4,7 +4,7 @@
 //! exposing the CLI argument definitions, command implementations, output
 //! formatters, and command runner, so the binary crate and tests can share
 //! a single compiled module tree.
-
+#![warn(missing_docs, missing_debug_implementations)]
 // `commands::completions::run` and `commands::server::list_servers` are `async fn` to match
 // the signature every other command handler needs (they're all dispatched uniformly from
 // `runner::execute_command`), even though these two happen to do no `.await`ing themselves.

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -48,6 +48,7 @@
 //! - **Progressive loading**: 98% token savings (30,000 → 500-1,500 tokens)
 //! - **Type-safe**: Full TypeScript types from MCP schemas
 //! - **Discoverable**: grep-friendly headers for tool discovery
+#![warn(missing_docs, missing_debug_implementations)]
 
 pub mod clock;
 mod output_dir;

--- a/crates/mcp-server/tests/skill_tests.rs
+++ b/crates/mcp-server/tests/skill_tests.rs
@@ -353,7 +353,12 @@ async fn test_scan_directory_permission_denied() {
             .unwrap();
 
         let result = scan_tools_directory(&restricted_dir).await;
-        assert!(result.is_err());
+        match result {
+            Err(ScanError::Io(err)) => {
+                assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("expected ScanError::Io(PermissionDenied), got: {other:?}"),
+        }
 
         // Restore permissions for cleanup
         let mut perms = tokio::fs::metadata(&restricted_dir)

--- a/crates/mcp-skill/src/lib.rs
+++ b/crates/mcp-skill/src/lib.rs
@@ -22,6 +22,7 @@
 //! # Ok(())
 //! # }
 //! ```
+#![warn(missing_docs, missing_debug_implementations)]
 
 mod context;
 mod output_path;

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -54,31 +54,56 @@ pub enum ScanError {
 
     /// Directory does not exist.
     #[error("directory does not exist: {path}")]
-    DirectoryNotFound { path: String },
+    DirectoryNotFound {
+        /// Sanitized path of the missing directory.
+        path: String,
+    },
 
     /// The `_meta.json` sidecar is missing from the server directory.
     #[error("metadata sidecar not found: {path} (was the server directory regenerated?)")]
-    MissingMetadata { path: String },
+    MissingMetadata {
+        /// Sanitized path of the expected sidecar file.
+        path: String,
+    },
 
     /// The `_meta.json` sidecar could not be parsed as valid `ServerMetadata` JSON.
     #[error("failed to parse metadata sidecar {path}: {source}")]
     MetadataParse {
+        /// Sanitized path of the sidecar file that failed to parse.
         path: String,
+        /// Underlying JSON deserialization error.
         #[source]
         source: serde_json::Error,
     },
 
     /// The sidecar's `schema_version` does not match the version this crate understands.
     #[error("unsupported metadata schema version: found {found}, expected {expected}")]
-    UnsupportedSchema { found: u32, expected: u32 },
+    UnsupportedSchema {
+        /// Schema version read from the sidecar.
+        found: u32,
+        /// Schema version this crate supports (`METADATA_SCHEMA_VERSION`).
+        expected: u32,
+    },
 
     /// Too many tools in the sidecar (denial-of-service protection).
     #[error("too many tools: {count} exceeds limit of {limit}")]
-    TooManyFiles { count: usize, limit: usize },
+    TooManyFiles {
+        /// Number of tools listed in the sidecar.
+        count: usize,
+        /// Maximum allowed number of tools (`MAX_TOOL_FILES`).
+        limit: usize,
+    },
 
     /// Sidecar file too large to process.
     #[error("file too large: {path} ({size} bytes exceeds {limit} limit)")]
-    FileTooLarge { path: String, size: u64, limit: u64 },
+    FileTooLarge {
+        /// Sanitized path of the oversized sidecar file.
+        path: String,
+        /// Actual size of the file, in bytes.
+        size: u64,
+        /// Maximum allowed size, in bytes (`MAX_FILE_SIZE`).
+        limit: u64,
+    },
 
     /// A tool listed in the `_meta.json` sidecar has no corresponding `.ts`
     /// file on disk.
@@ -91,8 +116,11 @@ pub enum ScanError {
          is missing (re-run 'generate' to regenerate this server)"
     )]
     StaleMetadata {
+        /// MCP tool name listed in the sidecar.
         tool: String,
+        /// `.ts` file name expected on disk for `tool`.
         expected_file: String,
+        /// Sanitized path of the sidecar that references `tool`.
         sidecar_path: String,
     },
 }
@@ -222,12 +250,15 @@ impl From<mcp_execution_core::metadata::ToolMetadata> for ParsedToolFile {
 /// ```
 pub async fn scan_tools_directory(dir: &Path) -> Result<ScanResult, ScanError> {
     // Canonicalize the base directory to resolve symlinks and get absolute path
-    let canonical_base =
-        tokio::fs::canonicalize(dir)
-            .await
-            .map_err(|_| ScanError::DirectoryNotFound {
+    let canonical_base = tokio::fs::canonicalize(dir).await.map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            ScanError::DirectoryNotFound {
                 path: sanitize_path_for_error(dir),
-            })?;
+            }
+        } else {
+            ScanError::Io(err)
+        }
+    })?;
 
     let meta_path = canonical_base.join(METADATA_FILE_NAME);
 
@@ -235,11 +266,17 @@ pub async fn scan_tools_directory(dir: &Path) -> Result<ScanResult, ScanError> {
     // directory, preventing path traversal via a symlinked `_meta.json`.
     let canonical_meta = match tokio::fs::canonicalize(&meta_path).await {
         Ok(path) if path.starts_with(&canonical_base) => path,
-        _ => {
+        Ok(_) => {
             return Err(ScanError::MissingMetadata {
                 path: sanitize_path_for_error(&meta_path),
             });
         }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ScanError::MissingMetadata {
+                path: sanitize_path_for_error(&meta_path),
+            });
+        }
+        Err(err) => return Err(ScanError::Io(err)),
     };
 
     let file_metadata = tokio::fs::metadata(&canonical_meta).await?;
@@ -847,6 +884,27 @@ mod tests {
         let result = scan_tools_directory(Path::new("/nonexistent/path/for/testing")).await;
 
         assert!(matches!(result, Err(ScanError::DirectoryNotFound { .. })));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_scan_tools_directory_canonicalize_non_not_found_error_propagates_as_io() {
+        // Issue #302 regression: a symlink loop makes `canonicalize` fail with
+        // `ErrorKind::FilesystemLoop`/`Other` (never `NotFound`). Before the fix,
+        // every canonicalize failure — regardless of kind — collapsed into
+        // `DirectoryNotFound`, silently discarding the real error.
+        let temp_dir = TempDir::new().unwrap();
+        let loop_path = temp_dir.path().join("loop");
+        std::os::unix::fs::symlink(&loop_path, &loop_path).unwrap();
+
+        let result = scan_tools_directory(&loop_path).await;
+
+        match result {
+            Err(ScanError::Io(err)) => {
+                assert_ne!(err.kind(), std::io::ErrorKind::NotFound);
+            }
+            other => panic!("expected ScanError::Io, got: {other:?}"),
+        }
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
- `scan_tools_directory` in `crates/mcp-skill/src/parser.rs` discarded the real `io::Error` from both of its `canonicalize` calls (the server directory and the `_meta.json` sidecar), reporting every failure as `DirectoryNotFound`/`MissingMetadata` even when the actual cause was a permission error, symlink loop, or other I/O failure. Both call sites now preserve `io::ErrorKind::NotFound` as the existing not-found variant and propagate anything else via `ScanError::Io`.
- Enabled `#![warn(missing_docs, missing_debug_implementations)]` on `mcp-skill`, `mcp-server`, and `mcp-cli`, matching the other four workspace crates, and added field-level doc comments to every previously-undocumented `ScanError` field.

Fixes #302
Fixes #290

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (977/977 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Added a regression test covering the `ScanError::Io` branch via a symlink loop (`ELOOP`)
- [x] Tightened `test_scan_directory_permission_denied` to assert the specific `ScanError::Io(PermissionDenied)` variant instead of a bare `is_err()`