### PR TITLE
cli: escape server-supplied name in generate's Text/Pretty output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`mcp-cli`**: `generate`'s `Text`/`Pretty` output (both the success summary and the dry-run
+  preview) now escapes the MCP server's handshake-supplied name before printing it, closing a
+  terminal-injection gap (CWE-150-adjacent: unescaped output) where a malicious server could embed
+  raw ANSI/control escape sequences (e.g. `\x1b`) in `serverInfo.name` and have them written
+  verbatim to the user's terminal — every other subcommand already routed all output formats
+  through `formatters::format_output`, which escapes string values via `serde_json`, but `generate`
+  built its `Text`/`Pretty` lines by hand and bypassed that escaping. `Json` output was already
+  unaffected. The new `formatters::escape_display` helper always JSON-quotes the name it escapes,
+  even when it contains no control characters — so `generate`'s `Text`/`Pretty` output changes for
+  every server, not just malicious ones: e.g. `Server: Test Server (id)` is now
+  `Server: "Test Server" (id)` (#299).
+
 - **`mcp-execution-core`**: `validate_server_config` now bounds `ServerConfig`'s `command`/
   `args`/`env`/`headers`/`url` element counts and per-string lengths (`MAX_ARG_COUNT`,
   `MAX_ARG_LEN`, `MAX_ENV_COUNT`, `MAX_ENV_VALUE_LEN`, `MAX_HEADER_COUNT`,

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -7,6 +7,7 @@
 //! 3. Saves files to `~/.claude/servers/{server-id}/` directory
 
 use super::common::{RawServerArgs, resolve_server_config};
+use crate::formatters::escape_display;
 use anyhow::{Context, Result};
 use mcp_execution_codegen::GeneratedCode;
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
@@ -236,38 +237,46 @@ fn render_dry_run(
         total_size,
     };
 
-    match output_format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&result)?);
-        }
-        OutputFormat::Text => {
-            println!("Server: {} ({})", result.server_name, result.server_id);
-            println!(
-                "Would generate {} files ({}) to {}/",
-                result.total_files,
-                format_size(result.total_size),
-                result.output_path
-            );
-        }
+    println!("{}", format_dry_run(&result, output_format)?);
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Renders a [`DryRunResult`] for the given `output_format`.
+///
+/// `server_name` is server-supplied (untrusted), so `Text`/`Pretty` output escapes it via
+/// [`escape_display`] to neutralize embedded control characters; `Json` output is unaffected
+/// since `serde_json` already escapes string values.
+fn format_dry_run(result: &DryRunResult, output_format: OutputFormat) -> Result<String> {
+    Ok(match output_format {
+        OutputFormat::Json => serde_json::to_string_pretty(result)?,
+        OutputFormat::Text => format!(
+            "Server: {} ({})\nWould generate {} files ({}) to {}/",
+            escape_display(&result.server_name),
+            result.server_id,
+            result.total_files,
+            format_size(result.total_size),
+            result.output_path
+        ),
         OutputFormat::Pretty => {
-            println!(
-                "Would generate {} files to {}/:",
+            use std::fmt::Write as _;
+
+            let mut out = format!(
+                "Would generate {} files to {}/:\n\n",
                 result.total_files, result.output_path
             );
-            println!();
             for f in &result.files {
-                println!("  - {} ({})", f.path, format_size(f.size));
+                let _ = writeln!(out, "  - {} ({})", f.path, format_size(f.size));
             }
-            println!();
-            println!(
-                "Total: {} files, ~{}",
+            let _ = write!(
+                out,
+                "\nTotal: {} files, ~{}",
                 result.total_files,
                 format_size(result.total_size)
             );
+            out
         }
-    }
-
-    Ok(ExitCode::SUCCESS)
+    })
 }
 
 /// Builds the VFS from `generated_code` and exports it to `output_path` under `base_dir`.
@@ -314,26 +323,34 @@ fn render_success(
         next_step: NPM_INSTALL_HINT.to_string(),
     };
 
-    match output_format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&result)?);
-        }
-        OutputFormat::Text => {
-            println!("Server: {} ({})", result.server_name, result.server_id);
-            println!("Generated {} tool files", result.tool_count);
-            println!("Output: {}", result.output_path);
-            println!("Next step: {NPM_INSTALL_HINT}");
-        }
-        OutputFormat::Pretty => {
-            println!("✓ Successfully generated progressive loading files");
-            println!("  Server: {} ({})", result.server_name, result.server_id);
-            println!("  Tools: {}", result.tool_count);
-            println!("  Location: {}", result.output_path);
-            println!("  Next step: {NPM_INSTALL_HINT}");
-        }
-    }
+    println!("{}", format_success(&result, output_format)?);
 
     Ok(ExitCode::SUCCESS)
