### PR TITLE
fix(codegen): cap recursion depth in schema-to-TypeScript conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`mcp-execution-codegen`**: new `pub` constant `common::typescript::MAX_SCHEMA_RECURSION_DEPTH`
+  (128) bounding how deep `json_schema_to_typescript` and the JSDoc description sanitizer will
+  recurse into a schema before treating the remainder of a branch as opaque, as defense-in-depth
+  for direct callers of those two functions — a caller can hand either one an arbitrarily deep
+  `serde_json::Value` built by hand, which has no depth limit of its own the way a schema
+  deserialized from an MCP server's `tools/list` response does. This does not extend to the rest
+  of the `ProgressiveGenerator::generate`/`generate_with_categories` pipeline, which has other
+  unguarded recursive touches on the same schema (a raw `Value::Clone` before the sanitizer
+  runs, later re-serialization/Handlebars rendering, and eventual `Drop`) that this constant
+  does not cover (#303).
+
 ### Fixed
+
+- **`mcp-execution-codegen`**: `json_schema_to_typescript` and the JSDoc description sanitizer
+  recursed into a tool's `input_schema` with no depth limit, and the only existing guard bounded
+  the schema's serialized byte size rather than its nesting depth. Both functions now stop
+  recursing past `MAX_SCHEMA_RECURSION_DEPTH` and treat the remainder of the branch as opaque
+  instead of continuing to descend. This is defense-in-depth for direct callers of these two
+  functions, not a fix for a reachable live-server exploit: a schema arriving over the wire is
+  already bounded to well under this cap by `serde_json`'s own default deserialization
+  recursion limit before it ever reaches these functions (#303).
 
 - **`mcp-execution-skill`**: `scan_tools_directory` discarded the real `io::Error` from both of
   its `canonicalize` calls (the server directory and the `_meta.json` sidecar) and mislabeled

--- a/crates/mcp-codegen/src/common/typescript.rs
+++ b/crates/mcp-codegen/src/common/typescript.rs
@@ -23,6 +23,57 @@
 use serde_json::Value;
 use std::collections::HashSet;
 
+/// Maximum nesting depth [`json_schema_to_typescript`] will descend into before treating the
+/// remainder of a branch as opaque, rather than recursing further.
+///
+/// The JSDoc description sanitizer in `progressive::generator` uses the same cap. Both
+/// functions recurse into every nested `object`/`array` schema with no depth limit of
+/// their own, and `mcp_execution_introspector::MAX_SCHEMA_SIZE_BYTES` bounds a schema's
+/// *serialized byte size*, not its nesting depth — so nothing in this crate stops a caller from
+/// handing either function an arbitrarily deep, directly-constructed `serde_json::Value` (e.g.
+/// built by hand via `Value::Object`/`Map`, as in this module's own tests). That is the actual
+/// threat this constant defends against: **not** a schema arriving over the wire from a target
+/// MCP server. `input_schema` there is deserialized by `serde_json` from a `tools/list`
+/// response, and this workspace never raises or disables that deserializer's own default
+/// recursion limit (128 — no `disable_recursion_limit`/`unbounded_depth` anywhere in the
+/// dependency tree). Measured through a real `tools/list` envelope, that limit caps *reachable*
+/// nesting at 122 levels for an array-shaped schema and ~61 levels for `properties`-nested
+/// objects (each object level costs two parser recursion levels: the wrapper and its
+/// `properties` map) — a server that sends anything deeper gets its response line dropped as a
+/// parse error before `mcp-execution-introspector` ever builds a `ToolInfo` from it, let alone
+/// hands it to this crate. So on the wire path, this cap can never fire, let alone protect
+/// against a stack overflow.
+///
+/// This cap is therefore defense-in-depth for direct callers of these two functions — bounding
+/// a `Value` handed straight to `json_schema_to_typescript` or the JSDoc sanitizer, regardless
+/// of provenance — not a fix for a reachable wire-path denial of service, and **not** a
+/// guarantee that covers the rest of the `ProgressiveGenerator::generate`/
+/// `generate_with_categories` pipeline built on top of them. That pipeline has other
+/// unconditionally-recursive touches on the same schema this cap does not reach: e.g.
+/// `progressive::generator`'s `create_tool_context` clones `tool.input_schema` (an
+/// unguarded, recursive `Value::Clone`) before ever calling the capped sanitizer, and the
+/// schema is later re-serialized (`serde_json::to_vec`) and rendered through Handlebars, and
+/// eventually dropped (`Value`'s `Drop` impl is itself recursive) — none of which this constant
+/// bounds. 128 is set at the wire path's own ceiling (comfortably above the 122 levels a real
+/// `tools/list` response can ever produce, so no schema that actually arrives via introspection
+/// is ever clipped) while still bounding the unconditionally-recursive descent for a `Value`
+/// passed directly to either of these two functions.
+///
+/// That ceiling is coupled to `serde_json`'s own default recursion limit staying at 128: this
+/// value isn't an arbitrary round number, it's chosen to sit at the wire path's current ceiling
+/// specifically because that upstream default is 128. If a future `serde_json` release changes
+/// its own default, or this workspace ever configures a different limit, this constant's "never
+/// clips a real wire schema" property needs re-verifying against the new ceiling.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_codegen::common::typescript::MAX_SCHEMA_RECURSION_DEPTH;
+///
+/// assert!(MAX_SCHEMA_RECURSION_DEPTH > 0);
+/// ```
+pub const MAX_SCHEMA_RECURSION_DEPTH: usize = 128;
+
 /// Converts a snake_case name to camelCase for TypeScript.
 ///
 /// # Examples
@@ -192,6 +243,35 @@ pub fn json_type_to_typescript(json_type: &str) -> &'static str {
 /// ```
 #[must_use]
 pub fn json_schema_to_typescript(schema: &Value) -> String {
+    let mut cap_hit = false;
+    let ts_type = json_schema_to_typescript_at_depth(schema, 0, &mut cap_hit);
+    if cap_hit {
+        // Known limitation: `extract_properties` calls this function once per top-level
+        // property, so a schema whose properties each nest deeply logs once per affected
+        // property rather than once per tool, and this warning carries no tool/server
+        // identifier to correlate it back to the originating `generate_with_categories` call.
+        tracing::warn!(
+            max_depth = MAX_SCHEMA_RECURSION_DEPTH,
+            "schema nesting exceeded MAX_SCHEMA_RECURSION_DEPTH; branches beyond that depth were \
+             rendered as an opaque `unknown` type"
+        );
+    }
+    ts_type
+}
+
+/// Depth-tracked implementation backing [`json_schema_to_typescript`].
+///
+/// Once `depth` reaches [`MAX_SCHEMA_RECURSION_DEPTH`], the current branch is treated as
+/// opaque (`unknown`/`unknown[]`) instead of recursing further — see that constant's docs for
+/// what this cap actually defends against. `cap_hit` is set (never cleared) the first time any
+/// branch trips the cap, so the public wrapper can log once per call rather than once per
+/// clipped branch.
+fn json_schema_to_typescript_at_depth(schema: &Value, depth: usize, cap_hit: &mut bool) -> String {
+    if depth >= MAX_SCHEMA_RECURSION_DEPTH {
+        *cap_hit = true;
+        return "unknown".to_string();
+    }
+
     match schema {
         Value::Object(obj) => {
             // Get type field
@@ -216,7 +296,8 @@ pub fn json_schema_to_typescript(schema: &Value) -> String {
                         for (key, value) in props {
                             let is_required = required.contains(&key.as_str());
                             let optional_marker = if is_required { "" } else { "?" };
-                            let ts_type = json_schema_to_typescript(value);
+                            let ts_type =
+                                json_schema_to_typescript_at_depth(value, depth + 1, cap_hit);
                             let base_key = sanitize_ts_identifier(key);
                             let safe_key = disambiguate_identifier(&base_key, &mut used_keys);
                             fields.push(format!("  {safe_key}{optional_marker}: {ts_type};"));
@@ -234,7 +315,10 @@ pub fn json_schema_to_typescript(schema: &Value) -> String {
                 "array" => {
                     let items = obj.get("items");
                     if let Some(item_schema) = items {
-                        format!("{}[]", json_schema_to_typescript(item_schema))
+                        format!(
+                            "{}[]",
+                            json_schema_to_typescript_at_depth(item_schema, depth + 1, cap_hit)
+                        )
                     } else {
                         "unknown[]".to_string()
                     }
@@ -250,6 +334,15 @@ pub fn json_schema_to_typescript(schema: &Value) -> String {
 /// Extracts property definitions from JSON Schema for template rendering.
 ///
 /// Returns a vector of property information suitable for Handlebars templates.
+///
+/// Calls [`json_schema_to_typescript`] once per top-level property, starting each call fresh
+/// at depth 0 — the `schema`'s own `type: "object"` wrapper and `properties` map are peeled off
+/// by this function rather than counted by [`MAX_SCHEMA_RECURSION_DEPTH`]. So the real
+/// per-tool call path (`ProgressiveGenerator::extract_property_infos` /
+/// `extract_property_data`, both built on this function) tolerates one level more of true JSON
+/// nesting in a tool's raw `input_schema` than the constant's value alone would suggest: a
+/// property value schema can nest `MAX_SCHEMA_RECURSION_DEPTH` levels *below* the property
+/// itself before clipping, for `MAX_SCHEMA_RECURSION_DEPTH + 1` raw levels overall.
 ///
 /// # Examples
 ///
@@ -532,6 +625,85 @@ mod tests {
         });
 
         assert_eq!(json_schema_to_typescript(&schema), "string[]");
+    }
+
+    /// Builds a schema with `depth` nested `type: "array"` levels wrapping a `string` leaf.
+    ///
+    /// Assembles each level directly via `serde_json::Map`/`Value` (rather than the `json!`
+    /// macro, which round-trips embedded values through `to_value`'s own recursive
+    /// serializer) so building this pathological fixture can't itself overflow the stack.
+    fn nested_array_schema(depth: usize) -> Value {
+        let mut schema = json!({"type": "string"});
+        for _ in 0..depth {
+            let mut map = serde_json::Map::new();
+            map.insert("type".to_string(), Value::String("array".to_string()));
+            map.insert("items".to_string(), schema);
+            schema = Value::Object(map);
+        }
+        schema
+    }
+
+    /// Builds a schema with `depth` nested `type: "object"` levels (each with a single
+    /// property `"a"`) wrapping a `string` leaf, for the same construction reason as
+    /// [`nested_array_schema`].
+    fn nested_object_schema(depth: usize) -> Value {
+        let mut schema = json!({"type": "string"});
+        for _ in 0..depth {
+            let mut properties = serde_json::Map::new();
+            properties.insert("a".to_string(), schema);
+            let mut map = serde_json::Map::new();
+            map.insert("type".to_string(), Value::String("object".to_string()));
+            map.insert("properties".to_string(), Value::Object(properties));
+            map.insert("required".to_string(), Value::Array(Vec::new()));
+            schema = Value::Object(map);
+        }
+        schema
+    }
+
+    /// Runs `f` on a dedicated thread with a generous stack, and returns its result.
+    ///
+    /// `serde_json::Value`'s own `Drop` impl is recursive and unrelated to this module's fix:
+    /// a `Value` nested 5,000+ levels deep overflows the *default* thread stack merely by
+    /// going out of scope, regardless of how it was traversed beforehand. That's not
+    /// reachable in production — `serde_json`'s deserializer already rejects JSON nested
+    /// beyond its own default recursion limit (well under 5,000) before a `Value` this deep
+    /// can ever be constructed from the wire — but a test fixture built directly via
+    /// `Value`/`Map` (bypassing deserialization, see [`nested_array_schema`]) still has to
+    /// survive being dropped at the end of the test. A larger stack lets construction, the
+    /// (now depth-capped) function under test, and teardown all complete without that
+    /// unrelated limitation masking a pass.
+    fn run_on_large_stack<F: FnOnce() + Send + 'static>(f: F) {
+        std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn test thread")
+            .join()
+            .expect("test thread panicked");
+    }
+
+    #[test]
+    fn test_json_schema_to_typescript_bounds_deeply_nested_array() {
+        // Issue #303: verifies the recursion-depth cap actually bounds this function's
+        // descent for a `Value` nested far beyond MAX_SCHEMA_RECURSION_DEPTH (see that
+        // constant's docs — this is defense-in-depth for the `pub` API, not a reachable
+        // wire-path scenario). Past the cap, the type must degrade to a well-formed
+        // `unknown[]...[]` string rather than continuing to recurse.
+        run_on_large_stack(|| {
+            let schema = nested_array_schema(5_000);
+            let result = json_schema_to_typescript(&schema);
+            assert!(result.starts_with("unknown"), "{result}");
+            assert!(result.ends_with("[]"), "{result}");
+        });
+    }
+
+    #[test]
+    fn test_json_schema_to_typescript_bounds_deeply_nested_object() {
+        // Same cap-behavior check as the array case above, for object nesting.
+        run_on_large_stack(|| {
+            let schema = nested_object_schema(5_000);
+            let result = json_schema_to_typescript(&schema);
+            assert!(result.contains("unknown"), "{result}");
+        });
     }
 
     #[test]

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -32,7 +32,8 @@
 
 use crate::common::types::{GeneratedCode, GeneratedFile};
 use crate::common::typescript::{
-    disambiguate_identifier, extract_properties, sanitize_ts_identifier, to_camel_case,
+    MAX_SCHEMA_RECURSION_DEPTH, disambiguate_identifier, extract_properties,
+    sanitize_ts_identifier, to_camel_case,
 };
 use crate::progressive::types::{
     BridgeContext, CategoryInfo, IndexContext, PropertyInfo, ToolCategorization, ToolContext,
@@ -981,11 +982,41 @@ fn resolve_typescript_names(tools: &[ToolInfo]) -> Vec<String> {
 }
 
 fn sanitize_schema_jsdoc_descriptions(mut value: serde_json::Value) -> serde_json::Value {
-    sanitize_schema_jsdoc_value(&mut value);
+    let mut cap_hit = false;
+    sanitize_schema_jsdoc_value(&mut value, 0, &mut cap_hit);
+    if cap_hit {
+        // Known limitation: unlike `json_schema_to_typescript` (called once per property via
+        // `extract_properties`), `create_tool_context` calls this once per tool directly on
+        // the whole `input_schema` — but this warning still carries no tool/server identifier
+        // to correlate it back to the originating `generate_with_categories` call.
+        tracing::warn!(
+            max_depth = MAX_SCHEMA_RECURSION_DEPTH,
+            "schema nesting exceeded MAX_SCHEMA_RECURSION_DEPTH; descriptions beyond that depth \
+             were left unsanitized"
+        );
+    }
     value
 }
 
-fn sanitize_schema_jsdoc_value(value: &mut serde_json::Value) {
+/// Sanitizes every `description` field in `value`'s tree in place, recursing into nested
+/// objects and arrays up to [`MAX_SCHEMA_RECURSION_DEPTH`] — see that constant's docs for what
+/// this cap actually defends against (this crate's `pub` API surface, not a reachable wire-path
+/// schema). `cap_hit` is set (never cleared) the first time any branch trips the cap, so the
+/// public wrapper can log once per call rather than once per clipped branch.
+///
+/// `value` is (a clone of) a tool's `input_schema`, called on the schema's true top level with
+/// no depth peeled off beforehand (unlike [`typescript::extract_properties`]'s call path into
+/// `json_schema_to_typescript`) — so `depth` here always matches the schema's real JSON
+/// nesting. Beyond the depth cap, remaining branches are left unsanitized rather than
+/// continuing to recurse.
+///
+/// [`typescript::extract_properties`]: crate::common::typescript::extract_properties
+fn sanitize_schema_jsdoc_value(value: &mut serde_json::Value, depth: usize, cap_hit: &mut bool) {
+    if depth >= MAX_SCHEMA_RECURSION_DEPTH {
+        *cap_hit = true;
+        return;
+    }
+
     match value {
         serde_json::Value::Object(map) => {
             for (key, child) in map.iter_mut() {
@@ -996,13 +1027,13 @@ fn sanitize_schema_jsdoc_value(value: &mut serde_json::Value) {
                         *child = serde_json::Value::Null;
                     }
                 } else {
-                    sanitize_schema_jsdoc_value(child);
+                    sanitize_schema_jsdoc_value(child, depth + 1, cap_hit);
                 }
             }
         }
         serde_json::Value::Array(values) => {
             for child in values {
-                sanitize_schema_jsdoc_value(child);
+                sanitize_schema_jsdoc_value(child, depth + 1, cap_hit);
             }
         }
         _ => {}
@@ -2234,6 +2265,102 @@ mod tests {
             .unwrap();
 
         assert_eq!(description, "Tag *\\/ injected next");
+    }
+
+    /// Builds a schema with `depth` nested `type: "array"` levels, each carrying its own
+    /// `description`, wrapping a `string` leaf that also has a `description`.
+    ///
+    /// Assembled directly via `serde_json::Map`/`Value` (like
+    /// `typescript::tests::nested_array_schema`) so building this fixture can't itself
+    /// overflow the stack, and using `"array"`/`"items"` rather than `"object"`/`"properties"`
+    /// so each `depth` step costs exactly one recursion level in
+    /// [`sanitize_schema_jsdoc_value`] — unlike an `"object"`/`"properties"`-nested schema,
+    /// where the intermediate `properties` map itself consumes a level (see
+    /// [`sanitize_schema_jsdoc_value`]'s doc comment) — making it possible to predict exactly
+    /// which nesting level lands on either side of [`MAX_SCHEMA_RECURSION_DEPTH`].
+    fn nested_array_schema_with_descriptions(depth: usize, description: &str) -> serde_json::Value {
+        let mut schema = json!({"type": "string", "description": description});
+        for _ in 0..depth {
+            let mut map = serde_json::Map::new();
+            map.insert(
+                "type".to_string(),
+                serde_json::Value::String("array".to_string()),
+            );
+            map.insert("items".to_string(), schema);
+            map.insert(
+                "description".to_string(),
+                serde_json::Value::String(description.to_string()),
+            );
+            schema = serde_json::Value::Object(map);
+        }
+        schema
+    }
+
+    /// Walks `depth` `"items"` hops into `value`, returning the schema found there.
+    fn nth_level(value: &serde_json::Value, depth: usize) -> serde_json::Value {
+        let mut v = value.clone();
+        for _ in 0..depth {
+            v = v["items"].clone();
+        }
+        v
+    }
+
+    #[test]
+    fn test_sanitize_schema_jsdoc_bounds_deeply_nested_schema() {
+        // Issue #303: `input_schema` is attacker-controlled and this sanitizer used to
+        // recurse into every nested object/array with no depth limit; this is
+        // defense-in-depth for the pub API surface (see `MAX_SCHEMA_RECURSION_DEPTH`'s docs
+        // in `typescript.rs`), not a fix for a wire-reachable schema. Asserts the cap's actual
+        // observable effect rather than just "doesn't panic": a `description` one level below
+        // the cap is still sanitized, while one at the cap is left untouched because the
+        // function stops recursing before ever reaching it.
+        const MALICIOUS: &str = "desc */ injected\nnext";
+        let depth = MAX_SCHEMA_RECURSION_DEPTH + 10;
+        let schema = nested_array_schema_with_descriptions(depth, MALICIOUS);
+
+        let sanitized = sanitize_schema_jsdoc_descriptions(schema);
+
+        let just_below_cap = nth_level(&sanitized, MAX_SCHEMA_RECURSION_DEPTH - 1);
+        let below_description = just_below_cap["description"]
+            .as_str()
+            .expect("description below the cap must still be a string");
+        assert!(
+            !below_description.contains("*/"),
+            "description one level below the cap must be sanitized: {below_description}"
+        );
+
+        let at_cap = nth_level(&sanitized, MAX_SCHEMA_RECURSION_DEPTH);
+        let at_cap_description = at_cap["description"]
+            .as_str()
+            .expect("description at the cap must still be a string");
+        assert_eq!(
+            at_cap_description, MALICIOUS,
+            "description at the cap must be left untouched — the function must stop \
+             recursing before reaching it"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_schema_jsdoc_survives_pathologically_deep_input() {
+        // Issue #303: a caller of this crate's `pub` API could hand it a `Value` nested far
+        // beyond any depth reachable via introspection (see `MAX_SCHEMA_RECURSION_DEPTH`'s
+        // docs). Must not stack overflow at 5,000+ levels, however that `Value` was built.
+        //
+        // Runs on a dedicated large-stack thread because `serde_json::Value`'s own `Drop` is
+        // recursive and unrelated to this fix: dropping a sufficiently deep `Value` overflows
+        // the *default* thread stack merely by going out of scope, regardless of how it was
+        // traversed beforehand — see `typescript::tests::run_on_large_stack` for the full
+        // rationale.
+        std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(|| {
+                let schema = nested_array_schema_with_descriptions(5_000, "leaf");
+                let sanitized = sanitize_schema_jsdoc_descriptions(schema);
+                assert!(sanitized.is_object());
+            })
+            .expect("spawn test thread")
+            .join()
+            .expect("test thread panicked");
     }
 
     #[test]

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -1153,6 +1153,22 @@ fn build_server_info(
 /// `description`, and serialized `input_schema`/`output_schema` size (denial-of-service
 /// protection, CWE-400) against a malicious or misbehaving MCP server.
 ///
+/// `(*tool.input_schema).clone()` below, and both `serde_json::to_vec` calls, walk the
+/// schema's full tree recursively with no depth limit of their own (`Value`'s `Clone` impl and
+/// its `Serialize` implementation are both unconditionally recursive) — the same class of
+/// unguarded recursion `mcp-execution-codegen`'s `MAX_SCHEMA_RECURSION_DEPTH` defends against
+/// (issue #303). That cap is not duplicated here because it doesn't need to be: by the time a
+/// `Tool` reaches this function, `tool.input_schema`/`tool.output_schema` were already produced
+/// by deserializing this server's `tools/list` response (via this crate's own JSON-RPC decoder
+/// for the stdio transport, or `rmcp`'s HTTP transport for the HTTP/SSE case), and `serde_json`
+/// enforces its own default recursion limit (128) while deserializing — nothing in this
+/// workspace's dependency tree raises or disables it (no `disable_recursion_limit`/
+/// `unbounded_depth`). A schema nested deep enough to threaten a recursive `clone`/serialize
+/// here would already have failed to deserialize into a `Tool` in the first place, surfacing as
+/// a recoverable parse error rather than reaching this function. See
+/// `mcp_execution_codegen::common::typescript::MAX_SCHEMA_RECURSION_DEPTH`'s docs for the
+/// measured reachable-depth ceiling this reasoning is based on.
+///
 /// # Errors
 ///
 /// Returns [`Error::ResourceLimitExceeded`] if the tool's name exceeds [`MAX_TOOL_NAME_LEN`],

--- a/crates/mcp-server/src/state.rs
+++ b/crates/mcp-server/src/state.rs
@@ -76,6 +76,15 @@ pub enum StateError {
 /// `server_info`'s tool list), used only to enforce [`MAX_TOTAL_PENDING_BYTES`]. A serialization
 /// failure is treated as exceeding any bound, rather than silently under-counting a session
 /// that could not be measured.
+///
+/// `serde_json::to_vec`'s `Serialize` implementation for `Value` (nested inside `server_info`'s
+/// tool schemas) is unconditionally recursive with no depth limit of its own — the same class
+/// of unguarded recursion `mcp-execution-codegen`'s `MAX_SCHEMA_RECURSION_DEPTH` defends
+/// against (issue #303). It isn't guarded separately here for the same reason it isn't guarded
+/// in `mcp-execution-introspector`'s `build_tool_info`, which is what originally built every
+/// schema in `server_info`: `serde_json`'s deserializer already enforces its own default
+/// recursion limit while parsing a `tools/list` response, so nothing reaching this function was
+/// ever deep enough to threaten a recursive serialize.
 fn estimate_size_bytes(generation: &PendingGeneration) -> usize {
     serde_json::to_vec(&generation.server_info).map_or(usize::MAX, |bytes| bytes.len())
 }


### PR DESCRIPTION
## Summary

- `json_schema_to_typescript` and the JSDoc description sanitizer in `mcp-execution-codegen` recursed into a tool's `input_schema` with no depth limit. The only existing guard, `MAX_SCHEMA_SIZE_BYTES`, bounds serialized byte size, not nesting depth, so a schema could reach thousands of levels while staying well under that cap.
- Adds `MAX_SCHEMA_RECURSION_DEPTH` (128, matched to `serde_json`'s own parse-time recursion limit) to both functions; each degrades to an opaque type / unsanitized remainder past the cap instead of recursing further, and logs a warning when the cap trips.
- The cap is documented as defense-in-depth for direct callers of these two functions rather than a guarantee over the full `ProgressiveGenerator::generate` pipeline — a schema arriving over the wire is already bounded well under this cap by `serde_json`'s own recursion limit (no `unbounded_depth`/`disable_recursion_limit` is used anywhere in the dependency tree, for either stdio or HTTP transports), so this closes a defense-in-depth gap in the public library API rather than a currently-reachable live-server DoS.
- `mcp-introspector`/`mcp-server` got doc-only comments explaining why their own recursive clone/serialize calls on the same schema tree don't need a matching guard, for the same reason.

Closes #303

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1007/1007)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Regression tests assert the cap's observable effect and were independently verified (twice) to fail against the pre-fix unbounded implementation