+}
+
+/// Renders a [`GenerationResult`] for the given `output_format`.
+///
+/// `server_name` is server-supplied (untrusted), so `Text`/`Pretty` output escapes it via
+/// [`escape_display`] to neutralize embedded control characters; `Json` output is unaffected
+/// since `serde_json` already escapes string values.
+fn format_success(result: &GenerationResult, output_format: OutputFormat) -> Result<String> {
+    Ok(match output_format {
+        OutputFormat::Json => serde_json::to_string_pretty(result)?,
+        OutputFormat::Text => format!(
+            "Server: {} ({})\nGenerated {} tool files\nOutput: {}\nNext step: {NPM_INSTALL_HINT}",
+            escape_display(&result.server_name),
+            result.server_id,
+            result.tool_count,
+            result.output_path
+        ),
+        OutputFormat::Pretty => format!(
+            "✓ Successfully generated progressive loading files\n  Server: {} ({})\n  Tools: {}\n  Location: {}\n  Next step: {NPM_INSTALL_HINT}",
+            escape_display(&result.server_name),
+            result.server_id,
+            result.tool_count,
+            result.output_path
+        ),
+    })
 }
 
 #[cfg(test)]
@@ -381,6 +398,120 @@ mod tests {
         assert!(json.contains("\"server_id\":\"test\""));
         assert!(json.contains("\"tool_count\":5"));
         assert!(json.contains(NPM_INSTALL_HINT));
+    }
+
+    #[test]
+    fn test_format_success_text_escapes_control_chars() {
+        // A malicious MCP server can set its handshake `serverInfo.name` to anything,
+        // including raw ANSI/control escape sequences. Text output must not pass them through.
+        let result = GenerationResult {
+            server_id: "test".to_string(),
+            server_name: "evil\u{1b}[2J\u{1b}]0;pwned\u{7}".to_string(),
+            tool_count: 1,
+            output_path: "/path/to/output".to_string(),
+            next_step: NPM_INSTALL_HINT.to_string(),
+        };
+
+        let output = format_success(&result, OutputFormat::Text).unwrap();
+        assert!(!output.contains('\u{1b}'));
+        assert!(output.contains("\\u001b"));
+    }
+
+    #[test]
+    fn test_format_success_pretty_escapes_control_chars() {
+        let result = GenerationResult {
+            server_id: "test".to_string(),
+            server_name: "evil\u{1b}[2Jname".to_string(),
+            tool_count: 1,
+            output_path: "/path/to/output".to_string(),
+            next_step: NPM_INSTALL_HINT.to_string(),
+        };
+
+        let output = format_success(&result, OutputFormat::Pretty).unwrap();
+        assert!(!output.contains('\u{1b}'));
+        assert!(output.contains("\\u001b"));
+    }
+
+    #[test]
+    fn test_format_dry_run_text_escapes_control_chars() {
+        let result = DryRunResult {
+            server_id: "test".to_string(),
+            server_name: "evil\u{1b}[2Jname".to_string(),
+            output_path: "/path/to/output".to_string(),
+            files: vec![],
+            total_files: 0,
+            total_size: 0,
+        };
+
+        let output = format_dry_run(&result, OutputFormat::Text).unwrap();
+        assert!(!output.contains('\u{1b}'));
+        assert!(output.contains("\\u001b"));
+    }
+
+    #[test]
+    fn test_format_dry_run_pretty_never_prints_raw_control_chars() {
+        // The Pretty dry-run branch does not interpolate `server_name` at all (only file
+        // paths and computed sizes/counts), but assert this stays true rather than silently
+        // regressing if someone adds a server-name line later without escaping it.
+        let result = DryRunResult {
+            server_id: "test".to_string(),
+            server_name: "evil\u{1b}[2Jname".to_string(),
+            output_path: "/path/to/output".to_string(),
+            files: vec![],
+            total_files: 0,
+            total_size: 0,
+        };
+
+        let output = format_dry_run(&result, OutputFormat::Pretty).unwrap();
+        assert!(!output.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn test_format_success_json_unaffected_by_control_chars() {
+        // Json path already relies on serde_json escaping and must stay unchanged.
+        let result = GenerationResult {
+            server_id: "test".to_string(),
+            server_name: "evil\u{1b}[2Jname".to_string(),
+            tool_count: 1,
+            output_path: "/path/to/output".to_string(),
+            next_step: NPM_INSTALL_HINT.to_string(),
+        };
+
+        let output = format_success(&result, OutputFormat::Json).unwrap();
+        assert!(!output.contains('\u{1b}'));
+        assert!(output.contains("\\u001b"));
+    }
+
+    #[test]
+    fn test_format_success_text_quotes_benign_server_name() {
+        // Pin the visible output-format change: escape_display always JSON-quotes the server
+        // name, even when it contains no control characters, so `Server: Test Server (id)`
+        // becomes `Server: "Test Server" (id)` for every server, not just malicious ones.
+        let result = GenerationResult {
+            server_id: "test".to_string(),
+            server_name: "Test Server".to_string(),
+            tool_count: 1,
+            output_path: "/path/to/output".to_string(),
+            next_step: NPM_INSTALL_HINT.to_string(),
+        };
+
+        let output = format_success(&result, OutputFormat::Text).unwrap();
+        assert!(output.contains("Server: \"Test Server\" (test)"));
+    }
+
+    #[test]
+    fn test_format_dry_run_text_quotes_benign_server_name() {
+        let result = DryRunResult {
+            server_id: "test".to_string(),
+            server_name: "Test Server".to_string(),
+            output_path: "/path/to/output".to_string(),
+            files: vec![],
+            total_files: 0,
+            total_size: 0,
+        };
+
+        let output = format_dry_run(&result, OutputFormat::Text).unwrap();
+        assert!(output.contains("Server: \"Test Server\" (test)"));
     }
 
     #[test]

--- a/crates/mcp-cli/src/formatters.rs
+++ b/crates/mcp-cli/src/formatters.rs
@@ -48,6 +48,35 @@ pub fn format_output<T: Serialize>(data: &T, format: OutputFormat) -> Result<Str
     }
 }
 
+/// Escapes a string for safe interpolation into hand-crafted `Text`/`Pretty` output lines.
+///
+/// Commands that render whole structs through [`format_output`] get escaping for free, since
+/// every string value is serialized through `serde_json` before printing. Commands that instead
+/// build freeform lines (e.g. `"Server: {name} ({id})"`) must escape server-supplied strings
+/// themselves, or a malicious MCP server could inject raw ANSI/control escape sequences into the
+/// user's terminal via handshake or tool metadata fields. `pretty`'s internal value formatter
+/// delegates to this same function for its `String` values, so control characters (including
+/// ESC) are backslash-escaped instead of passed through verbatim, and both call sites share one
+/// implementation. The returned string is always JSON-quoted, even for input with no control
+/// characters, since callers need one consistent (and unambiguous) rendering rather than
+/// conditionally-quoted output.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_cli::formatters::escape_display;
+///
+/// assert_eq!(escape_display("hello"), "\"hello\"");
+/// assert_eq!(escape_display("esc\u{1b}[2J"), "\"esc\\u001b[2J\"");
+/// ```
+#[must_use]
+pub fn escape_display(s: &str) -> String {
+    // `Value::String`'s `Display` impl serializes through the same JSON string writer as
+    // `serde_json::to_string`, but is infallible (no `Result` to unwrap): formatting a `String`
+    // as a JSON string literal cannot fail.
+    serde_json::Value::String(s.to_owned()).to_string()
+}
+
 /// JSON output formatting.
 pub mod json {
     use super::{Result, Serialize};
@@ -140,7 +169,7 @@ pub mod text {
 
 /// Pretty (human-readable) output formatting.
 pub mod pretty {
-    use super::{Colorize, Result, Serialize};
+    use super::{Colorize, Result, Serialize, escape_display};
 
     /// Format data as colorized, human-readable output.
     ///
@@ -183,10 +212,7 @@ pub mod pretty {
             Value::Null => Ok("null".dimmed().to_string()),
             Value::Bool(b) => Ok(b.to_string().yellow().to_string()),
             Value::Number(n) => Ok(n.to_string().cyan().to_string()),
-            Value::String(s) => {
-                let quoted = serde_json::to_string(s)?;
-                Ok(quoted.green().to_string())
-            }
+            Value::String(s) => Ok(escape_display(s).green().to_string()),
             Value::Array(arr) => {
                 if arr.is_empty() {
                     return Ok("[]".to_string());
@@ -384,6 +410,18 @@ mod tests {
             }
         }
         result
+    }
+
+    #[test]
+    fn test_escape_display_neutralizes_control_chars() {
+        let escaped = escape_display("evil\u{1b}[2Jname");
+        assert!(!escaped.contains('\u{1b}'));
+        assert!(escaped.contains("\\u001b"));
+    }
+
+    #[test]
+    fn test_escape_display_plain_string() {
+        assert_eq!(escape_display("hello"), "\"hello\"");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `generate`'s Text/Pretty output built its success and dry-run messages via direct `println!` interpolation, unlike `introspect`/`server`, which route all output through `formatters::format_output` and therefore escape control characters. A malicious or compromised MCP server could inject raw ANSI/control escape sequences into the user's terminal via its handshake `serverInfo.name`, reaching the default `Pretty` output path.
- Added `formatters::escape_display`, a small helper reusing the existing JSON-escaping mechanism, and wired it into `generate`'s Text/Pretty rendering. `pretty::format_value`'s `String` arm now delegates to the same helper instead of duplicating the escaping logic.
- Note: as a side effect, all server names (not just malicious ones) are now quoted in Text/Pretty output, e.g. `Server: Test Server (id)` becomes `Server: "Test Server" (id)`. Documented in CHANGELOG and pinned by tests.
- Known residual, intentionally out of scope here: `runner.rs`'s error-formatting path (`eprintln!("Error: {err:?}")`) still leaks raw control characters from a server-supplied JSON-RPC error message, on every subcommand's error path. Tracked separately in #308.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (969/969 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New unit tests cover control-char injection and benign-name quoting for both Text/Pretty, success/dry-run paths

Closes #299