### PR TITLE
docs: reverse-engineered specification package

### DIFF
--- a/specs/BRD-mcp-execution-2026-07-27.md
+++ b/specs/BRD-mcp-execution-2026-07-27.md
@@ -1,0 +1,575 @@
+---
+aliases:
+  - mcp-execution BRD
+  - MCP Code Execution BRD
+tags:
+  - brd
+  - mcp
+  - codegen
+  - status/draft
+created: 2026-07-27
+project: "mcp-execution"
+status: draft
+related:
+  - "[[README]]"
+  - "[[constitution]]"
+  - "[[SRS-mcp-execution-2026-07-27]]"
+  - "[[NFR-mcp-execution-2026-07-27]]"
+---
+
+# mcp-execution: Business Requirements Document
+
+> [!abstract]
+> This BRD was **reverse-engineered from an already-built, released system**
+> (workspace version `0.8.0`, 18 tags from `v0.1.0` to `v0.8.0`), not authored
+> before implementation. Every statement below is grounded in `README.md`,
+> `CHANGELOG.md`, `Cargo.toml` package metadata, `SECURITY.md`,
+> `CONTRIBUTING.md`, and the per-crate specs in this `specs/` package. There
+> is no stream-of-consciousness input document to preserve — the "problem
+> statement" and "target users" sections below are derived from what the
+> project's own public-facing documents say about themselves, not from an
+> interview or a founding brief, because no such artifact exists in this
+> repository. Where the repo is silent on a normally-expected BRD element
+> (market sizing, named stakeholders, budget, timeline), this is stated
+> explicitly rather than invented — see [[#Open Questions]].
+
+## Executive Summary
+
+**mcp-execution** is a Rust workspace (CLI binary, MCP server binary, and five
+library crates) that converts any [MCP (Model Context
+Protocol)](https://spec.modelcontextprotocol.io/) server's tool definitions
+into a self-contained package of TypeScript files using a "progressive
+loading" code-generation pattern — one file per tool, discoverable via plain
+`ls`/`cat` — so that an AI coding agent (concretely, Claude Code) loads only
+the token budget of the tools it actually invokes in a session instead of an
+entire server's tool manifest. The project explicitly credits [Anthropic's
+"Code Execution with
+MCP"](https://www.anthropic.com/engineering/code-execution-with-mcp)
+engineering blog post as its inspiration (`README.md`). It ships both as a
+standalone CLI (`mcp-execution-cli`) and as an MCP server in its own right
+(`mcp-execution-server`), the latter letting Claude Code drive the same
+generation pipeline using its own natural-language tool-categorization
+ability instead of a second, separately-billed LLM call.
+
+## Problem Statement
+
+- **What problem exists today?** Per `README.md`'s own "The Problem" section:
+  "Traditional MCP integration loads ALL tools from a server (~30,000
+  tokens), even when you only need one or two. This wastes context window
+  space and slows down AI agents."
+- **Who experiences this problem?** Any developer or AI-agent host (Claude
+  Code, by name, per the generated-file target path
+  `~/.claude/servers/{id}/` and the `~/.claude/mcp.json` config format
+  consumed by `--from-config`) that connects to one or more MCP servers with
+  more tools than a given task needs.
+- **What is the impact of not solving it?** Context-window/token-budget
+  consumption for the AI agent session, quantified in `README.md` as up to
+  **98% token savings** achieved by not solving it the traditional way — this
+  is the project's own claimed number, not an independently verified
+  benchmark. `CHANGELOG.md`'s `[0.2.0]` "Notes" section additionally records
+  that an original internal estimate of "90%+ savings" was revised down to an
+  asymptotic "~83% maximum" as the codebase matured, then the current
+  `README.md` states 98% — the two documents disagree numerically and the
+  repo does not reconcile them; see [[#Open Questions]].
+- **What are current workarounds (if any)?** The de-facto workaround this
+  project replaces is the standard MCP client behavior of loading a server's
+  full tool manifest up front; the project's own solution *is* the
+  documented alternative (Anthropic's code-execution-with-MCP pattern).
+
+> [!warning] Assumptions
+> - No user research, customer interviews, or support-ticket history is
+>   present anywhere in this repository. The problem statement above is
+>   taken at face value from the project's own README, not independently
+>   validated against real user complaints.
+> - "AI agents" and "Claude Code" are used interchangeably in project
+>   documentation; the repo does not evidence testing against, or explicit
+>   support for, any other MCP-capable agent host, even though the
+>   generation output (plain TypeScript executed via `tsx`/`deno`/Node) is
+>   not intrinsically Claude-specific.
+
+## Target Users
+
+> [!warning] Assumptions
+> No persona research, user interviews, or usage telemetry exist in this
+> repository. The user categories below are inferred solely from *who the
+> software's interfaces are built for* (CLI ergonomics, config file format,
+> crates.io publishing), not from any documented research.
+
+### Primary Users
+
+Individual developers who run **Claude Code** locally with one or more MCP
+servers configured in `~/.claude/mcp.json`, and who use
+`mcp-execution-cli generate --from-config <server>` (or the equivalent MCP
+server tools) to pre-generate progressive-loading TypeScript tools instead of
+letting their agent host load the server's full tool manifest. Evidenced by:
+the CLI's `--from-config` flag reading `~/.claude/mcp.json` directly
+(`specs/cli/spec.md`), the fixed output path `~/.claude/servers/{id}/`, and
+the `setup` subcommand that specifically validates a local Node.js
+installation and `~/.claude/mcp.json`'s presence.
+
+### Secondary Users
+
+Rust developers embedding individual workspace crates
+(`mcp-execution-core`, `-introspector`, `-codegen`, `-files`, `-skill`) as
+libraries in their own tooling, rather than using the CLI at all. Evidenced
+by: each crate being independently published to crates.io with its own
+`description`/`keywords`/`categories` in `Cargo.toml`, and `README.md`'s "As a
+library" installation section.
+
+### Stakeholders
+
+The repository's sole recorded author/maintainer (`Andrei G`, per
+`Cargo.toml`'s `workspace.package.authors` and `git config`), and open-source
+contributors following `CONTRIBUTING.md`. No product owner, company,
+customer, or sponsor distinct from the maintainer is evidenced anywhere in
+the repository (no `NOTICE`, no named organization in `Cargo.toml`, no
+enterprise-support document). `CHANGELOG.md`'s earliest entries (`[0.2.0]`,
+2025-11-23) credit "Rust Project Architect, Performance Engineer, and
+Security Engineer agents" for development — i.e. the project's own history
+records AI-agent-assisted development, not a human team roster.
+
+## Functional Requirements
+
+Feature areas below map 1:1 to the workspace crates documented in
+[[README#Block Structure]] and are expanded into formal `SHALL` requirements
+with acceptance criteria in [[SRS-mcp-execution-2026-07-27]]. FR numbering is
+shared between this BRD and the SRS for traceability.
+
+### Server Introspection
+
+- **FR-001**: As a developer, I need to connect to any MCP server (stdio
+  subprocess, or HTTP/SSE endpoint) and discover its tools, so that I can
+  generate code for a server without knowing its schema in advance.
+  - *Acceptance criteria*: `introspect` (CLI) / `introspect_server` (MCP
+    tool) returns tool count, names, descriptions, and (optionally) full
+    JSON schemas for a reachable server; a hung or unreachable server fails
+    within its configured timeout rather than blocking indefinitely.
+  - *Priority*: Must
+- **FR-002**: As a developer, I need introspection to reject a server that
+  returns an excessive number of tools, or tools with oversized
+  names/descriptions/schemas, so that a misbehaving or hostile server cannot
+  exhaust memory or disk during code generation.
+  - *Acceptance criteria*: introspection enforces documented, fixed bounds
+    (tool count, name/description length, schema size) and fails with a
+    named-resource error rather than degrading silently.
+  - *Priority*: Must
+- **FR-003**: As a developer, I need the tool that introspects a server on my
+  behalf to validate the connection details (command, arguments, environment
+  variables, URL, headers) before using them, so that a hand-edited or
+  malicious server config cannot be used to run arbitrary shell commands or
+  leak environment variables.
+  - *Acceptance criteria*: connection details containing shell metacharacters
+    or a forbidden/dangerous environment variable name are rejected before
+    any process is spawned or connection opened.
+  - *Priority*: Must
+- **FR-004**: As a developer, I need repeated introspection of the same
+  server within one process to be cached, so that redundant network/process
+  round-trips are avoided.
+  - *Acceptance criteria*: `Introspector` exposes `get_server`/`list_servers`
+    over an in-process cache keyed by server id.
+  - *Priority*: Should
+
+### Progressive Loading Code Generation
+
+- **FR-005**: As a developer, I need each discovered tool converted into its
+  own self-contained TypeScript file (types, JSDoc, an executable CLI
+  entry point), so that an agent can load exactly one tool's definition
+  instead of a whole server's manifest.
+  - *Acceptance criteria*: for a server with N tools, generation produces one
+    `.ts` file per tool plus a fixed set of supporting files (index,
+    runtime bridge, package/tsconfig, metadata sidecar).
+  - *Priority*: Must
+- **FR-006**: As a developer, I need generated tool metadata (name,
+  description, parameter descriptions) recoverable without re-parsing the
+  generated TypeScript, so that downstream tooling (SKILL.md generation) can
+  read structured data instead of scraping source code.
+  - *Acceptance criteria*: a `_meta.json` sidecar is always emitted alongside
+    the generated tools, versioned, and consumed by `mcp-execution-skill`
+    directly.
+  - *Priority*: Must
+- **FR-007**: As a developer, I need Claude Code's own natural-language
+  understanding to categorize tools during generation, so that this project
+  does not need its own separately-billed LLM API integration.
+  - *Acceptance criteria*: `mcp-execution-server` exposes a two-call protocol
+    (`introspect_server` then `save_categorized_tools`) in which the calling
+    Claude session supplies the categorization; the CLI's plain `generate`
+    path produces uncategorized output without contacting any LLM.
+  - *Priority*: Must
+- **FR-008**: As a developer, I need generation to reject a tool set that
+  would produce an excessive number of files or bytes, so that a large or
+  hostile server cannot be used to fill disk space via generated output.
+  - *Acceptance criteria*: generation enforces fixed file-count and byte
+    bounds, derived from introspection's own bounds, and fails loudly rather
+    than partially writing output.
+  - *Priority*: Must
+- **FR-009**: As a developer, I need to preview what generation would produce
+  without writing anything to disk, so that I can inspect the output of a
+  new/unfamiliar server safely.
+  - *Acceptance criteria*: `generate --dry-run` renders a file list with
+    sizes and writes nothing to the filesystem.
+  - *Priority*: Should
+
+### Virtual Filesystem & Atomic Export
+
+- **FR-010**: As a developer, I need generated output published to
+  `~/.claude/servers/{id}/` such that a process killed mid-write never leaves
+  a half-written tree, so that a crashed generation run cannot corrupt a
+  previously working tool set.
+  - *Acceptance criteria*: export stages content in a sibling temporary
+    directory and publishes it via an atomic rename; a killed process leaves
+    the previous, complete tree in place or a recoverable staging artifact,
+    never a partial target directory.
+  - *Priority*: Must
+- **FR-011**: As a developer, I need re-generating one server's tools to
+  never affect a different server's already-generated directory, so that
+  managing many MCP servers' generated output side by side is safe.
+  - *Acceptance criteria*: export treats the shared servers directory as a
+    set of independently-published per-server groups; a failure publishing
+    one server's group does not roll back or corrupt a sibling group.
+  - *Priority*: Must
+- **FR-012**: As a developer, I need re-generating a server with fewer tools
+  than before to remove the now-stale tool files, so that deleted/renamed
+  tools don't leave orphaned files behind.
+  - *Acceptance criteria*: exporting a server's group replaces that group's
+    directory contents wholesale rather than merging.
+  - *Priority*: Must
+- **FR-013**: As a developer, I need export to reject a batch that would
+  exceed fixed file-count/byte bounds before writing anything, so that
+  export cannot be used to exhaust disk space independent of the
+  code-generation bound already checked upstream.
+  - *Acceptance criteria*: `FilesBuilder`/`FileSystem` export enforces
+    `MAX_EXPORT_FILES`/`MAX_EXPORT_BYTES`, equal to codegen's own derived
+    bounds.
+  - *Priority*: Must
+
+### SKILL.md Generation
+
+- **FR-014**: As a developer, I need a Claude Code `SKILL.md` integration
+  file generated from a server's already-generated tools, so that Claude
+  Code can discover and describe the tool set without me hand-writing
+  documentation.
+  - *Acceptance criteria*: `mcp-execution-cli skill` renders a `SKILL.md`
+    directly from a generated server's `_meta.json`, with no LLM call
+    required.
+  - *Priority*: Must
+- **FR-015**: As a developer, I need an alternative path where Claude itself
+  composes the `SKILL.md` body (better summaries than a fixed template), so
+  that I can trade a template-only render for LLM-quality prose when using
+  the MCP server.
+  - *Acceptance criteria*: `mcp-execution-server`'s `generate_skill` returns
+    an LLM-facing generation prompt; `save_skill` writes Claude's composed
+    content back to disk.
+  - *Priority*: Should
+- **FR-016**: As a developer, I need `SKILL.md` generation to detect drift
+  between the metadata sidecar and the tool files actually on disk, so that
+  I'm warned if the two have gone out of sync (e.g. manual edits, partial
+  regeneration).
+  - *Acceptance criteria*: scanning fails loudly if a sidecar entry has no
+    matching `.ts` file, and reports (non-fatally) any `.ts` file with no
+    sidecar entry.
+  - *Priority*: Must
+- **FR-017**: As a developer, I need `save_skill`/CLI `skill` writes confined
+  to the intended output location, so that a malicious or malformed
+  `server_id`/output path cannot write outside the intended skills
+  directory.
+  - *Acceptance criteria*: output path resolution is confined to
+    `base_dir/server_id`, symlink-aware, and rejects path traversal.
+  - *Priority*: Must
+
+### CLI Server Configuration Management
+
+- **FR-018**: As a developer, I need to list, inspect, and validate the MCP
+  servers configured in `~/.claude/mcp.json` without running full generation,
+  so that I can check my configuration quickly.
+  - *Acceptance criteria*: `mcp-execution-cli server list/info/validate`
+    read `~/.claude/mcp.json` as the single source of truth and report each
+    entry's availability.
+  - *Priority*: Should
+- **FR-019**: As a developer, I need to verify my local machine is ready to
+  execute generated tools (Node.js present and new enough, generated files
+  executable, config present), so that I can diagnose setup problems before
+  first use.
+  - *Acceptance criteria*: `mcp-execution-cli setup` checks Node.js version,
+    marks generated `.ts` files executable (Unix), and reports config
+    presence.
+  - *Priority*: Should
+- **FR-020**: As a developer, I need shell completion scripts for the CLI, so
+  that I can use it efficiently from an interactive shell.
+  - *Acceptance criteria*: `mcp-execution-cli completions <shell>` emits a
+    valid completion script for bash/zsh/fish/powershell/elvish.
+  - *Priority*: Could
+- **FR-021**: As a developer, I need every CLI output format (JSON/text/
+  pretty) to escape server-reported values before printing them, so that a
+  malicious MCP server cannot inject terminal control sequences into my
+  shell.
+  - *Acceptance criteria*: server-supplied names/text are escaped/quoted in
+    every output format, not only JSON.
+  - *Priority*: Must
+
+### MCP Server Exposure (Session-Based Workflow)
+
+- **FR-022**: As Claude Code (or another MCP client), I need to introspect a
+  server and receive a session id representing that introspection, so that I
+  can categorize its tools in a follow-up call rather than in one giant
+  request.
+  - *Acceptance criteria*: `introspect_server` returns a session id and
+    expiry; the session can be redeemed exactly once by
+    `save_categorized_tools`.
+  - *Priority*: Must
+- **FR-023**: As Claude Code, I need my categorization submitted in
+  `save_categorized_tools` validated against what was actually introspected,
+  so that I cannot (accidentally or otherwise) cause generation for tools
+  that were never discovered.
+  - *Acceptance criteria*: submitted tool names must match the session's own
+    introspected set exactly (after identical sanitization); extra, missing,
+    or duplicate names are rejected.
+  - *Priority*: Must
+- **FR-024**: As the operator of this MCP server, I need the number of
+  in-flight (pending) introspection sessions and their aggregate memory
+  footprint bounded, so that many concurrent or abandoned sessions cannot
+  exhaust server memory.
+  - *Acceptance criteria*: a fixed cap on pending session count and a
+    separate fixed cap on aggregate estimated session bytes both apply
+    independently; exceeding either is rejected before the session is
+    stored.
+  - *Priority*: Must
+- **FR-025**: As Claude Code, I need to list previously generated servers
+  under the default (or a caller-specified, confined) output location, so
+  that I can check what's already been generated without re-introspecting.
+  - *Acceptance criteria*: `list_generated_servers` enumerates subdirectories
+    with tool counts and generation timestamps; a caller-specified
+    `base_dir` is confined to the server's own base directory.
+  - *Priority*: Should
+- **FR-026**: As the operator of this MCP server, I need a long-running or
+  hung request against one target server to never block requests targeting
+  a different server, so that one slow/unreachable MCP server doesn't
+  degrade the whole session for unrelated servers.
+  - *Acceptance criteria*: per-server-id and per-output-directory locking is
+    scoped narrowly enough that concurrent operations against different
+    targets proceed independently.
+  - *Priority*: Should
+
+### Security Validation & Hardening
+
+- **FR-027**: As any user of this software, I need any value that could be a
+  secret (env var value, HTTP header value, URL credentials, CLI argument)
+  excluded from debug/log output, so that a crash report, verbose log, or
+  error message never leaks a token.
+  - *Acceptance criteria*: every type capable of carrying such a value
+    implements a redacting `Debug`; regression tests assert specific secret
+    substrings never appear in debug-formatted output.
+  - *Priority*: Must
+- **FR-028**: As any user of this software, I need any text an introspected
+  (untrusted) MCP server supplies — before it reaches me as an LLM prompt or
+  rendered document — sanitized and clearly marked as untrusted data, so
+  that a hostile server cannot smuggle instructions into what I read as
+  trusted output.
+  - *Acceptance criteria*: server-reported tool names/descriptions/keywords
+    are sanitized (control characters removed/flattened) and, where
+    LLM-facing, wrapped in an explicit, unforgeable untrusted-data boundary.
+  - *Priority*: Must
+- **FR-029**: As any user of this software, I need every filesystem write
+  whose target path is influenced by caller/server input confined to its
+  intended base directory, so that a crafted `server_id` or path cannot
+  write outside the intended location, even via a planted symlink.
+  - *Acceptance criteria*: path confinement is checked component-by-component
+    against a canonicalized base, rejects a symlink at the confinement
+    boundary outright, and is re-checked immediately before each write
+    (never cached).
+  - *Priority*: Must
+
+## Non-Functional Requirements
+
+Detailed, measurable non-functional requirements are specified separately in
+[[NFR-mcp-execution-2026-07-27]] (this project has more than five quality
+attributes with concrete, code-enforced targets, meeting this pipeline's own
+threshold for a standalone NFR document). Summary below.
+
+### Performance
+
+Token-budget reduction is the project's core value proposition (claimed 98%
+savings, `README.md`), backed by measured code-generation/export timings far
+inside documented targets. See [[NFR-mcp-execution-2026-07-27#2. Performance Efficiency]].
+
+### Scalability
+
+Not applicable in the traditional server-scaling sense — this is a
+locally-run CLI/library/single-process MCP server, not a hosted multi-tenant
+service. Resource-exhaustion bounds (tool count, file count, session count)
+exist instead to bound a *single* process's worst case; see
+[[NFR-mcp-execution-2026-07-27#3. Reliability]].
+
+### Security & Privacy
+
+The dominant, most heavily-invested engineering concern in this codebase per
+the reverse-engineered [[constitution#V. Security]]. Fully detailed in
+[[NFR-mcp-execution-2026-07-27#4. Security]].
+
+### Availability
+
+Not applicable — no hosted/always-on component exists; the MCP server binary
+runs for the lifetime of a local Claude Code session over stdio, not as a
+managed service with an uptime SLA.
+
+### Usability
+
+Developer-CLI usability only (help text, shell completions, structured exit
+codes); no GUI, no accessibility, no internationalization requirements are
+evidenced. See [[NFR-mcp-execution-2026-07-27#5. Usability]].
+
+## Scope & Boundaries
+
+### In Scope
+
+- CLI (`mcp-execution-cli`): introspect, generate, skill, server, setup,
+  completions subcommands.
+- MCP server (`mcp-execution-server`): `introspect_server`,
+  `save_categorized_tools`, `list_generated_servers`, `generate_skill`,
+  `save_skill` tools.
+- Progressive-loading TypeScript code generation from MCP tool schemas.
+- SKILL.md generation for Claude Code integration.
+- In-memory VFS with atomic, crash-safe filesystem export.
+- Security hardening: command-injection defense, resource-exhaustion (CWE-400)
+  bounds, prompt-injection defense, debug-redaction, path confinement.
+- Independent publishing of five library crates to crates.io.
+
+### Out of Scope
+
+> [!danger] Explicit Exclusions
+> Confirmed by direct evidence (removed code, documented non-goals, or
+> structural guards against the excluded thing), not assumed.
+
+- **A standalone runtime package.** `mcp-execution-runtime` (an npm package
+  duplicating the generated bridge) was removed entirely (`CHANGELOG.md`
+  `[Unreleased]`, #261) for being an unhardened, structurally-unsynchronizable
+  fork of the generated bridge template.
+- **A WASM-based execution runtime and a disk-based plugin/persistence
+  store.** Early `CHANGELOG.md` history (`[0.2.0]`–`[0.5.0]`) documents a
+  `mcp-wasm-runtime` crate, a `mcp-plugin-store` crate (Blake3-verified
+  plugin persistence), a `mcp-bridge` crate, and a `mcp-examples` crate —
+  none of these exist in the current `crates/*` workspace members. The
+  project's architecture moved from a WASM-execution model to the current
+  plain-TypeScript progressive-loading model; the WASM/plugin-persistence
+  direction is abandoned, not merely undocumented.
+- **This project's own LLM API integration for tool categorization.** By
+  explicit design (`constitution.md`#VII): categorization is delegated to the
+  *calling* Claude Code session's own language understanding via the
+  `introspect_server`/`save_categorized_tools` split, specifically to avoid
+  a second, separately-billed LLM call.
+- **HTTP/SSE transport for the MCP server's own introspection tool.**
+  `IntrospectServerParams` has no field capable of selecting HTTP/SSE
+  transport, and a dedicated test pins its exact field set so a future
+  change re-adding one is a compile error unless updated deliberately — a
+  structural SSRF guard, not an oversight (`specs/server/spec.md`
+  `introspect_server`).
+- **Sandboxing untrusted commands.** The forbidden-environment-variable list
+  is explicitly documented as an "accidental-misconfiguration guard, not a
+  sandbox boundary" (`specs/core/spec.md`) — it does not protect against a
+  malicious command/binary itself being executed.
+- **A response-size bound on the HTTP/SSE introspection transport.**
+  Documented as a known, currently-unfixable upstream (`rmcp`) limitation,
+  not a deliberate scope decision, and not yet resolved
+  (`specs/introspector/spec.md#Known Gap: HTTP Response Size`).
+
+## Integrations & Dependencies
+
+| System | Direction | Data | Status |
+|--------|-----------|------|--------|
+| MCP servers (any, via `rmcp` SDK) | Read | Tool schemas, server handshake metadata | Exists |
+| `~/.claude/mcp.json` | Read | Server connection configuration | Exists |
+| `~/.claude/servers/{id}/` (Claude Code) | Write | Generated TypeScript tools | Exists |
+| `~/.claude/skills/{id}/` (Claude Code) | Write | Generated `SKILL.md` | Exists |
+| Node.js / `tsx` / `deno` (generated-code execution runtime) | N/A (consumed externally) | Executes generated `.ts` files | Exists, not bundled |
+| crates.io / docs.rs | Write (publish) | Library crate distribution | Exists |
+| GitHub Actions CI, Codecov | N/A | Build/test/lint/coverage automation | Exists |
+| `cargo-deny` advisory/license/source database | Read | Supply-chain policy enforcement | Exists |
+
+## Constraints & Assumptions
+
+### Technical Constraints
+
+- Rust, edition 2024, MSRV 1.91 (`Cargo.toml`, CI-enforced `msrv` job).
+- `tokio` async runtime throughout; `rmcp` as the sole MCP protocol
+  implementation (client and server).
+- No `unsafe` code anywhere in the workspace (`#![deny(unsafe_code)]` in
+  every crate except the two binaries, which don't need it).
+- Workspace-wide Clippy `all`/`cargo`/`nursery`/`pedantic` set to `deny`.
+- Generated output executes via Node.js 18+ (checked by `setup`), `tsx`, or
+  `deno` — not bundled with this project, and not verified by this
+  project's own CI beyond generating syntactically valid TypeScript.
+
+### Business Constraints
+
+> [!question] Ungrounded
+> No document in this repository records a timeline, budget, funding, team
+> size, or roadmap. `CHANGELOG.md`'s early phase history attributes
+> development to named AI-agent roles ("Rust Project Architect, Performance
+> Engineer, Security Engineer") rather than a human team roster, which is
+> unusual for a BRD's "Business Constraints" section and is reported here
+> exactly as found, not reinterpreted.
+
+### Assumptions
+
+> [!warning] Assumptions
+> - The primary and near-exclusive consumer of generated output is Claude
+>   Code specifically (not a generic "any MCP client"), based on the fixed
+>   `~/.claude/*` output paths. If this assumption is wrong (e.g. the project
+>   intends broader agent-host support), several functional requirements
+>   above (FR-005 through FR-017) would need a configurable output root
+>   rather than a hardcoded one.
+> - The claimed "98% token savings" (README) is the project's own estimate,
+>   not an independently reproduced benchmark; `CHANGELOG.md`'s own revised
+>   "~83% asymptotic maximum" note (`[0.2.0]`) is never reconciled with the
+>   current README figure anywhere in the repo.
+
+## Success Criteria
+
+- [x] Generated code-generation/export latency stays within documented
+  targets — README's own performance table reports all four measured
+  scenarios exceeding target by 8x–526x (generation: 0.19ms vs. <100ms
+  target for 10 tools; export: 1.2ms vs. <10ms target).
+- [x] Test suite passes with zero known failures — README states "657 tests
+  with 100% pass rate" (a point-in-time claim tied to the README's own last
+  edit, not a live-verified figure as of this document's date).
+- [ ] Token-savings claim is reconciled and independently reproducible — not
+  currently demonstrated by an executable benchmark in this repository (the
+  93–98% figures live only in prose).
+- [ ] A defined process exists for resolving the introspector's documented
+  HTTP/SSE response-size gap — currently tracked only as a "known
+  limitation" note, with no committed target release.
+
+## Open Questions
+
+> [!question] Unresolved Items
+> These cannot be answered by reading the codebase — they require input
+> from the maintainer or a governing body that doesn't appear to exist yet.
+
+- [ ] What is the actual target user base size, and is there a support
+  channel/SLA beyond "file a GitHub issue"?
+- [ ] Is there a business model (this is dual MIT/Apache-2.0 licensed with no
+  evidence of commercial licensing, hosting, or paid support)?
+- [ ] Which figure is authoritative for the headline savings claim — 98%
+  (current README) or the ~83% asymptotic maximum documented in
+  `CHANGELOG.md` `[0.2.0]`?
+- [ ] Is broader (non-Claude-Code) MCP-host support an intended future
+  direction, given the hardcoded `~/.claude/*` output paths?
+- [ ] Is there a roadmap beyond the `[Unreleased]` section of
+  `CHANGELOG.md`?
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| MCP | Model Context Protocol — the open protocol this project introspects servers over and exposes a server for, via the `rmcp` SDK |
+| Progressive loading | This project's code-generation pattern: one TypeScript file per tool, discoverable and loadable independently, instead of one large manifest |
+| VFS | Virtual filesystem — `mcp-execution-files`'s in-memory staging area for generated output before it is exported to disk |
+| `_meta.json` | The structured metadata sidecar emitted by codegen and consumed by skill generation, replacing a historical regex-based TypeScript re-parser |
+| SKILL.md | A Claude Code integration file describing a generated server's tools, produced either by direct template rendering or by an LLM-composed path |
+| CWE-400 | Common Weakness Enumeration 400 (Uncontrolled Resource Consumption) — the security category this project's resource bounds (tool count, file count, byte totals, session count) defend against |
+
+## See Also
+
+- [[README]] — reverse-engineered cross-block architecture and data flow
+- [[constitution]] — reverse-engineered project principles
+- [[SRS-mcp-execution-2026-07-27]] — formal functional requirements derived from this BRD and the per-crate specs
+- [[NFR-mcp-execution-2026-07-27]] — formal non-functional/quality requirements

--- a/specs/NFR-mcp-execution-2026-07-27.md
+++ b/specs/NFR-mcp-execution-2026-07-27.md
@@ -1,0 +1,352 @@
+---
+aliases:
+  - mcp-execution NFR
+  - mcp-execution Quality Requirements
+tags:
+  - nfr
+  - requirements/non-functional
+  - mcp
+  - codegen
+  - status/draft
+created: 2026-07-27
+project: "mcp-execution"
+status: draft
+standard: "ISO/IEC 25010:2011"
+related:
+  - "[[BRD-mcp-execution-2026-07-27]]"
+  - "[[SRS-mcp-execution-2026-07-27]]"
+---
+
+# mcp-execution: Non-Functional Requirements Specification
+
+> [!abstract]
+> Quality attribute requirements for **mcp-execution**, workspace version
+> `0.8.0`. Based on ISO/IEC 25010:2011. Traceable to
+> [[BRD-mcp-execution-2026-07-27]]. Every target below is either (a) a
+> literal constant already enforced in the codebase, (b) a measured figure
+> already published in `README.md`, or (c) explicitly marked as **not
+> enforced/not measured** where the repository asserts an intention (a doc
+> comment target) without a corresponding CI gate. No numeric target in this
+> document was invented for the occasion.
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This document specifies the non-functional (quality) requirements for
+`mcp-execution`. It complements [[SRS-mcp-execution-2026-07-27]], which
+covers functional requirements.
+
+### 1.2 Scope
+
+Covered: Performance Efficiency, Reliability, Security, Maintainability,
+Portability/Compatibility (CLI cross-platform + protocol interoperability).
+Explicitly out of scope, with justification: Usability (accessibility/
+internationalization — no GUI, no localization exists), Compatibility's
+browser/mobile sub-areas (not applicable to a CLI/library), and any
+service-level Availability target (no hosted component exists).
+
+### 1.3 Definitions
+
+| Term | Definition |
+|------|-----------|
+| SLA | Service Level Agreement |
+| RTO | Recovery Time Objective |
+| RPO | Recovery Point Objective |
+| P95 | 95th percentile |
+| CWE-400 | Common Weakness Enumeration 400, Uncontrolled Resource Consumption |
+| MSRV | Minimum Supported Rust Version |
+
+### 1.4 References
+
+- [[BRD-mcp-execution-2026-07-27]] — Business Requirements Document
+- [[SRS-mcp-execution-2026-07-27]] — Software Requirements Specification
+- ISO/IEC 25010:2011 — Systems and software Quality Requirements and Evaluation
+- [[constitution]] — reverse-engineered project principles (source for most
+  Security and Maintainability targets below)
+
+### 1.5 Priority and Trade-offs
+
+> [!tip] Quality Attribute Priority
+> Inferred from the *volume and depth of documented engineering effort*
+> actually found in the codebase (doc comments, dedicated tests, issue
+> references), not from a stated priority order — no such order is written
+> down anywhere in the repository.
+> 1. **Security** — by far the most heavily invested area; see
+>    [[constitution#V. Security]] ("the dominant concern of this codebase").
+> 2. **Reliability** (specifically: crash-safety of filesystem export, and
+>    fail-closed behavior under resource-bound violations).
+> 3. **Performance** — the project's stated value proposition (token
+>    savings), and the only area with numeric targets published in
+>    `README.md`.
+> 4. **Maintainability** — extensive test/doc-comment discipline, but
+>    without an enforced numeric coverage gate (see
+>    [[#7.2 Testability]]).
+
+## 2. Performance Efficiency
+
+### 2.1 Time Behaviour
+
+| ID | Requirement | Target | Measurement | Conditions |
+|----|------------|--------|-------------|-----------|
+| NFR-PERF-001 | Progressive-loading code generation latency | <100ms for 10 tools; <20ms for 50 tools | `criterion` benchmark (`crates/mcp-codegen/benches/code_generation.rs`); reported achieved: 0.19ms (10 tools, 526x under target), 0.97ms (50 tools, 20.6x under target) | Local benchmark run, single process, per `README.md`'s Performance table |
+| NFR-PERF-002 | Virtual filesystem export latency | <10ms (README); <50ms for a 30-file export (crate doc comment, `crates/mcp-files/src/filesystem.rs`) | `criterion` benchmark (`crates/mcp-files/benches/filesystem_export.rs`); reported achieved: 1.2ms (8.3x under the README target) | Local benchmark run |
+| NFR-PERF-003 | Per-tool token footprint of a loaded generated file | ~500–1,500 tokens/tool | Not an automated measurement — a documented estimate in `README.md`/`specs/README.md`, not re-derived by any test or benchmark in this repository | N/A |
+
+> [!warning] Assumptions
+> The headline "98% token savings" figure (`README.md`) and the "83%
+> asymptotic maximum" figure (`CHANGELOG.md` `[0.2.0]` "Notes") are **not**
+> reconciled anywhere in the repository, and neither is backed by an
+> automated, reproducible benchmark measuring actual end-to-end token
+> consumption in a real Claude Code session. Both NFR-PERF-003 and the
+> savings percentage itself should be treated as documented estimates, not
+> verified NFRs, until such a benchmark exists — see
+> [[BRD-mcp-execution-2026-07-27#Open Questions]].
+
+### 2.2 Resource Utilization
+
+| ID | Requirement | Target | Measurement |
+|----|------------|--------|-------------|
+| NFR-PERF-010 | Memory usage generating 1000 tools | < 256 MB (README target) | Reported achieved: ~2 MB (`README.md` Performance table); also profiled via a dedicated `dhat`-based heap-profiling example (`crates/mcp-files/examples/profile_memory.rs`, `dhat-heap` feature) |
+| NFR-PERF-011 | Bounded resource consumption per untrusted input | See CWE-400 bound table in [[#4.1 Confidentiality]]/[[#4.3 Integrity]] below | Unit tests at each bound's exact boundary value (`MAX_TOOL_COUNT`, `MAX_SCHEMA_SIZE_BYTES`, `MAX_GENERATED_FILES`/`MAX_GENERATED_BYTES`, `MAX_EXPORT_FILES`/`MAX_EXPORT_BYTES`, `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES`, `MAX_REQUEST_LINE_SIZE`/`MAX_RESPONSE_LINE_SIZE`) |
+
+### 2.3 Capacity
+
+| ID | Requirement | Target | Growth |
+|----|------------|--------|--------|
+| NFR-PERF-020 | Tools discoverable per server | ≤ 1000 (`MAX_TOOL_COUNT`) | Fixed constant, not currently configurable at runtime |
+| NFR-PERF-021 | Concurrent in-flight MCP requests (server binary) | ≤ 8 (`MAX_CONCURRENT_REQUESTS`) admitted at once; a bounded decode-ahead queue (also 8) lets notifications/responses keep flowing behind an unadmitted request | Fixed constant; chosen because `rmcp` 2.2.0 spawns an unbounded task per inbound request with no concurrency knob of its own |
+| NFR-PERF-022 | Concurrently pending introspection→categorization sessions | ≤ 1000 (`MAX_PENDING_SESSIONS`), further bounded by aggregate estimated bytes (`MAX_TOTAL_PENDING_BYTES`) | Fixed constants; no growth/scaling policy exists (this is a single local process, not a scaled service) |
+
+> [!note] Not Applicable
+> There is no "requests per second" or "data volume per year" NFR — this is
+> a single-user, locally-run tool invoked per developer action, not a
+> service under sustained external load. Applying an RPS-style capacity
+> target would misrepresent the system's actual operating model.
+
+## 3. Reliability
+
+### 3.1 Availability
+
+> [!note] Not Applicable
+> No hosted, always-on component exists. `mcp-execution-server` runs for the
+> lifetime of a single local Claude Code session over stdio; there is no
+> uptime SLA, no monitoring window, and no planned-maintenance concept to
+> specify.
+
+### 3.2 Fault Tolerance
+
+| ID | Requirement | Behaviour |
+|----|------------|-----------|
+| NFR-REL-010 | A hung/unreachable target MCP server during introspection | Bounded by `connect_timeout`/`discover_timeout` (default 30s each, max 600s); fails with `Error::Timeout`, never blocks indefinitely; a per-server-id lock ensures only operations against that *same* server id are affected, never unrelated ones |
+| NFR-REL-011 | A malformed/oversized/skipped line on a bounded stdio stream (either direction this project controls) | Dropped and logged at WARN, not treated as a fatal stream error (`RecoveringCodec`); the request it was answering then times out normally rather than surfacing a distinct, uncorrelatable size-limit error |
+| NFR-REL-012 | An MCP server's own tool metadata drifting from a previously generated sidecar | Detected and surfaced (fails loudly for a missing referenced file, warns non-fatally for an unreferenced extra file) rather than silently generating documentation from stale data — see SRS FR-016 |
+| NFR-REL-013 | A single component (one target MCP server, one output directory) failing or being slow | Failure/slowness is scoped to that one identity via per-resource locking (introspector cache keyed by `ServerId`, export lock keyed by output directory); does not degrade unrelated concurrent operations |
+
+### 3.3 Recoverability
+
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-REL-020 | Filesystem export crash recovery | A process killed at any point before a staged export is published leaves the previous target directory intact or a recoverable staging/displaced-backup artifact — never a partially-written target. A later export's stale-artifact sweep (age-gated at `STALE_ARTIFACT_MIN_AGE` = 5 minutes) reclaims true crash leftovers without touching a genuinely concurrent sibling export |
+| NFR-REL-021 | Export atomicity granularity | Per-top-level-group (one server's own subtree), not whole-batch across multiple servers sharing one output root — a documented, accepted scope, not a defect |
+| NFR-REL-022 | Backup / data-loss window | No conventional backup exists (this is generated, reproducible output, not user-authored data); the one accepted residual risk is a process killed **between** the two renames of `swap_into_place`, leaving the target transiently absent until the next export's sweep reclaims the displaced original — accepted as a louder failure (a visibly missing directory) than the silent broken-import bug this design replaces |
+
+> [!note]
+> Traditional RTO/RPO framing (minutes-based recovery targets, scheduled
+> backup frequency) does not map cleanly onto a tool whose "data" is
+> regenerable, deterministic build output. The entries above restate the
+> actual, code-enforced guarantees in the closest applicable ISO 25010
+> sub-characteristic rather than forcing an artificial RTO/RPO number.
+
+## 4. Security
+
+### 4.1 Confidentiality
+
+| ID | Requirement | Implementation |
+|----|------------|---------------|
+| NFR-SEC-001 | Command/environment/URL/header values are validated before use | `validate_server_config` (shell metacharacters `;|&><\`$()`/CR/LF in command+args; forbidden env var names `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, `PATH`, `NODE_OPTIONS`, `BASH_ENV`, `PYTHONPATH`, `PYTHONSTARTUP`, `RUBYOPT`, `PERL5OPT`, `JAVA_TOOL_OPTIONS`, plus any `DYLD_`-prefixed name; URL scheme restricted to `http`/`https`; header names checked against RFC 7230 `tchar`, values checked for control characters; duplicate header names rejected case-insensitively) — runs unconditionally inside the config builder, and again at the point of use (defense in depth) |
+| NFR-SEC-002 | Secret values never appear in debug/log output | Hand-written (never derived) `Debug` impls using `RedactedItems`/`RedactedMapValues`/`RedactedUrl`/`sanitize_path_for_error`, applied to every type from `ServerConfig` up through the CLI's `Commands` enum; `Serialize` is deliberately exempt (config persistence needs real values) — this asymmetry is documented at every layer that repeats it, not accidental |
+| NFR-SEC-003 | No secret/PII handling policy beyond the above | Not applicable in the traditional sense (this project handles infrastructure credentials — API tokens, connection strings — not end-user PII); no masking/pseudonymization/deletion policy exists because no PII is collected or stored |
+
+### 4.2 Authentication & Authorization
+
+> [!note] Not Applicable
+> This project has no user accounts, login, session-based user identity, or
+> role model. The one session concept that exists (`mcp-execution-server`'s
+> `PendingGeneration`) is a short-lived workflow token bridging two MCP tool
+> calls within a single already-trusted MCP client connection, not an
+> authentication mechanism — see [[#4.5 Compliance]] for the closest
+> applicable control (session validation, not identity).
+
+### 4.3 Integrity
+
+| ID | Requirement | Implementation |
+|----|------------|---------------|
+| NFR-SEC-020 | Every attacker-influenced input is validated server-side (no client-trust assumption) | `validate_server_config` (connection details), `validate_server_id`/`validate_path_segment` (identifiers), size/count bounds at every pipeline stage (introspection, codegen, export, session store, wire framing) — see the CWE-400 bound table below |
+| NFR-SEC-021 | Resource-exhaustion (CWE-400) bounds at every layer, each derived from the layer below rather than independently chosen | See table below; this cascading-by-value relationship is itself a tested invariant (data that already cleared a lower layer's bound must never be deterministically rejected by a higher layer for merely being as large as already allowed) |
+| NFR-SEC-022 | Prompt-injection / Markdown-injection defense for LLM-facing or document-embedded untrusted text | `sanitize_untrusted_text` (control-character flattening, length truncation) plus `wrap_untrusted_block` (`<untrusted-data>...</untrusted-data>`, `&`/`<`/`>`-escaped body) — applied by both `mcp-skill` and `mcp-server`, regression-tested against an explicit boundary-forgery attempt |
+| NFR-SEC-023 | The generated TypeScript runtime bridge cannot silently drift from the Rust source of truth for its own security rules | `FORBIDDEN_CHARS`/`FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` are rendered into `_runtime/mcp-bridge.ts` directly from `mcp_execution_core`'s Rust constants at generation time (via `BridgeContext::default()`, hand-written with no `derive(Default)` so it can never render a fail-open/empty bridge), not hand-copied |
+
+**CWE-400 bound cascade** (root constants and their direct, by-value
+derivations):
+
+| Root (mcp-introspector) | Derived (mcp-codegen) | Derived (mcp-files) | Derived (mcp-server) |
+|---|---|---|---|
+| `MAX_TOOL_COUNT` = 1000 | `MAX_GENERATED_FILES` = `MAX_TOOL_COUNT` + 5 | `MAX_EXPORT_FILES` = `MAX_GENERATED_FILES` | (session count independently bounded, `MAX_PENDING_SESSIONS` = 1000) |
+| `MAX_TOOL_NAME_LEN` = 256 B, `MAX_TOOL_DESCRIPTION_LEN` = 8 KiB, `MAX_SCHEMA_SIZE_BYTES` = 64 KiB | `MAX_GENERATED_BYTES` = 2 × `MAX_TOOL_COUNT` × (name+desc+schema) | `MAX_EXPORT_BYTES` = `MAX_GENERATED_BYTES` | `MAX_TOTAL_PENDING_BYTES` = 4 × per-session estimate built from the same three root constants |
+
+Independent, non-derived bounds enforced elsewhere in the same category:
+`MAX_ARG_COUNT` (256), `MAX_ARG_LEN` (4096 B), `MAX_ENV_COUNT` (256),
+`MAX_ENV_VALUE_LEN` (32 KiB), `MAX_HEADER_COUNT` (128),
+`MAX_HEADER_VALUE_LEN` (8 KiB), `MAX_URL_LEN` (8 KiB) — all in
+`mcp-execution-core::command`; `MAX_REQUEST_LINE_SIZE`/
+`MAX_RESPONSE_LINE_SIZE` (4 MiB each, stdio framing, both directions this
+project controls); `MAX_CONCURRENT_REQUESTS` (8, server binary);
+`MAX_TOOL_FILES` (500, skill scanning); `MAX_FILE_SIZE` (1 MiB, `_meta.json`);
+`MAX_FRONTMATTER_SIZE` (8 KiB, SKILL.md YAML block); `MAX_SKILL_CONTENT_SIZE`
+(100 KiB, `save_skill`).
+
+### 4.4 Non-repudiation / Accountability
+
+> [!note] Not Applicable
+> No audit-log, user-identity-attributed action log, or non-repudiation
+> mechanism exists or is claimed. `tracing` structured logs exist for
+> operational diagnosis (see [[#7.3 Analysability]]), not as an
+> accountability control.
+
+### 4.5 Compliance
+
+> [!note] Not Applicable
+> No regulatory compliance requirement (GDPR/CCPA/HIPAA/PCI DSS/SOC 2) is
+> evidenced or claimed anywhere in the repository — consistent with this
+> being a locally-run developer tool that stores no end-user personal data.
+> The closest analogous control actually present is **supply-chain policy**,
+> enforced via `cargo-deny` (`deny.toml`): dependency licenses restricted to
+> an explicit allow-list (MIT, Apache-2.0, BSD-2/3-Clause, ISC,
+> CDLA-Permissive-2.0, Unicode-3.0, Zlib, BSL-1.0, MPL-2.0), unknown
+> registries/git sources denied, only `crates.io` allowed as a dependency
+> source, and security advisories scanned (RUSTSEC/CVE) — enforced in CI
+> (`security` job, `EmbarkStudios/cargo-deny-action`).
+
+## 5. Usability
+
+> [!note] Not Applicable (mostly)
+> This is a developer-facing CLI/library with no GUI; the ISO 25010
+> Usability sub-characteristics of UI aesthetics and accessibility do not
+> apply. The two sub-areas below are the only ones with real, evidenced
+> content.
+
+### 5.1 Operability
+
+| ID | Requirement | Target |
+|----|------------|--------|
+| NFR-USE-010 | Shell completion availability | bash, zsh, fish, powershell, elvish (`completions` subcommand) |
+| NFR-USE-011 | Error messages must not leak secrets while still being actionable | Every rejection path omits the offending value when it could be secret-shaped (e.g. a misparsed `--api-key sk-...`), while still naming the *kind* of failure (e.g. "stdio server entry must not set \"url\"") |
+
+### 5.2 Accessibility / Internationalization
+
+> [!note] Not Applicable
+> No GUI exists to apply WCAG/accessibility standards to. No localization
+> or multi-language output exists — all CLI/error/log text is English-only,
+> consistent with this repository's own English-only documentation
+> convention.
+
+## 6. Compatibility
+
+### 6.1 Interoperability
+
+| ID | Requirement | Standard/Protocol |
+|----|------------|-------------------|
+| NFR-COM-001 | MCP protocol compliance | Model Context Protocol, version `2025-06-18` (advertised by `mcp-execution-server`'s `get_info()`), via the official `rmcp` SDK (both client and server roles) |
+| NFR-COM-002 | Generated output executes without depending on this project's own runtime | Generated TypeScript is a self-contained package (own `package.json`/`tsconfig.json`) runnable via `tsx`, `deno`, or Node's native TypeScript stripping — not merged into a consumer's own TypeScript build |
+
+### 6.2 Co-existence
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-COM-010 | OS support (build/run this project itself) | Linux, macOS, Windows — pre-built binaries published for macOS (arm64/amd64), Linux (amd64/arm64); Windows built from source/release zip per `README.md` |
+| NFR-COM-011 | Runtime dependency for executing generated output | Node.js ≥ 18.0.0, checked by `setup` |
+| NFR-COM-012 | Coexistence with other MCP-aware tools sharing `~/.claude/mcp.json` | `McpServerEntry` deserialization warns (not fails) on unrecognized top-level keys (e.g. another tool's `disabled`/`alwaysAllow` keys), so this project's CLI can read a config file shared with tools it doesn't otherwise know about |
+
+> [!note] Not Applicable
+> No browser or mobile compatibility requirement applies — there is no
+> browser-rendered or mobile-app surface anywhere in this project.
+
+## 7. Maintainability
+
+### 7.1 Modularity & Modifiability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-MNT-001 | Architecture style | Layered workspace (Cargo workspace, 7 crates), strict low→high dependency direction, zero circular or upward dependencies (`mcp-core` has zero intra-workspace dependencies) — see [[README#Block Structure]] |
+| NFR-MNT-002 | API versioning | Semantic Versioning (workspace version `0.8.0`, pre-1.0 — breaking changes are permitted and are documented under `[Unreleased]`/`Breaking` in `CHANGELOG.md` rather than deferred) |
+| NFR-MNT-003 | Lint policy as a modularity/quality gate | Clippy `all`/`cargo`/`nursery`/`pedantic` set to `deny` at workspace level; any `#[allow(...)]` narrower than workspace scope requires a justification comment (enforced by convention, backfilled per `CHANGELOG.md` `[Unreleased]`/`Documentation`, #186) |
+
+### 7.2 Testability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-MNT-010 | Test count | README states "657 tests with 100% pass rate" — a point-in-time claim as of the README's last edit, not independently re-verified while writing this document |
+| NFR-MNT-011 | Coverage measurement vs. enforcement | Coverage is generated and uploaded to Codecov on every CI run (`coverage` job, `cargo llvm-cov nextest`), but **`fail_ci_if_error: false`** is set on the upload step and no numeric coverage threshold gate exists in `.github/workflows/ci.yml` — coverage is tracked, not enforced. No specific percentage target should be asserted as a requirement without adding such a gate. |
+| NFR-MNT-012 | Doc-tests as executable documentation | `#![warn(missing_docs)]` workspace-wide; every `pub` item requires a doc comment with a runnable `# Examples` section, verified by `cargo test --doc --all-features --workspace` in CI |
+| NFR-MNT-013 | CI/CD pipeline | Build + lint (`fmt --check`, `clippy -D warnings`) + test (`nextest`) + doc-test + coverage + MSRV check + `cargo-deny` security/license/source audit + benchmark build, on every push/PR (`.github/workflows/ci.yml`) |
+| NFR-MNT-014 | Regression traceability | Tests are named and commented to cite the exact issue number they guard against (e.g. `test_build_and_export_rejects_empty_top_level_component`), making the test suite itself a changelog of past correctness/security incidents |
+
+### 7.3 Analysability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-MNT-020 | Structured logging | `tracing` used throughout; `mcp-execution-server`'s tool handlers carry structured spans (e.g. a `server_id` field, deliberately left empty on early validation failure rather than logging unvalidated input) |
+| NFR-MNT-021 | Observability stack | Logs only (`tracing`/`tracing-subscriber`, `env-filter`); no metrics or distributed-tracing export exists or is claimed — consistent with this being a locally-run tool, not a monitored service |
+| NFR-MNT-022 | Health check endpoints | Not applicable — no long-running network service with a health-check surface exists (`mcp-execution-server` communicates over stdio to a single local client, not a service with `/health`/`/ready`) |
+
+## 8. Portability
+
+### 8.1 Adaptability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-POR-001 | Deployment environments | Local developer machine only (Linux/macOS/Windows); no cloud/on-prem/hybrid hosted deployment target exists or is claimed |
+| NFR-POR-002 | Containerization | Not evidenced — no `Dockerfile`/container manifest exists in this repository |
+
+### 8.2 Installability
+
+| ID | Requirement | Details |
+|----|------------|---------|
+| NFR-POR-010 | Installation methods | `cargo install mcp-execution-cli` (crates.io, recommended); pre-built release binaries (GitHub Releases, per-platform archives); build from source (`cargo install --path crates/mcp-cli`); individual library crates via `cargo add` |
+| NFR-POR-011 | Configuration management | A single JSON file, `~/.claude/mcp.json`, read directly from the filesystem; no environment-variable-based or secrets-manager-based configuration path exists for this project's *own* configuration (as opposed to the *target* MCP servers it introspects, whose env vars it explicitly validates — see [[#4.1 Confidentiality]]) |
+| NFR-POR-012 | MSRV policy | Rust 1.91 minimum, enforced by a dedicated CI job (`msrv`); README states MSRV increases are treated as minor version bumps |
+
+## 9. Verification Matrix
+
+| ID | Method | Environment | Frequency |
+|----|--------|-------------|-----------|
+| NFR-PERF-001, NFR-PERF-002 | `criterion` benchmark | Local dev machine / CI (`cargo bench --no-run --profile bench-fast` build-only in CI; full run is manual) | Ad hoc / per performance-sensitive change |
+| NFR-PERF-010 | `dhat`-based heap profiling (`profile_memory` example, `dhat-heap` feature) | Local dev machine | Ad hoc |
+| NFR-SEC-001–023 | Unit + integration test suite (`cargo nextest run --all-features --workspace`) | CI (`test` job) | Every push/PR |
+| NFR-SEC-021 (advisories/licenses/sources) | `cargo-deny` | CI (`security` job) | Every push/PR |
+| NFR-MNT-010–014 | `cargo nextest run`, `cargo test --doc` | CI | Every push/PR |
+| NFR-MNT-011 (coverage) | `cargo llvm-cov nextest` → Codecov upload | CI (`coverage` job, Linux only) | Every push/PR; **not gating** (`fail_ci_if_error: false`, no threshold check) |
+| NFR-POR-012 (MSRV) | `cargo check`/`build` pinned to Rust 1.91 | CI (`msrv` job) | Every push/PR |
+
+## 10. Open Questions
+
+> [!question] Unresolved Quality Requirements
+> - [ ] Should coverage become a gating CI check (a numeric threshold), or
+>   remain tracked-only as it is today?
+> - [ ] Is there an intended target for closing the introspector's HTTP/SSE
+>   response-size gap (see [[SRS-mcp-execution-2026-07-27#FR-002]]), and
+>   should a quantitative NFR (e.g. a maximum buffered-response size) be set
+>   for it once `rmcp` exposes the necessary knob?
+> - [ ] Should the 98% token-savings claim be backed by an automated,
+>   reproducible benchmark (making it a verifiable NFR rather than a
+>   documented estimate)?
+> - [ ] Is any future hosted/multi-tenant deployment mode planned (which
+>   would reintroduce Availability/Scalability as real, specifiable NFR
+>   categories rather than "not applicable")?
+
+## See Also
+
+- [[BRD-mcp-execution-2026-07-27]] — business requirements (source)
+- [[SRS-mcp-execution-2026-07-27]] — functional requirements
+- [[README]] — project knowledge base / cross-block index

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,300 @@
+---
+aliases:
+  - Specifications Index
+  - mcp-execution Specs Overview
+  - MOC-specs
+tags:
+  - moc
+  - sdd
+created: 2026-07-27
+status: moc
+related:
+  - "[[constitution]]"
+  - "[[BRD-mcp-execution-2026-07-27]]"
+  - "[[SRS-mcp-execution-2026-07-27]]"
+  - "[[NFR-mcp-execution-2026-07-27]]"
+---
+
+# mcp-execution — Specification Package
+
+> [!abstract]
+> This is a **reverse-engineering documentation pass** over the existing
+> `mcp-execution` codebase (not a design for a new feature). Every claim
+> below was verified against the actual source in this worktree
+> (`crates/*`), not paraphrased from `CLAUDE.md`. Where `CLAUDE.md`'s
+> summary and the real code disagree, it is called out explicitly in
+> [[#Discrepancies vs CLAUDE.md]].
+>
+> Business and formal requirements documents — [[BRD-mcp-execution-2026-07-27|BRD]],
+> [[SRS-mcp-execution-2026-07-27|SRS]], [[NFR-mcp-execution-2026-07-27|NFR]] —
+> are also reverse-engineered (from `README.md`, `CHANGELOG.md`, `Cargo.toml`,
+> and the per-crate specs below), not authored ahead of implementation. They
+> explicitly flag what genuinely cannot be grounded this way (market
+> validation, named business stakeholders, a reconciled token-savings figure)
+> rather than inventing it — see each document's own "Open Questions".
+
+## What This Project Does
+
+**mcp-execution** generates TypeScript code from MCP (Model Context
+Protocol) server tool definitions using a *progressive loading* pattern —
+one file per tool — so Claude Code loads only the tools it actually needs
+(~500-1,500 tokens/tool) instead of an entire server's tool manifest
+upfront (~30,000 tokens), a 93-98% token-budget reduction. It also exposes
+that same generation capability *as an MCP server itself*, letting Claude
+Code drive tool categorization with its own natural-language understanding
+instead of a second LLM call, and it can render Claude Code `SKILL.md`
+integration files from a server's already-generated tools.
+
+## Business & Requirements Documents
+
+| Document | Standard | Scope |
+|---|---|---|
+| [[BRD-mcp-execution-2026-07-27\|BRD]] | — | Business goals, problem statement, target users, functional requirements (business-level), scope/boundaries, success criteria |
+| [[SRS-mcp-execution-2026-07-27\|SRS]] | ISO/IEC/IEEE 29148:2018 | Formal `SHALL`-level functional requirements, traced to the per-crate specs below and to the BRD |
+| [[NFR-mcp-execution-2026-07-27\|NFR]] | ISO/IEC 25010:2011 | Quality attributes (performance, reliability, security, maintainability, portability) with measurable, code-grounded targets |
+
+## Block Structure
+
+Seven functional blocks, one per workspace crate, matching the real
+dependency graph (low → high, verified from `Cargo.toml`'s
+`[workspace.dependencies]` and each crate's own `Cargo.toml`):
+
+```mermaid
+graph TD
+    core[mcp-execution-core]
+    introspector[mcp-execution-introspector]
+    codegen[mcp-execution-codegen]
+    files[mcp-execution-files]
+    skill[mcp-execution-skill]
+    server[mcp-execution-server]
+    cli[mcp-execution-cli]
+
+    introspector --> core
+    codegen --> core
+    codegen --> introspector
+    files --> codegen
+    skill --> core
+    server --> core
+    server --> introspector
+    server --> codegen
+    server --> files
+    server --> skill
+    cli --> core
+    cli --> introspector
+    cli --> codegen
+    cli --> files
+    cli --> skill
+```
+
+| Block | Crate / Path | Spec |
+|---|---|---|
+| Core types & security | `mcp-execution-core` (`crates/mcp-core`) | [[core/spec]] |
+| Introspection | `mcp-execution-introspector` (`crates/mcp-introspector`) | [[introspector/spec]] |
+| Codegen / templating | `mcp-execution-codegen` (`crates/mcp-codegen`) | [[codegen/spec]] |
+| Virtual filesystem & export | `mcp-execution-files` (`crates/mcp-files`) | [[files/spec]] |
+| Skill generation | `mcp-execution-skill` (`crates/mcp-skill`) | [[skill/spec]] |
+| MCP server exposure | `mcp-execution-server` (`crates/mcp-server`) | [[server/spec]] |
+| CLI | `mcp-execution-cli` (`crates/mcp-cli`) | [[cli/spec]] |
+
+`mcp-server` and `mcp-cli` are **parallel front doors** onto the same lower
+four crates (`introspector`/`codegen`/`files`/`skill`) — they do not depend
+on each other, and neither is "more canonical" than the other. `mcp-server`
+adds a session-based, cancellation-aware, LLM-categorization workflow;
+`mcp-cli` is synchronous, scriptable, and (for `generate`) uncategorized by
+default.
+
+## End-to-End Data Flow
+
+Two entry points converge on the same lower pipeline:
+
+```
+CLI (mcp-cli generate / introspect)          MCP client, e.g. Claude Code
+        │                                              │
+        ▼                                              ▼
+resolve_server_config() [cli/common.rs]     introspect_server tool [server/service.rs]
+        │  mcp.json OR --http/--sse/positional args    │  always builds a *stdio* ServerConfig
+        ▼                                              ▼
+              ServerConfig  (mcp-core: security-validated —
+              shell metachars, forbidden env vars incl. NODE_OPTIONS/
+              BASH_ENV/PYTHONPATH/..., URL scheme, header safety,
+              size/count bounds, timeout bounds; Stdio OR Http OR Sse)
+                              │
+                              ▼
+      Introspector::discover_server()  (mcp-introspector)
+        — bounded stdio response-line decoder (4 MiB, WARN+drop on overflow)
+        — OR Streamable HTTP/SSE transport (rmcp) — NO response-size bound (documented gap)
+        — pages tools/list, bails out early past MAX_TOOL_COUNT (1000)
+        — per-tool name/description/schema size bounds
+                              │
+                              ▼
+                    ServerInfo { tools: Vec<ToolInfo> }
+                              │
+              ┌───────────────┴───────────────┐
+              ▼ (mcp-cli: uncategorized)       ▼ (mcp-server: Claude-categorized via
+     ProgressiveGenerator::generate()             save_categorized_tools)
+              │                          ProgressiveGenerator::generate_with_categories()
+              └───────────────┬───────────────┘
+                              ▼
+                    GeneratedCode { files: Vec<GeneratedFile> }
+              (index.ts, {tool}.ts × N, _runtime/mcp-bridge.ts,
+               package.json, tsconfig.json, _meta.json — 7 files for
+               a 2-tool server; sanitized JSDoc/TS-literal injection
+               defenses applied before Handlebars renders; bounded by
+               MAX_GENERATED_FILES/MAX_GENERATED_BYTES, derived from
+               mcp-introspector's own bounds)
+                              │
+                              ▼
+     FilesBuilder::from_generated_code(code, base) (mcp-files)
+        .build_and_export(base_dir)   [cli path, shared base_dir, per-group atomic]
+        .build().export_to_filesystem(output_dir)  [server path, per-output-dir Mutex]
+                              │
+                              ▼
+              ~/.claude/servers/{server-id}/  (staged in a sibling temp
+              dir, published via atomic rename; age-gated stale-artifact
+              sweep guards concurrent siblings)
+                              │
+                              ▼ (optional, either entry point)
+      mcp-skill: scan_tools_directory() reads _meta.json (not the .ts
+      source) → build_skill_context() (sanitizes every untrusted field,
+      wraps LLM-facing prompt in <untrusted-data> boundary)
+              │                                    │
+   mcp-cli skill:                        mcp-server generate_skill/save_skill:
+   render_skill_md() directly            returns prompt → Claude composes →
+   (no LLM)                              save_skill confines + writes
+              │                                    │
+              └────────────────┬───────────────────┘
+                                ▼
+                 ~/.claude/skills/{server-id}/SKILL.md
+```
+
+## Cross-Block Contracts (the load-bearing ones)
+
+1. **`ServerConfig` validation is enforced at construction, re-checked at
+   the trust boundary.** `mcp-core::ServerConfigBuilder::build()` runs full
+   security validation, but every consumer that might receive a
+   `ServerConfig` from somewhere else (deserialized JSON, a struct literal)
+   re-validates: `mcp-introspector::Introspector::discover_server` does it
+   as defense in depth even though its own callers always go through the
+   builder. See [[core/spec#Defense in depth]].
+
+2. **Resource bounds cascade downward by value, not by independent
+   choice.** `mcp-introspector::MAX_TOOL_COUNT`/`MAX_TOOL_NAME_LEN`/
+   `MAX_TOOL_DESCRIPTION_LEN`/`MAX_SCHEMA_SIZE_BYTES` are the root inputs;
+   `mcp-codegen::MAX_GENERATED_FILES`/`MAX_GENERATED_BYTES` and
+   `mcp-files::MAX_EXPORT_FILES`/`MAX_EXPORT_BYTES` are literally *equal to*
+   (or a documented multiple of) those roots, `mcp-server`'s
+   `MAX_TOTAL_PENDING_BYTES` derives from the same roots again. This is a
+   deliberate, tested invariant: data that already cleared a lower layer's
+   bound must never be deterministically rejected by a higher layer for
+   merely being "as large as the lower layer already allows."
+
+3. **`_meta.json` is the wire contract between codegen and everything that
+   reads tool metadata back.** Schema owned by `mcp-core::metadata`
+   (`METADATA_SCHEMA_VERSION`), written by `mcp-codegen`, read by
+   `mcp-skill::scan_tools_directory` — which **cross-checks it against the
+   `.ts` files actually on disk** rather than trusting it blindly (a
+   sidecar entry with no matching file is a hard error; a `.ts` file with
+   no sidecar entry is a non-fatal, surfaced warning). This replaced a
+   historical regex-based re-parse of generated TypeScript that could never
+   recover parameter descriptions.
+
+4. **Path confinement is duplicated intentionally, not accidentally,
+   across `mcp-skill` and `mcp-server`**, sharing the same primitives
+   (`mcp-core::{sanitize_path_for_error, validate_path_segment}`):
+   `mcp-skill::resolve_skill_output_path` (a file target) and
+   `mcp-server::output_dir::resolve_output_dir` (a directory target,
+   deliberately not pre-created — the export layer publishes it atomically)
+   both walk one path component at a time, reject a symlink at the
+   `server_id` boundary outright (not merely "resolve and re-check"), and
+   are only ever resolved fresh, immediately before the write they guard —
+   never cached across a session's lifetime.
+
+5. **Debug-redaction is a workspace-wide, hand-maintained discipline, not
+   a `derive`.** Any type carrying env vars, HTTP headers, CLI args, or
+   URLs implements `Debug` by hand using `mcp-core::redact`'s wrapper types,
+   from `ServerConfig` itself up through `mcp-cli`'s `Commands` enum.
+   `Serialize` is deliberately exempt (config persistence needs real
+   values) — this asymmetry is documented at every layer that repeats it.
+
+6. **The generated TypeScript runtime bridge re-derives its own security
+   rules from the same Rust source of truth**, rendered via Handlebars at
+   generation time (`BridgeContext::default()`), not hand-copied — so
+   `FORBIDDEN_CHARS`/`FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` in
+   `_runtime/mcp-bridge.ts` cannot silently drift from
+   `mcp-core::command`'s Rust constants.
+
+7. **Prompt-injection defense is one primitive (`mcp-core::untrusted`), two
+   independent call sites.** Both `mcp-skill` (SKILL.md body + LLM
+   generation prompt) and `mcp-server` (`introspect_server`'s tool
+   summaries returned to Claude) sanitize control characters/Markdown-
+   structural line breaks and, for LLM-facing text specifically, wrap it in
+   an explicit, unforgeable `<untrusted-data>` boundary.
+
+## Discrepancies vs `CLAUDE.md`
+
+`CLAUDE.md`'s crate table and data-flow diagram are directionally correct
+but materially incomplete/stale in the following ways (verified against
+the real source, not assumed):
+
+- **Transport support is undocumented.** `CLAUDE.md`'s data-flow diagram
+  only shows a stdio subprocess path (`ServerConfig (security-validated...)
+  → Introspector::discover_server() — spawns server process`). The real
+  `TransportType` enum has three variants — `Stdio`, `Http`, `Sse` — and
+  `mcp-introspector` implements a full Streamable HTTP client path
+  alongside stdio. Neither `ServerConfig`'s HTTP/SSE fields (`url`,
+  `headers`) nor the CLI's `--http`/`--sse` flags nor `mcp.json`'s
+  `"type": "http"`/`"sse"` entries are mentioned anywhere in `CLAUDE.md`.
+- **Forbidden-env-var list is stale.** `CLAUDE.md` states: *"no forbidden
+  env vars: LD_PRELOAD, LD_LIBRARY_PATH, DYLD_*, PATH"*. The actual list
+  (`mcp-core::command::FORBIDDEN_ENV_NAMES`) additionally includes
+  `LD_AUDIT`, `NODE_OPTIONS`, `BASH_ENV`, `PYTHONPATH`, `PYTHONSTARTUP`,
+  `RUBYOPT`, `PERL5OPT`, `JAVA_TOOL_OPTIONS` — an entire category
+  (interpreter-hijack vectors, not just dynamic-linker/PATH) is omitted.
+- **`mcp-execution-server`'s scope is undersold.** `CLAUDE.md` describes it
+  only as *"MCP server exposing progressive loading as MCP tools."* The
+  actual crate exposes **five** tools, not just progressive-loading
+  generation: `introspect_server`, `save_categorized_tools`,
+  `list_generated_servers`, **and** `generate_skill`/`save_skill` — the
+  latter two duplicate `mcp-cli skill`'s functionality via the MCP-tool
+  interface, letting Claude compose SKILL.md content itself rather than a
+  template-only render. `CLAUDE.md` never mentions this crate's dependency
+  on `mcp-execution-skill`.
+- **Generated file set is incomplete.** `CLAUDE.md`'s example tree shows
+  only `index.ts`, per-tool `.ts` files, and `_runtime/mcp-bridge.ts`. The
+  real generator (`ProgressiveGenerator::generate_with_categories`) also
+  always emits `package.json`, `tsconfig.json`, and a `_meta.json`
+  structured-metadata sidecar — the latter is load-bearing (it's the
+  contract `mcp-skill` reads instead of re-parsing TypeScript).
+  `CLAUDE.md` says nothing about the required `npm install` post-generation
+  step either, which `mcp-cli generate` itself surfaces as a hint.
+- **Resource-exhaustion (CWE-400) hardening is entirely undocumented.**
+  `CLAUDE.md` does not mention any of the tool-count/schema-size/file-
+  count/byte/session-count/session-byte/request-concurrency bounds that
+  are, by volume of doc comments and tests, the single most invested-in
+  architectural concern in this codebase (see [[constitution#V. Security]]).
+- **Prompt-injection defense (`mcp-core::untrusted`) is undocumented.**
+  Not mentioned in `CLAUDE.md` at all, despite being a dedicated module
+  used by two separate crates specifically to prevent an introspected MCP
+  server's self-reported metadata from smuggling Markdown structure or LLM
+  instructions into Claude-facing text.
+- **Atomicity/concurrency guarantees of the export path are undocumented.**
+  `CLAUDE.md`'s data flow ends at `FileSystem::export()` as if it were a
+  simple write. The real implementation is a staged-directory-then-atomic-
+  rename with an age-gated stale-artifact sweep and per-resource locking at
+  the `mcp-server` layer — deliberate engineering against a documented
+  historical data-loss race, none of which is mentioned.
+
+None of these are contradictions of what `CLAUDE.md` says — they are gaps
+where the real system does materially more, or differently, than the
+summary implies. Anyone extending this project via `CLAUDE.md` alone would
+be unaware of HTTP/SSE transport, the fuller forbidden-env-var list, the
+`generate_skill`/`save_skill` tools, `_meta.json`, or any of the
+resource/prompt-injection hardening.
+
+## See Also
+
+- [[constitution]] — principles observed across every block
+- [[core/spec]] — read this first; every other block depends on it
+- [[BRD-mcp-execution-2026-07-27]] — business requirements (reverse-engineered)
+- [[SRS-mcp-execution-2026-07-27]] — formal functional requirements
+- [[NFR-mcp-execution-2026-07-27]] — formal non-functional/quality requirements

--- a/specs/SRS-mcp-execution-2026-07-27.md
+++ b/specs/SRS-mcp-execution-2026-07-27.md
@@ -1,0 +1,989 @@
+---
+aliases:
+  - mcp-execution SRS
+  - mcp-execution Functional Spec
+tags:
+  - srs
+  - requirements/functional
+  - mcp
+  - codegen
+  - status/draft
+created: 2026-07-27
+project: "mcp-execution"
+status: draft
+standard: "ISO/IEC/IEEE 29148:2018"
+related:
+  - "[[BRD-mcp-execution-2026-07-27]]"
+  - "[[NFR-mcp-execution-2026-07-27]]"
+  - "[[README]]"
+---
+
+# mcp-execution: Software Requirements Specification
+
+> [!abstract]
+> Functional requirements specification for **mcp-execution**, workspace
+> version `0.8.0`. Based on ISO/IEC/IEEE 29148:2018. Traceable to
+> [[BRD-mcp-execution-2026-07-27]]. This is a **formal restatement** of
+> behavior already implemented and already informally documented in
+> `specs/core/spec.md`, `specs/introspector/spec.md`, `specs/codegen/spec.md`,
+> `specs/files/spec.md`, `specs/skill/spec.md`, `specs/server/spec.md`, and
+> `specs/cli/spec.md` — every `SHALL` statement below traces to a concrete,
+> already-tested code path cited in one of those documents, not to a new
+> design decision.
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This SRS specifies, in verifiable `SHALL`/`SHOULD`/`MAY` form, the functional
+behavior of the `mcp-execution` workspace: its CLI binary
+(`mcp-execution-cli`), its MCP server binary (`mcp-execution-server`), and the
+five library crates behind both (`mcp-execution-core`, `-introspector`,
+`-codegen`, `-files`, `-skill`). Its intended audience is any developer or
+coding agent extending, auditing, or re-implementing part of this system, and
+any reviewer verifying that documented business requirements are actually
+implemented.
+
+### 1.2 Scope
+
+`mcp-execution` converts MCP server tool definitions into self-contained,
+per-tool TypeScript files (the "progressive loading" pattern) and generates
+Claude Code `SKILL.md` integration files from the result. It does **not**
+execute the generated TypeScript itself (that runs externally via Node.js/
+`tsx`/`deno`), does not provide its own LLM API integration, and does not
+sandbox the commands it is configured to spawn (see
+[[BRD-mcp-execution-2026-07-27#Out of Scope]]). Full business rationale is in
+[[BRD-mcp-execution-2026-07-27]].
+
+### 1.3 Definitions, Acronyms, and Abbreviations
+
+| Term | Definition |
+|------|-----------|
+| MCP | Model Context Protocol |
+| VFS | Virtual filesystem (`mcp-execution-files`'s in-memory staging structure) |
+| TS | TypeScript |
+| CWE-400 | Common Weakness Enumeration 400, Uncontrolled Resource Consumption |
+| Stdio transport | An MCP server reached by spawning a local subprocess and speaking JSON-RPC over its stdin/stdout |
+| HTTP/SSE transport | An MCP server reached over a Streamable HTTP or Server-Sent Events endpoint |
+| `_meta.json` | The structured metadata sidecar defined by `mcp_execution_core::metadata`, produced by codegen, consumed by skill generation |
+| Session | A `mcp-execution-server` in-memory record (`PendingGeneration`) bridging `introspect_server` and `save_categorized_tools` |
+
+### 1.4 References
+
+- [[BRD-mcp-execution-2026-07-27]] — Business Requirements Document
+- [[NFR-mcp-execution-2026-07-27]] — Non-Functional Requirements Specification
+- [[README]] — cross-block architecture, data flow, and discrepancies vs. `CLAUDE.md`
+- [[constitution]] — reverse-engineered project principles
+- `specs/core/spec.md`, `specs/introspector/spec.md`, `specs/codegen/spec.md`, `specs/files/spec.md`, `specs/skill/spec.md`, `specs/server/spec.md`, `specs/cli/spec.md` — the per-crate informal specs this SRS formalizes
+
+### 1.5 Document Overview
+
+Section 2 describes the product in context (interfaces, user classes,
+environment). Section 3 states the formal requirements, grouped by the same
+seven feature areas as the BRD. Section 4 defines verification methods.
+Section 5 (Appendices) provides the BRD↔SRS↔NFR traceability matrix.
+
+## 2. Overall Description
+
+### 2.1 Product Perspective
+
+> [!info] System Context
+> `mcp-execution` sits between an MCP server (any implementation, reached via
+> the official `rmcp` SDK) and Claude Code's local filesystem
+> (`~/.claude/mcp.json`, `~/.claude/servers/`, `~/.claude/skills/`). It is
+> invoked either directly by a developer (CLI) or by a Claude Code session
+> itself, over MCP (`mcp-execution-server`).
+
+```mermaid
+graph LR
+    dev[Developer / shell] -->|mcp-execution-cli| cli[mcp-execution-cli]
+    claude[Claude Code session] -->|MCP stdio| srv[mcp-execution-server]
+    cli --> pipeline[introspector to codegen to files to skill]
+    srv --> pipeline
+    pipeline --> mcpserver[Any MCP server, via rmcp]
+    pipeline --> fsout["~/.claude/servers/{id}/, ~/.claude/skills/{id}/"]
+```
+
+- **System interfaces**: an MCP server (client role, via `rmcp`); the local
+  filesystem (`~/.claude/mcp.json` read, `~/.claude/servers/`/
+  `~/.claude/skills/` written); the calling MCP client (server role, via
+  `rmcp`, for `mcp-execution-server` only).
+- **User interfaces**: a `clap`-derived command-line interface only; no GUI.
+- **Hardware interfaces**: none beyond a standard POSIX/Windows filesystem
+  and process-spawning capability.
+- **Software interfaces**: Node.js 18+ (external, executes generated
+  output); `tsx`/`deno` (external, alternative execution runtimes; not
+  invoked by this project itself).
+- **Communication interfaces**: stdio (subprocess JSON-RPC, both as an MCP
+  client introspecting a target server, and as the MCP server binary
+  itself); Streamable HTTP/SSE (as an MCP client only, for HTTP/SSE-transport
+  target servers).
+- **Memory / storage constraints**: see [[NFR-mcp-execution-2026-07-27#2.2 Resource Utilization]].
+- **Operations / site adaptation**: none — single-user, local-machine tool;
+  no multi-tenant configuration.
+
+### 2.2 Product Functions
+
+- **Server introspection** — connect to an MCP server, discover its tools.
+- **Progressive-loading code generation** — render discovered tools as
+  self-contained TypeScript.
+- **Virtual filesystem export** — stage and atomically publish generated
+  output to disk.
+- **SKILL.md generation** — produce a Claude Code integration document from
+  already-generated tools.
+- **CLI server-configuration management** — list/inspect/validate
+  `~/.claude/mcp.json` entries; validate the local runtime.
+- **MCP server exposure** — expose the above as MCP tools, with a
+  session-based, Claude-driven categorization workflow.
+- **Security validation and hardening** — cross-cutting: input validation,
+  resource bounds, redaction, prompt-injection defense, path confinement.
+
+### 2.3 User Classes and Characteristics
+
+| User Class | Description | Proficiency | Frequency |
+|-----------|-------------|-------------|-----------|
+| CLI end user | Developer running `mcp-execution-cli` directly from a shell | Medium (comfortable with CLI tools, `mcp.json`) | Per new MCP server integrated, or on demand |
+| MCP client (Claude Code) | An automated caller of `mcp-execution-server`'s MCP tools | N/A (machine caller) | Per introspection/generation session initiated by a user's request to Claude |
+| Library consumer | Rust developer depending on one or more crates directly | High (Rust, MCP protocol familiarity) | Per their own release cadence |
+
+### 2.4 Operating Environment
+
+- OS: Linux, macOS, Windows (README lists pre-built binaries for all three;
+  `setup`'s Unix-only executable-bit step degrades gracefully — always
+  reports `files_made_executable: 0` — on non-Unix).
+- Rust: edition 2024, MSRV 1.91 (CI-enforced).
+- Node.js: 18+ required to execute generated output (not to build/run
+  `mcp-execution` itself).
+- Network: required only for HTTP/SSE-transport target servers and for
+  installing the tool/its dependencies; stdio-transport introspection uses
+  local process spawning only.
+
+### 2.5 Design and Implementation Constraints
+
+- No `unsafe` code in any crate (`#![deny(unsafe_code)]`, except the two
+  binaries which don't need it).
+- `thiserror` for every library-crate error type; `anyhow` only in the CLI
+  binary.
+- Workspace Clippy `all`/`cargo`/`nursery`/`pedantic` set to `deny`.
+- `serde_norway` (not `serde_yaml`/`serde_yml`) for the one YAML use case
+  (SKILL.md frontmatter parsing).
+- Handlebars rendering with HTML-escaping explicitly disabled
+  (`no_escape`), since output is TypeScript/JSDoc — injection safety is a
+  separate, hand-written sanitization layer (see
+  [[NFR-mcp-execution-2026-07-27#4. Security]]).
+
+### 2.6 Assumptions and Dependencies
+
+> [!warning] Assumptions
+> - The output paths `~/.claude/servers/{id}/` and `~/.claude/skills/{id}/`
+>   are effectively hardcoded conventions shared with Claude Code, not a
+>   generic, configurable target for an arbitrary MCP host.
+> - `rmcp` is assumed to correctly implement the MCP wire protocol; this
+>   project's own tests validate its *usage* of `rmcp`, not `rmcp` itself.
+>   One known gap is explicitly attributed to an `rmcp` limitation, not this
+>   project's own code (unbounded HTTP/SSE response buffering — see
+>   [[#FR-002]]).
+
+## 3. Specific Requirements
+
+### 3.1 External Interface Requirements
+
+#### 3.1.1 User Interfaces
+
+`clap`-derived CLI only. Global flags: `-v/--verbose` (raises log level to
+DEBUG), `--format {json,text,pretty}` (default `pretty`). No wireframes
+apply — output is textual, rendered via `formatters::{json,text,pretty}`.
+
+#### 3.1.2 Hardware Interfaces
+
+None.
+
+#### 3.1.3 Software Interfaces
+
+| Interface | System | Protocol | Data Format |
+|-----------|--------|----------|-------------|
+| Target MCP server (client role) | Any MCP server | JSON-RPC over stdio, or Streamable HTTP/SSE | JSON (MCP wire format) |
+| This project's own MCP server (server role) | Claude Code / any MCP client | JSON-RPC over stdio | JSON (MCP wire format), `schemars`-derived tool schemas |
+| `~/.claude/mcp.json` | Local filesystem | File read | JSON |
+| `~/.claude/servers/{id}/`, `~/.claude/skills/{id}/` | Local filesystem | File write | TypeScript source, JSON (`_meta.json`, `package.json`, `tsconfig.json`), Markdown+YAML frontmatter (`SKILL.md`) |
+
+#### 3.1.4 Communication Interfaces
+
+Stdio JSON-RPC framing is **size-bounded** on both sides this project
+controls: `mcp-execution-server`'s own request stream (`MAX_REQUEST_LINE_SIZE`
+= 4 MiB, via a custom `RecoveringCodec`) and `mcp-introspector`'s stdio
+discovery response stream (`MAX_RESPONSE_LINE_SIZE` = 4 MiB, via
+`bounded_response_stream`) — replacing `rmcp`'s own unbounded default reader
+in both directions. HTTP/SSE responses received while introspecting a target
+server are **not** bound in the same way (documented upstream `rmcp`
+limitation; see [[#FR-002]]).
+
+### 3.2 Functional Requirements
+
+#### 3.2.1 Server Introspection
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#Server Introspection]]
+
+**FR-001**: The system shall connect to a target MCP server described by a
+`ServerConfig` (stdio subprocess, or HTTP/SSE endpoint) and return a
+`ServerInfo` containing its name, version, capability flags, and discovered
+tools.
+
+- *Rationale*: introspection is the entry point of every downstream pipeline
+  stage (codegen, export, skill generation) — nothing else can proceed
+  without it.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-001
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Given a reachable stdio-transport server, `discover_server` returns
+     `ServerInfo` with `tools.len()` equal to the server's actual tool count.
+  2. Given a server that sends no peer info on handshake, `discover_server`
+     still returns a usable `ServerInfo`, falling back to the config's own
+     `command`/`url` as the name and `"unknown"` as the version.
+  3. Given a server that never responds, the connect attempt fails with
+     `Error::Timeout` no later than `config.connect_timeout()` (default 30s,
+     max 600s).
+- *Dependencies*: none
+
+**FR-002**: The system shall bound the number of tools and the size of each
+tool's name, description, and input/output schema accepted from a target
+server during introspection, rejecting any excess as a resource-limit error
+rather than accepting it.
+
+- *Rationale*: an introspected server is untrusted; without bounds, a
+  malicious or malfunctioning server could exhaust this process's memory
+  (CWE-400) purely by how many/how large tools it reports.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-002
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A server reporting more than `MAX_TOOL_COUNT` (1000) tools causes
+     discovery to fail with `Error::ResourceLimitExceeded` as soon as a page
+     pushes the running total over the limit — not after buffering the
+     server's entire response.
+  2. A single tool exceeding `MAX_TOOL_NAME_LEN` (256 B), `MAX_TOOL_DESCRIPTION_LEN`
+     (8 KiB), or `MAX_SCHEMA_SIZE_BYTES` (64 KiB, per input **or** output
+     schema) causes discovery to fail, naming the offending tool.
+  3. **Known gap** (not a violation of this requirement, but a documented
+     limitation of the transport it runs over): on an HTTP/SSE-transport
+     server, `rmcp`'s client buffers a full response/SSE event in memory
+     *before* this bound is checked; only `discover_timeout` bounds how long
+     an unbounded read is allowed to run, not how large it grows. This is
+     attributed to `rmcp` 2.2.0, not to this project's own code.
+- *Dependencies*: FR-001
+
+**FR-003**: The system shall validate every `ServerConfig` (shell
+metacharacters in command/arguments, forbidden environment variable names,
+URL scheme, header name/value safety, timeout bounds) before it is used to
+spawn a process or open a network connection, and shall re-validate a config
+at each point it could have arrived from an unvalidated source.
+
+- *Rationale*: command-injection and dangerous-environment-variable defense
+  is the single most heavily invested security concern in this codebase
+  (see [[constitution#V. Security]]); a config obtained via
+  `serde_json::from_str` (e.g. from a hand-edited `mcp.json`) bypasses the
+  builder's own validation, since every field is `#[serde(default)]`.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-003
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `ServerConfigBuilder::build()` runs full validation unconditionally and
+     returns `Err` for any of: a forbidden shell metacharacter
+     (`;|&><\`$()` or CR/LF) in `command`/any `arg`; a forbidden environment
+     variable name (exact match against a fixed list, or the `DYLD_` prefix);
+     an unsupported URL scheme for HTTP/SSE transport; a header name outside
+     RFC 7230 `tchar`, or a duplicate header name (case-insensitively); a
+     timeout of `0` or greater than 600s.
+  2. `Introspector::discover_server` re-runs `validate_server_config` on its
+     `config` argument even though callers are expected to have already
+     validated it via the builder.
+  3. Every rejection error omits the offending value from its message when
+     that value could itself be a secret.
+- *Dependencies*: none
+
+**FR-004**: The system shall cache the result of a successful introspection
+in-process, keyed by server id, and expose it for retrieval without
+re-connecting.
+
+- *Rationale*: avoids redundant process spawns/network round-trips within a
+  single run.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-004
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `Introspector::get_server(id)` returns the previously discovered
+     `ServerInfo` without a new connection attempt.
+  2. `list_servers`/`server_count`/`remove_server`/`clear` operate on the same
+     cache.
+- *Dependencies*: FR-001
+
+#### 3.2.2 Progressive Loading Code Generation
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#Progressive Loading Code Generation]]
+
+**FR-005**: The system shall render each discovered tool as one
+self-contained TypeScript file (parameter/result types, JSDoc, an executable
+CLI entry point) plus a fixed set of supporting files (`index.ts`, a runtime
+bridge, `package.json`, `tsconfig.json`, `_meta.json`), such that a server
+with N tools produces exactly N + 5 files.
+
+- *Rationale*: this is the "progressive loading" pattern itself — the
+  project's entire raison d'être (claimed token savings depend on tools
+  being independently loadable).
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-005
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `ProgressiveGenerator::generate`/`generate_with_categories` produce
+     exactly `tools.len() + 5` `GeneratedFile` entries for any valid input.
+  2. Two tools sharing an identical raw name, or a tool named after a JS/TS
+     reserved word (e.g. `delete`), receive distinct, valid TypeScript
+     identifiers via `resolve_typescript_names`/`disambiguate_identifier`.
+  3. `generate` (no categorization) and `generate_with_categories` called
+     with an empty categorization map produce byte-identical `index.ts`
+     category grouping (regression-tested: no spurious "uncategorized"
+     group is synthesized).
+- *Dependencies*: FR-001
+
+**FR-006**: The system shall emit a versioned, structured metadata sidecar
+(`_meta.json`) alongside generated tools, containing each tool's raw
+(unsanitized) name, description, and parameter descriptions, recoverable
+without parsing the generated TypeScript.
+
+- *Rationale*: replaces a historical regex-based TypeScript re-parser that
+  could never recover parameter descriptions (issue #141); this is the wire
+  contract skill generation depends on.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-006
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Every `generate`/`generate_with_categories` call emits `_meta.json`
+     conforming to `mcp_execution_core::metadata::ServerMetadata`, tagged
+     with `METADATA_SCHEMA_VERSION`.
+  2. `_meta.json`'s parameter descriptions are the raw MCP-reported text,
+     not JSDoc-sanitized (sanitization applies only to the `.ts` JSDoc
+     copy).
+- *Dependencies*: FR-005
+
+**FR-007**: The system shall support generating TypeScript from a caller-
+supplied per-tool categorization (category, keywords, short description)
+without itself calling any LLM API.
+
+- *Rationale*: lets the calling Claude Code session categorize tools using
+  its own natural-language understanding instead of this project needing a
+  separately-billed LLM integration (see
+  [[constitution#VII. Simplicity]]).
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-007
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `generate_with_categories` accepts a `HashMap<String, ToolCategorization>`
+     keyed by raw tool name and reflects it in `index.ts` grouping and
+     per-tool JSDoc.
+  2. No crate in the workspace makes an outbound call to a third-party LLM
+     API as part of code generation.
+- *Dependencies*: FR-005
+
+**FR-008**: The system shall reject, before completing generation, any tool
+set that would produce more than a fixed number of files or more than a
+fixed number of total bytes, where both bounds are derived from
+introspection's own bounds rather than chosen independently.
+
+- *Rationale*: CWE-400 defense — a `ServerInfo` that already cleared
+  introspection's bounds must never be deterministically rejected here for
+  merely being "as large as introspection already allows," but an
+  amplifying re-embedding (e.g. `_meta.json` re-embedding every schema) must
+  still be caught.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-008
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `tools.len() + 5 > MAX_GENERATED_FILES` (= `MAX_TOOL_COUNT` + 5) is
+     rejected before any per-tool rendering begins.
+  2. The running byte total is checked incrementally as each file is
+     produced against `MAX_GENERATED_BYTES` (= 2 × `MAX_TOOL_COUNT` ×
+     (`MAX_TOOL_NAME_LEN` + `MAX_TOOL_DESCRIPTION_LEN` + `MAX_SCHEMA_SIZE_BYTES`)),
+     not only after the whole output is assembled.
+- *Dependencies*: FR-002, FR-005
+
+**FR-009**: The system shall support previewing the file list and sizes
+generation would produce, without writing anything to the filesystem.
+
+- *Rationale*: lets a developer inspect an unfamiliar/new server's output
+  safely before committing to disk.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-009
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `mcp-execution-cli generate --dry-run` produces a `DryRunResult` listing
+     every file's path and human-readable size.
+  2. No file is created, modified, or removed on disk as a result of a
+     `--dry-run` invocation.
+- *Dependencies*: FR-005
+
+#### 3.2.3 Virtual Filesystem & Atomic Export
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#Virtual Filesystem & Atomic Export]]
+
+**FR-010**: The system shall publish generated output to its target
+directory such that a process killed at any point before publication
+completes leaves the target directory either fully absent, in its previous
+complete state, or a still-recoverable staging artifact — never a
+partially-written target.
+
+- *Rationale*: crash-safety for the export step; a half-written
+  `~/.claude/servers/{id}/` would silently break every tool in that
+  directory, not just the one being regenerated.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-010
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Export stages every file in a sibling temporary directory (created via
+     `tempfile::Builder`), writing each via temp-file-then-fsync-then-rename,
+     before any file lands at its final location.
+  2. Publication is a single directory rename when the target doesn't yet
+     exist; when it does, the existing target is moved aside, the staged
+     directory is renamed into place, then the displaced original is
+     removed — and if the second rename fails, the displaced original is
+     renamed back, so the target is never observed missing except in the
+     narrow window between those two renames.
+  3. A failure at any point before publication leaves the target directory
+     untouched; the staging directory's own `Drop` removes the partial tree.
+- *Dependencies*: FR-005
+
+**FR-011**: The system shall treat a shared output root (e.g.
+`~/.claude/servers/`) as containing independently-published per-top-level-
+group subdirectories, such that publishing one server's group can never
+corrupt, delete from, or block on a sibling server's already-published
+group.
+
+- *Rationale*: multiple MCP servers' generated output coexists under one
+  root; a single-owner "replace-wholesale" semantics (appropriate within one
+  server's own subtree) would be catastrophic applied to the shared root
+  itself.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-011
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `FilesBuilder::build_and_export` splits the VFS by top-level path
+     component into a `BTreeMap` of groups (deterministic publish order)
+     plus any bare top-level files.
+  2. Each group publishes via the same atomic staging/rename mechanism as
+     FR-010, scoped to `base_path/<group-name>` only.
+  3. A publish failure partway through a multi-group batch leaves groups
+     already published intact and surfaces the failure to the caller; the
+     batch as a whole is not rolled back.
+- *Dependencies*: FR-010
+
+**FR-012**: The system shall, when re-publishing a server's group with fewer
+tool files than a previous publish, remove the now-stale files from that
+group's directory rather than leaving them alongside the new set.
+
+- *Rationale*: a tool removed or renamed upstream should not leave an
+  orphaned, misleadingly-present file behind.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-012
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. Re-exporting a group whose new file set is a strict subset of the
+     previous one results in the previous-only files being absent after
+     publication.
+  2. Sibling groups under the same shared root are unaffected.
+- *Dependencies*: FR-011
+
+**FR-013**: The system shall reject, before writing any file, an export
+batch whose total file count or total byte size exceeds a fixed bound equal
+to codegen's own derived bounds.
+
+- *Rationale*: a payload split across many small per-group files must not be
+  able to bypass the per-group bound each individual publish already
+  enforces.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-013
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `check_export_bounds()` runs against the **whole** VFS up front in
+     `build_and_export`, not only per-group.
+  2. `MAX_EXPORT_FILES`/`MAX_EXPORT_BYTES` equal
+     `mcp-execution-codegen::MAX_GENERATED_FILES`/`MAX_GENERATED_BYTES`
+     exactly.
+- *Dependencies*: FR-008
+
+#### 3.2.4 SKILL.md Generation
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#SKILL.md Generation]]
+
+**FR-014**: The system shall render a `SKILL.md` file directly from a
+generated server's `_meta.json` sidecar, without any LLM call, grouping
+tools by category and selecting representative example tools.
+
+- *Rationale*: a fast, deterministic, no-external-dependency path to a usable
+  integration document.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-014
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `mcp-execution-cli skill` scans a server directory's `_meta.json`,
+     builds a skill context, and renders `SKILL.md` via
+     `render_skill_md` with no network call.
+  2. Tools without a category are grouped under `"uncategorized"`, sorted
+     last.
+- *Dependencies*: FR-006
+
+**FR-015**: The system shall support generating an LLM-facing prompt
+(instead of a directly rendered document) so that the calling Claude session
+can compose the `SKILL.md` body itself, and shall support writing that
+Claude-composed content back to the intended output location.
+
+- *Rationale*: trades a template-only render for LLM-quality summaries when
+  running as an MCP server.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-015
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `generate_skill` returns a rendered generation prompt
+     (`render_generation_prompt`) without writing any file.
+  2. `save_skill` validates content size (≤ 100 KiB), that it begins with
+     `---`, extracts and validates its frontmatter, and writes it to the
+     confined output path, refusing to overwrite an existing file unless
+     `overwrite: true`.
+- *Dependencies*: FR-014
+
+**FR-016**: The system shall detect and report drift between a server's
+metadata sidecar and the tool files actually present on disk: a sidecar
+entry missing its corresponding file shall fail the scan; a file present
+without a corresponding sidecar entry shall be reported as a non-fatal
+warning.
+
+- *Rationale*: `_meta.json` and the `.ts` files it describes can fall out of
+  sync (manual edits, partial regeneration, interrupted export); a caller
+  needs to know before generating documentation from stale data.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-016
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `scan_tools_directory` fails with `ScanError::StaleMetadata`, naming
+     the missing tool/file, on the first sidecar entry with no matching
+     `.ts` file.
+  2. A `.ts` file present but not referenced by the sidecar is excluded from
+     the scan's tool list and surfaced as a human-readable string in
+     `ScanResult::warnings`, not merely logged.
+  3. `index.ts` is never treated as an "extra" file.
+- *Dependencies*: FR-006
+
+**FR-017**: The system shall confine any filesystem write whose target path
+depends on a caller-supplied `server_id` or output path to that server's own
+subdirectory of a fixed base directory, rejecting absolute paths, `..`
+traversal, and pre-existing symlinks at any point along the confined path.
+
+- *Rationale*: `server_id`/`output_path` for `save_skill` (and the analogous
+  `save_categorized_tools` output directory) are caller-supplied and must
+  not be usable to write outside the intended location, including via a
+  symlink planted at exactly the confinement boundary.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-017
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `resolve_skill_output_path` rejects `server_id`/`output_path` failing
+     `validate_server_id`/`validate_path_segment`, an absolute
+     `output_path`, or `..` anywhere in it.
+  2. The `server_id`'s own directory is rejected outright if it already
+     exists as a symlink, regardless of where it points (including at a
+     sibling server's own directory).
+  3. The final path component is rejected if it exists as a symlink, whether
+     dangling or not.
+- *Dependencies*: none
+
+#### 3.2.5 CLI Server Configuration Management
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#CLI Server Configuration Management]]
+
+**FR-018**: The system shall list, describe, and validate the MCP server
+entries configured in `~/.claude/mcp.json`, reporting a time-boxed
+availability signal per entry for the list view and a full-handshake result
+for the single-target views.
+
+- *Rationale*: lets a developer audit configuration quickly (bounded,
+  concurrent checks) versus authoritatively (full timeout, single target).
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-018
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `server list` checks every entry concurrently, each bounded by
+     `LIST_AVAILABILITY_TIMEOUT` (3s) independent of the entry's own
+     configured `connect_timeout_secs`; stdio entries are checked via `PATH`
+     lookup only, http/sse entries via URL well-formedness plus a bounded
+     real introspection attempt.
+  2. `server info <server>`/`server validate <command>` perform a full
+     introspection handshake using the entry's own configured timeout.
+  3. A server merely slower than 3s but within its own configured timeout
+     may legitimately report `unavailable` in `list` while reporting
+     `available` in `info`/`validate` — this is a documented, accepted
+     trade-off, not a defect.
+- *Dependencies*: FR-001, FR-003
+
+**FR-019**: The system shall validate that the local runtime is ready to
+execute generated tools: Node.js is present and at least version 18.0.0,
+generated `.ts` files are executable (on Unix), and `~/.claude/mcp.json`
+exists.
+
+- *Rationale*: surfaces the most common first-run failure modes before a
+  developer tries to execute generated output.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-019
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `setup` fails with a clear error if `node --version` is missing or
+     below 18.0.0.
+  2. On Unix, every `.ts` file under `~/.claude/servers/` is made
+     executable, and the count of files changed is reported.
+  3. On non-Unix platforms, `setup` reports `servers_dir_found: false` and
+     `files_made_executable: 0` unconditionally, never attempting a
+     permission-bit operation that doesn't apply.
+- *Dependencies*: none
+
+**FR-020**: The system shall generate a shell completion script for
+bash, zsh, fish, powershell, and elvish.
+
+- *Rationale*: standard CLI ergonomics.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-020
+- *Priority*: Could
+- *Acceptance criteria*:
+  1. `completions <shell>` writes a syntactically valid completion script
+     for that shell to stdout and always exits successfully.
+- *Dependencies*: none
+
+**FR-021**: The system shall escape or quote any server-reported text before
+printing it in any CLI output format (JSON, text, or pretty).
+
+- *Rationale*: a malicious MCP server's handshake `serverInfo.name` (or
+  other server-reported text) could otherwise inject raw ANSI/control escape
+  sequences into the user's terminal (CWE-150-adjacent).
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-021
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `generate`'s `Text`/`Pretty` output escapes the server's handshake name
+     via `formatters::escape_display` before printing, matching the
+     escaping already applied to every other subcommand's output via
+     `format_output`.
+  2. `escape_display` always JSON-quotes its input, even absent control
+     characters, so the guarantee is uniform rather than conditional on
+     detecting an attack.
+- *Dependencies*: none
+
+#### 3.2.6 MCP Server Exposure (Session-Based Workflow)
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#MCP Server Exposure (Session-Based Workflow)]]
+
+**FR-022**: The system shall, on `introspect_server`, always use a stdio
+transport regardless of caller input, introspect the target, store the
+result as a time-limited session, and return a session id.
+
+- *Rationale*: `IntrospectServerParams` has no field capable of selecting
+  HTTP/SSE transport, and a dedicated test pins its exact field set with no
+  `..` rest pattern, making the addition of such a field a compile error
+  unless the guard test is updated too — a deliberate SSRF-risk guard, not
+  an omission.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-022
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `introspect_server` builds a stdio `ServerConfig` via
+     `build_stdio_server_config` unconditionally.
+  2. A successful call returns a session id and expiry
+     (`DEFAULT_TIMEOUT_MINUTES` = 30), redeemable exactly once by
+     `save_categorized_tools`.
+  3. Introspection observes the request's cancellation token
+     (`tokio::select!`), reliably killing the spawned child if cancelled.
+- *Dependencies*: FR-001, FR-003
+
+**FR-023**: The system shall, on `save_categorized_tools`, validate the
+submitted categorized tool set against the session's own introspected tool
+names (compared after identical sanitization), rejecting extras, unknowns,
+duplicates, and over-length fields.
+
+- *Rationale*: prevents generation for tools that were never actually
+  discovered, and bounds the categorization payload's own size.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-023
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. A submitted tool name not present in the session's introspected set
+     (after `sanitize_untrusted_text`) is rejected.
+  2. A duplicate name, or more entries than
+     `min(introspected count, MAX_TOOL_FILES)`, is rejected.
+  3. Any field (`name`/`category`/`keywords`/`short_description`) exceeding
+     its own fixed byte cap is rejected.
+  4. A well-behaved caller echoing back exactly the sanitized names it was
+     shown by `introspect_server` never fails this check due to sanitization
+     mismatch.
+- *Dependencies*: FR-022
+
+**FR-024**: The system shall bound both the number of concurrently pending
+introspection sessions and their aggregate estimated memory footprint,
+independently, rejecting a new session that would exceed either bound.
+
+- *Rationale*: a session-count cap alone doesn't bound memory (a single
+  session's real footprint can vary by orders of magnitude with tool
+  count); both bounds are necessary.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-024
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `StateManager::store` rejects with `StateError::AtCapacity` once
+     `pending_count() == MAX_PENDING_SESSIONS` (1000).
+  2. `StateManager::store` rejects with `StateError::MemoryBudgetExceeded`
+     once aggregate estimated bytes would exceed `MAX_TOTAL_PENDING_BYTES`.
+  3. A session-size serialization failure is treated as `usize::MAX` (always
+     exceeding the bound), never silently under-counted.
+  4. Expired sessions are swept lazily as a side effect of `store`/`take`.
+- *Dependencies*: FR-022
+
+**FR-025**: The system shall enumerate previously-generated servers under a
+default or caller-specified (confined) base directory, reporting each
+server's tool file count and last-generation timestamp.
+
+- *Rationale*: lets a caller discover what's already generated without
+  re-introspecting.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-025
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. `list_generated_servers` confines a caller-specified `base_dir` to
+     `servers_base_dir` both lexically (before existence is known) and, if
+     the path exists, via canonicalization (catching a symlink planted
+     inside it).
+  2. Per-server tool count excludes `_`-prefixed entries and `_runtime`.
+- *Dependencies*: none
+
+**FR-026**: The system shall serialize concurrent operations against the
+same server id or the same output directory without blocking operations
+against a different server id or output directory.
+
+- *Rationale*: a slow or hung target server, or a concurrent export to the
+  same output directory, must not degrade unrelated operations.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-026
+- *Priority*: Should
+- *Acceptance criteria*:
+  1. The per-`ServerId` introspector lock and the per-output-directory
+     export lock are each scoped to a `HashMap` keyed by that identity, with
+     the outer map lock released before the per-key handle is awaited.
+  2. Both lock tables evict entries by identity (`Arc::ptr_eq`), not by
+     value, after use.
+- *Dependencies*: FR-022
+
+#### 3.2.7 Security Validation & Hardening
+
+> [!info] Traceability
+> Traces to: [[BRD-mcp-execution-2026-07-27#Security Validation & Hardening]]
+
+**FR-027**: The system shall implement `Debug` by hand (never derive it) for
+every type capable of carrying an environment variable value, HTTP header
+value, URL, or CLI argument, redacting the value while preserving
+identifying keys, while leaving `Serialize` unredacted for that same type.
+
+- *Rationale*: `Debug` output routinely reaches logs/error messages/crash
+  reports; `Serialize` output is relied on for config persistence and must
+  carry real values — the two paths need opposite behavior, and this
+  asymmetry must be intentional and documented, not accidental.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-027
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `ServerConfig`, `ServerConfigBuilder`, and every CLI-facing type
+     capable of carrying a secret (`Cli`/`Commands`, `McpTransport`,
+     `RawMcpServerEntry`, `TransportArgs`, `RawServerArgs`) hand-write
+     `Debug` using `RedactedItems`/`RedactedMapValues`/`RedactedUrl`/
+     `sanitize_path_for_error`.
+  2. Regression tests assert a specific secret substring never appears in
+     `format!("{:?}", ...)` output for any of these types.
+- *Dependencies*: none
+
+**FR-028**: The system shall sanitize control characters out of, and where
+the destination is LLM-facing, wrap in an explicit and unforgeable
+untrusted-data boundary, any text originating from an introspected MCP
+server before it is embedded in a document or shown to an LLM.
+
+- *Rationale*: an introspected server's self-reported tool
+  names/descriptions/keywords are attacker-controlled from this project's
+  perspective; both a rendered document (SKILL.md) and an LLM-facing prompt
+  (introspection summaries, skill generation prompt) embed this data.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-028
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `sanitize_untrusted_text` flattens all control characters (and U+2028/
+     U+2029) to spaces and truncates by character count before any
+     server-reported field is used.
+  2. `wrap_untrusted_block` escapes `&`/`<`/`>` in the body and wraps it in
+     `<untrusted-data>...</untrusted-data>`, applied by both `mcp-skill`'s
+     generation prompt and `mcp-server`'s `introspect_server` tool
+     summaries.
+  3. A description crafted to forge the boundary's own delimiters is
+     regression-tested to fail to do so.
+- *Dependencies*: none
+
+**FR-029**: The system shall confine every filesystem write whose target
+path is influenced by caller or server-reported input to a canonicalized
+base directory, checking each path component in order, rejecting a symlink
+found at the confinement boundary outright, and re-resolving the
+confinement check immediately before each write rather than caching a
+previously-resolved path.
+
+- *Rationale*: a single `canonicalize`-then-`starts_with` check misses a
+  symlink planted at exactly the confinement boundary; caching a resolved
+  path across a session's lifetime leaves a window in which a
+  planted-afterward symlink is never re-checked.
+- *Source*: [[BRD-mcp-execution-2026-07-27]], FR-029
+- *Priority*: Must
+- *Acceptance criteria*:
+  1. `mcp-skill::resolve_skill_output_path` and
+     `mcp-server::output_dir::resolve_output_dir` both walk one path
+     component at a time using the shared `mcp-core::validate_path_segment`
+     primitive.
+  2. Both reject a symlink at the `server_id` directory boundary outright,
+     not merely "resolve and re-check."
+  3. Both resolve confinement fresh, immediately before the write they
+     guard, never cached across a longer-lived structure (e.g. a
+     30-minute MCP session).
+- *Dependencies*: FR-017
+
+### 3.3 Performance Requirements
+
+> [!note]
+> Detailed performance metrics are in
+> [[NFR-mcp-execution-2026-07-27#2. Performance Efficiency]]. This section
+> ties two specific functional requirements to a measured target.
+
+- FR-005 (code generation) is measured at 0.19ms for a 10-tool server and
+  0.97ms for a 50-tool server against documented targets of <100ms and
+  <20ms respectively (README performance table).
+- FR-010/FR-011 (VFS export) targets <50ms for a 30-file export
+  (`crates/mcp-files/src/filesystem.rs` doc comment) and is measured at
+  1.2ms against a <10ms README target.
+
+### 3.4 Logical Database Requirements
+
+Not applicable — this system holds no persistent database. The only
+structured, durable state is the filesystem itself
+(`~/.claude/mcp.json` read; `~/.claude/servers/{id}/`, `~/.claude/skills/{id}/`
+written) and the in-memory-only session table in `mcp-execution-server`
+(`StateManager`, never persisted to disk, lost on process restart).
+
+| Entity | Key Attributes | Relationships | Retention |
+|--------|---------------|--------------|-----------|
+| `PendingGeneration` (session) | `server_id`, `server_info`, `config`, `created_at`, `expires_at` | Redeemed exactly once by `save_categorized_tools` | In-memory only; expires after 30 minutes, swept lazily; never persisted |
+| Generated server directory | `_meta.json`, per-tool `.ts` files, `index.ts`, `_runtime/mcp-bridge.ts`, `package.json`, `tsconfig.json` | One directory per `server_id` under `~/.claude/servers/` | Until explicitly regenerated or removed by the user; no automatic expiry |
+
+### 3.5 Design Constraints
+
+- MCP protocol compliance is via the official `rmcp` SDK exclusively; no
+  hand-rolled JSON-RPC client/server implementation exists elsewhere in the
+  workspace.
+- Generated TypeScript targets `ES2022`, `NodeNext` module resolution,
+  `strict: true` — a fixed, non-configurable `tsconfig.json` regenerated on
+  every `generate` call (not intended to be `extends`-ed by a consumer).
+
+### 3.6 Software System Attributes
+
+> [!note]
+> Full quality attribute specifications are in
+> [[NFR-mcp-execution-2026-07-27]]. Summarized here as they constrain
+> functional design directly.
+
+- **Reliability**: export must be atomic (FR-010/FR-011) and introspection/
+  generation must fail closed (reject, not silently truncate) on any
+  resource-bound violation (FR-002, FR-008, FR-013, FR-024).
+- **Security**: every functional requirement in
+  [[#3.2.7 Security Validation & Hardening]] is a hard constraint on how
+  every other functional requirement in this document may be implemented —
+  e.g. FR-001 (introspection) cannot be satisfied by a code path that skips
+  FR-003 (config validation).
+- **Maintainability**: every `pub` item requires a doc comment with a
+  runnable `# Examples` section (workspace-wide, `#![warn(missing_docs)]`);
+  see [[NFR-mcp-execution-2026-07-27#7. Maintainability]].
+
+## 4. Verification and Validation
+
+### 4.1 Verification Matrix
+
+| Requirement | Method | Criteria | Status |
+|------------|--------|----------|--------|
+| FR-001 | Test (integration, stdio + HTTP fixtures) | `ServerInfo` returned matches fixture server's real tool set | Passing (existing test suite) |
+| FR-002 | Test (unit, boundary values at each constant) | Exceeding any bound yields `ResourceLimitExceeded`; exactly-at-bound is accepted | Passing |
+| FR-003 | Test (unit, per validation rule + defense-in-depth) | Every documented rejection case (metachar, forbidden env, bad URL scheme, bad header, timeout 0/601s) rejected; timeout 600s accepted | Passing |
+| FR-004 | Test (unit) | Cache returns previously-discovered `ServerInfo` without a new connection | Passing |
+| FR-005 | Test (unit + doc-test) | File count = N + 5; identifier collisions resolved | Passing |
+| FR-006 | Test (unit) | `_meta.json` schema-version-tagged, raw text preserved | Passing |
+| FR-007 | Test (unit, regression) | Empty categorization map byte-identical to uncategorized `generate` | Passing |
+| FR-008 | Test (unit, boundary) | Oversized tool set / byte total rejected before/incrementally during rendering | Passing |
+| FR-009 | Test (integration, CLI) | `--dry-run` writes no file; lists correct sizes | Passing |
+| FR-010 | Test (integration, kill-mid-export simulation via crash-point injection or artifact inspection) | No partial target directory observed | Passing |
+| FR-011 | Test (integration, multi-group batch) | Sibling group untouched by a failing group's publish | Passing |
+| FR-012 | Test (integration) | Stale files removed after shrinking re-export | Passing |
+| FR-013 | Test (unit, whole-batch bound) | Many-small-files payload rejected pre-write | Passing |
+| FR-014 | Test (unit) | Rendered `SKILL.md` matches expected template output, no network call | Passing |
+| FR-015 | Test (unit, MCP tool handlers) | Prompt returned by `generate_skill`; `save_skill` writes/validates as specified | Passing |
+| FR-016 | Test (unit, drift scenarios) | Missing file → `StaleMetadata`; extra file → non-fatal warning | Passing |
+| FR-017 | Test (unit, symlink scenarios incl. dangling) | Every documented rejection case confirmed | Passing |
+| FR-018 | Test (integration, `server` subcommand) | Time-boxed vs. full-timeout behavior distinguished | Passing |
+| FR-019 | Test (integration, `setup`) | Node version gate; Unix executable-bit behavior; non-Unix zeroed report | Passing |
+| FR-020 | Test (unit) | Valid completion script per shell | Passing |
+| FR-021 | Test (regression, CWE-150-adjacent) | Control-sequence-bearing server name escaped in Text/Pretty output | Passing |
+| FR-022 | Test (unit, pinned-shape guard) | `IntrospectServerParams` destructure has no HTTP/SSE field | Passing |
+| FR-023 | Test (unit, mismatch scenarios) | Each rejection case (unknown/dup/over-length name) confirmed | Passing |
+| FR-024 | Test (unit, capacity + memory-budget scenarios) | Both independent caps enforced | Passing |
+| FR-025 | Test (unit, confinement) | Escaping/symlinked `base_dir` rejected | Passing |
+| FR-026 | Test (unit, concurrency) | Per-server-id / per-output-dir isolation confirmed | Passing |
+| FR-027 | Test (regression, secret-substring assertion) | Secret never appears in `Debug` output | Passing |
+| FR-028 | Test (regression, forged-boundary attempt) | Sanitization + boundary both hold under attack input | Passing |
+| FR-029 | Test (unit, symlink-at-boundary scenarios) | Fresh-resolution-per-write and boundary-symlink rejection both confirmed | Passing |
+
+> [!note]
+> "Passing" reflects the existing, already-implemented test suite this SRS
+> formalizes (specs/*/spec.md cite the specific test names/behaviors this
+> table summarizes); it is not a claim independently re-verified while
+> writing this document. See [[NFR-mcp-execution-2026-07-27#7.2 Testability]]
+> for the workspace-wide testing policy this rests on.
+
+### 4.2 Acceptance Test Outline
+
+- **End-to-end CLI flow**: `introspect` a fixture stdio server → `generate`
+  → inspect `~/.claude/servers/{id}/` contents → `skill` → inspect
+  `~/.claude/skills/{id}/SKILL.md`.
+- **End-to-end MCP-server flow**: `introspect_server` → `save_categorized_tools`
+  → `list_generated_servers` → `generate_skill` → `save_skill`.
+- **Adversarial scenarios**: hostile server names/descriptions (control
+  characters, boundary-forgery attempts, oversized fields); malformed/
+  symlink-laden paths for every path-confinement entry point; a
+  `ServerConfig` deserialized directly from crafted JSON bypassing the
+  builder.
+
+## 5. Appendices
+
+### 5.1 Traceability Matrix
+
+| BRD Requirement | SRS Requirement(s) | NFR Requirement(s) |
+|----------------|--------------------|--------------------|
+| BRD-FR-001 | FR-001 | NFR-PERF-001, NFR-REL-010 |
+| BRD-FR-002 | FR-002 | NFR-SEC-030 |
+| BRD-FR-003 | FR-003 | NFR-SEC-001, NFR-SEC-002 |
+| BRD-FR-004 | FR-004 | — |
+| BRD-FR-005 | FR-005 | NFR-PERF-001 |
+| BRD-FR-006 | FR-006 | NFR-MNT-020 |
+| BRD-FR-007 | FR-007 | NFR-MNT-001 |
+| BRD-FR-008 | FR-008 | NFR-SEC-030 |
+| BRD-FR-009 | FR-009 | — |
+| BRD-FR-010 | FR-010 | NFR-REL-020, NFR-REL-021 |
+| BRD-FR-011 | FR-011 | NFR-REL-010, NFR-REL-020 |
+| BRD-FR-012 | FR-012 | NFR-REL-020 |
+| BRD-FR-013 | FR-013 | NFR-SEC-030, NFR-PERF-002 |
+| BRD-FR-014 | FR-014 | NFR-PERF-001 |
+| BRD-FR-015 | FR-015 | NFR-SEC-031 |
+| BRD-FR-016 | FR-016 | NFR-REL-011 |
+| BRD-FR-017 | FR-017 | NFR-SEC-040 |
+| BRD-FR-018 | FR-018 | NFR-PERF-001 |
+| BRD-FR-019 | FR-019 | NFR-COM-011 |
+| BRD-FR-020 | FR-020 | — |
+| BRD-FR-021 | FR-021 | NFR-SEC-032 |
+| BRD-FR-022 | FR-022 | NFR-SEC-001, NFR-REL-010 |
+| BRD-FR-023 | FR-023 | NFR-SEC-030 |
+| BRD-FR-024 | FR-024 | NFR-PERF-011, NFR-REL-010 |
+| BRD-FR-025 | FR-025 | NFR-SEC-040 |
+| BRD-FR-026 | FR-026 | NFR-REL-010 |
+| BRD-FR-027 | FR-027 | NFR-SEC-020 |
+| BRD-FR-028 | FR-028 | NFR-SEC-031 |
+| BRD-FR-029 | FR-029 | NFR-SEC-040 |
+
+### 5.2 Use Case Diagrams / Flows
+
+See [[README#End-to-End Data Flow]] for the full, verified end-to-end
+sequence diagram covering both the CLI and MCP-server entry points.
+
+## See Also
+
+- [[BRD-mcp-execution-2026-07-27]] — business requirements (source)
+- [[NFR-mcp-execution-2026-07-27]] — non-functional requirements
+- [[README]] — project knowledge base / cross-block index

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -1,0 +1,302 @@
+---
+aliases:
+  - mcp-execution-cli spec
+  - CLI spec
+tags:
+  - sdd
+  - spec
+  - cli
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../core/spec]]"
+  - "[[../introspector/spec]]"
+  - "[[../codegen/spec]]"
+  - "[[../files/spec]]"
+  - "[[../skill/spec]]"
+---
+
+# Block: Command-Line Interface (`mcp-execution-cli`)
+
+> [!abstract]
+> Path: `crates/mcp-cli`. `clap`-derived CLI binary (`mcp-execution-cli`)
+> that drives the whole pipeline directly (introspect → generate → skill),
+> plus server-config management, environment setup, and shell completions.
+> Depends on `mcp-execution-core`, `mcp-execution-introspector`,
+> `mcp-execution-codegen`, `mcp-execution-files`, `mcp-execution-skill`.
+
+## 1. Responsibility
+
+Provide the human/scriptable entry point to everything the other crates
+do, without going through the MCP-server layer at all: read
+`~/.claude/mcp.json` or accept transport flags directly, introspect a
+server, generate progressive-loading TypeScript, render SKILL.md, and
+manage/validate server configuration and the local runtime environment.
+
+## 2. Subcommands (`Commands` enum, `src/cli.rs`)
+
+| Subcommand | Purpose | Key flags |
+|---|---|---|
+| `introspect` | Connect + display server capabilities/tools | `--from-config`, `server` (positional), `--arg`/`-a`, `--env`/`-e`, `--cwd`, `--http`/`--sse`, `--header`, `--detailed`/`-d`, `--connect-timeout-secs`, `--discover-timeout-secs` |
+| `generate` | Introspect + emit progressive-loading TypeScript to `~/.claude/servers/{id}/` | same transport flags as `introspect` (long-form: `--arg`, `--env`, `--cwd`, `--http`, `--sse`, `--header`), plus `--name`, `--progressive-output`, `--dry-run` |
+| `skill` | Render SKILL.md directly from a generated server's tools (no LLM) | `-s/--server`, `--servers-dir`, `-o/--output`, `--skill-name`, `--hint` (repeatable), `--overwrite` |
+| `server` | Manage `~/.claude/mcp.json` entries | subcommand: `list`, `info <server>`, `validate <command>` |
+| `setup` | Validate the local runtime (Node.js version, executable bits, config presence) | none |
+| `completions` | Emit a shell completion script | `<shell>` (bash/zsh/fish/powershell/elvish) |
+
+Global flags on `Cli` (apply to every subcommand): `-v/--verbose` (DEBUG log
+level), `--format {json,text,pretty}` (default `pretty`, case-insensitive).
+
+`--from-config`/transport flags are **mutually exclusive** at the clap
+level (`conflicts_with_all`), and `server`/`http_url`/`sse_url` collectively
+satisfy `required_unless_present_any` — i.e. exactly one of "load from
+config" or "pick a transport" must be chosen, enforced before any command
+handler runs.
+
+## 3. `common.rs` — Shared Server-Resolution Machinery
+
+This module is the single place `introspect` and `generate` (which accept
+an identical flag surface) resolve "how do I reach this server":
+
+```rust
+pub struct RawServerArgs { from_config, server, args, env, cwd, http, sse, headers, connect_timeout_secs, discover_timeout_secs }
+pub(crate) fn resolve_server_config(raw: RawServerArgs) -> Result<(ServerId, ServerConfig)>;
+```
+`RawServerArgs` exists specifically to prevent transposing two
+same-typed fields (e.g. `http`/`sse`, both `Option<String>`) by positional
+argument order (issue #286's fix) — named fields instead.
+
+```rust
+pub struct McpConfig { pub mcp_servers: HashMap<String, McpServerEntry> }
+pub struct McpServerEntry { pub transport: McpTransport, pub connect_timeout_secs, pub discover_timeout_secs }
+pub enum McpTransport { Stdio{command,args,env,cwd}, Http{url,headers}, Sse{url,headers} }
+pub enum TransportArgs { Stdio{...}, Http{...}, Sse{...} } // raw, unparsed CLI-flag mirror of McpTransport
+impl TransportArgs { pub fn from_flags(...) -> Result<Self>; } // enforces "exactly one transport" as a safety net for direct callers
+```
+
+`McpServerEntry`'s `Deserialize` is **hand-written** (via a
+`RawMcpServerEntry` landing zone + `TryFrom`), not derived, so it can:
+- Infer `stdio` vs `http` when `"type"` is absent (via `command` vs `url`
+  presence) — an `mcp.json` entry can omit `"type"` for a bare `url`-only
+  http entry.
+- Reject cross-field violations with precise messages (`"http server entry
+  must not set \"command\""`, `"stdio server entry must not set
+  \"url\""`).
+- Silently accept-and-warn on unrecognized top-level keys (`extra:
+  HashMap<String, Value>`), since `~/.claude/mcp.json` is shared with other
+  MCP clients (e.g. Claude Code's own `disabled`/`alwaysAllow` keys) this
+  project doesn't model.
+
+`derive_server_id_from_url(url)` — the `ServerId` used for an Http/Sse
+config resolved from CLI flags (not `mcp.json`, which uses the config-file
+key as the id). Uses **only `host` + `path`** from the parsed URL, never
+`userinfo`, structurally excluding embedded credentials from the derived
+directory name; lowercased, runs of non-`[a-z0-9-]` collapsed to a single
+`-`, trimmed, truncated to `MAX_SERVER_ID_LENGTH`, falls back to
+`"http-server"` if the result would be empty (e.g. a bare `https://` with
+no host) or the URL fails to parse. This matters beyond cosmetics: the id
+becomes a directory name under `~/.claude/servers/{id}/` and is embedded in
+generated `.ts` literals, so a raw URL there would break
+`mcp-skill::validate_server_id`'s charset, could smuggle a `..` path
+segment, and (if not credential-excluded) would leak a token into a
+directory name and generated source.
+
+`parse_key_value(s, kind)` — parses a single `--env`/`--header` `KEY=VALUE`
+CLI argument. **Never echoes the raw input on failure** in any of its
+error paths (no `=` at all; empty key; key containing whitespace/`:`/
+control chars — the last case specifically catches a `Name: Value`-style
+mistake where the real `=` matched inside a secret value) — because the
+whole string, or the "key" half, may itself be the secret.
+
+## 4. Debug-Redaction Discipline
+
+Every CLI-facing type that can carry a secret (`Cli`/`Commands` themselves,
+`McpTransport`, `RawMcpServerEntry`, `TransportArgs`, `RawServerArgs`) hand-
+writes `Debug` rather than deriving it, applying `mcp-core`'s
+`RedactedItems`/`RedactedMapValues`/`RedactedUrl`/`sanitize_path_for_error`
+consistently — because `runner::report_and_classify` prints
+`format!("Error: {err:?}")` to stderr on any failure, and a `Commands`
+value routinely ends up inside that error's `anyhow::Context`. Regression
+tests assert specific secret substrings (e.g. `sk-verySECRETtoken...`)
+never appear in `format!("{:?}", cli.command)` for `--env`/`--header`/
+`--http`/`--sse` inputs.
+
+## 5. `runner.rs` — Dispatch and Exit-Code Classification
+
+```rust
+pub fn init_logging(verbose: bool) -> Result<()>;
+pub async fn execute_command(command: Commands, output_format: OutputFormat) -> Result<ExitCode>;
+pub fn report_and_classify(err: &anyhow::Error) -> ExitCode;
+```
+
+`execute_command` **never propagates a handler failure as `Err`** — it
+always resolves to `Ok(classified_exit_code)` (issue #195's fix, so `main`
+can always reach `std::process::exit` with a semantic code instead of
+falling back to anyhow's blanket exit-code-1 default). `main.rs` itself
+also routes pre-dispatch failures (e.g. clap already rejects an invalid
+`--format` before any command runs, but a hypothetical future pre-dispatch
+failure) through the same `report_and_classify`.
+
+`classify_exit_code`/`classify_core_error` walk the `anyhow::Error`'s cause
+chain (not just the top) looking first for a `mcp_execution_core::Error`,
+then (fallback) a `mcp_execution_files::FilesError` — the latter exists
+specifically because `generate`'s export step wraps `FilesError` via
+`anyhow::Context` rather than converting it to `CoreError`, so it would
+otherwise always fall through to the generic `ExitCode::ERROR` (issue #198
+M6's fix). `CoreError::ScriptGenerationError`'s wrapped `source` is
+recursed into, so e.g. a `ResourceLimitExceeded` wrapped inside it still
+classifies as `SERVER_ERROR`, not the generic fallback:
+
+| `Error` variant | `ExitCode` |
+|---|---|
+| `Timeout` | `TIMEOUT` (4) |
+| `ConnectionFailed`, `ResourceLimitExceeded` (core or files) | `SERVER_ERROR` (3) — "the remote MCP server is at fault," not the CLI caller |
+| `ValidationError`, `SecurityViolation`, `InvalidArgument` | `INVALID_INPUT` (2) |
+| `SerializationError`, everything else | `ERROR` (1) |
+| any `FilesError` other than `ResourceLimitExceeded` | `ERROR` (1) |
+
+## 6. `introspect` Command (`commands/introspect.rs`)
+
+`run(raw: RawServerArgs, detailed: bool, output_format: OutputFormat) -> Result<ExitCode>`.
+Resolves config via `resolve_server_config`, runs
+`Introspector::discover_server` once, formats an `IntrospectionResult`
+(`ServerMetadata` + `Vec<ToolDisplay>`, schemas included only when
+`detailed`). No output-directory writes at all — read-only, display-only
+command.
+
+## 7. `generate` Command (`commands/generate.rs`)
+
+`run(raw, name: Option<String>, output_dir: Option<PathBuf>, dry_run: bool, output_format) -> Result<ExitCode>`:
+
+1. `resolve_server_config` → `discover_server_info` (introspects; applies
+   `--name` override to `ServerInfo.id` if given, so generated
+   directory/literals use the custom name rather than the raw command).
+2. If the server has zero tools: logs a warning and returns
+   `ExitCode::SUCCESS` (not an error) without generating anything.
+3. `ProgressiveGenerator::generate` (uncategorized — no LLM step in this
+   path, unlike `mcp-server`'s `save_categorized_tools`).
+4. `resolve_base_dir(output_dir)` — defaults to `~/.claude/servers`.
+5. **`--dry-run`**: renders a `DryRunResult` (`FilePreview` per file: path +
+   size, human-readable `format_size`) **without writing anything to
+   disk** — the only place in this workspace that previews generated
+   output without ever touching the filesystem.
+6. Otherwise: `FilesBuilder::from_generated_code(code, "/").build_and_export(&base_dir)`
+   — see [[../files/spec#FilesBuilder::build_and_export]] for the
+   per-top-level-group atomicity this implies (a re-run with fewer tools
+   deletes stale tool files in that server's own directory, but never
+   touches sibling servers under the same `base_dir`).
+7. Success output names the required post-export step
+   (`NPM_INSTALL_HINT`: run `npm install` before type-checking the
+   generated package — issue #257's fix, since the generated `package.json`
+   declares `@types/node` as a `devDependency` that isn't installed by
+   `generate` itself).
+
+## 8. `skill` Command (`commands/skill.rs`)
+
+`run(server, servers_dir, output_path, skill_name, hints, overwrite, output_format) -> Result<ExitCode>`:
+validates `server` via `mcp_execution_skill::validate_server_id`
+(mapped to `CoreError::InvalidArgument` for correct exit-code
+classification), resolves the tool directory (default
+`~/.claude/servers/{server}`), scans via `scan_tools_directory`, builds
+context via `build_skill_context`, and **renders `SKILL.md` directly**
+(`render_skill_md`) — no LLM/prompt round-trip, unlike `mcp-server`'s
+`generate_skill`/`save_skill` split. The crate's own doc comment recommends
+preferring the MCP server path for "optimal results," since it can leverage
+Claude's own summarization instead of the mechanical template-only
+rendering this command does. Refuses to overwrite an existing output file
+unless `--overwrite`.
+
+## 9. `server` Command (`commands/server.rs`)
+
+Three actions (`ServerAction`), all reading `~/.claude/mcp.json` as the
+single source of truth:
+
+- `list` — enumerates every entry, checking a **time-boxed** availability
+  signal per entry (`LIST_AVAILABILITY_TIMEOUT` = 3s, deliberately shorter
+  than — and independent of — the entry's own configured
+  `connect_timeout_secs`): stdio = PATH lookup only; http/sse = URL
+  well-formedness + a bounded real `Introspector::discover_server` attempt.
+  Checks run concurrently across entries so one slow/firewalled server
+  doesn't visibly hang the whole listing. Because http/sse `list` and
+  `info`/`validate` now share the **exact same connection path**
+  (`Introspector::discover_server`), they can disagree only about *how
+  long* the check is allowed to run, not *how* the transport is reached —
+  a server merely slower than 3s but within its own configured timeout can
+  legitimately show `unavailable` in `list` and `available` in
+  `validate`/`info` (an intentional, documented trade-off, distinct from
+  the unconditional-wrong-answer bug it replaced).
+- `info <server>` / `validate <command>` — perform a **full** introspection
+  handshake (the entry's own full configured timeout applies), the
+  authoritative single-target check.
+
+## 10. `setup` Command (`commands/setup.rs`)
+
+Validates the local runtime is ready to execute generated tools:
+1. Checks `node --version` is ≥ 18.0.0 (hard error if missing/older).
+2. On Unix only: makes every `.ts` file under `~/.claude/servers/` executable
+   (`files_made_executable` count) and reports whether a servers directory
+   exists at all.
+3. Reports whether `~/.claude/mcp.json` exists, printing a starter example
+   if not.
+
+Non-Unix platforms always report `servers_dir_found: false`,
+`files_made_executable: 0` (permission bits aren't a concept there).
+
+## 11. `completions` Command (`commands/completions.rs`)
+
+`generate_completions(shell, cmd)` — thin wrapper over `clap_complete::generate`,
+writing the script to stdout. Cannot fail (always returns
+`ExitCode::SUCCESS`); all error handling is internal to `clap_complete`.
+
+## 12. Output Formatting (`formatters.rs`)
+
+```rust
+pub fn format_output<T: Serialize>(data: &T, format: OutputFormat) -> Result<String>;
+pub fn escape_display(s: &str) -> String; // wraps s as a JSON string literal (quotes + backslash-escapes, including control chars)
+pub mod json; pub mod text; pub mod pretty;
+```
+`escape_display` exists for commands that build **freeform** lines (e.g.
+`"Server: {name} ({id})"`) rather than serializing a whole struct through
+`format_output` — a malicious MCP server could otherwise inject raw
+ANSI/control escape sequences into the user's terminal via handshake or
+tool-metadata text. `pretty`'s own internal value formatter delegates to
+this same function for `String` values, so both call sites share one
+implementation and one guarantee.
+
+## 13. Error Conditions
+
+CLI commands surface errors as `anyhow::Error` (wrapping
+`mcp_execution_core::Error`/`mcp_execution_files::FilesError` via `?`/
+`.context(...)`), classified at the `runner` layer per [[#5. runner.rs]]
+into a process exit code — no command handler calls `std::process::exit`
+itself.
+
+## 14. Cross-Crate Contracts
+
+- **Consumes**: `mcp-core` (`ServerConfig`, `cli::{OutputFormat,ExitCode}`,
+  redaction helpers, `Error`), `mcp-introspector::Introspector`,
+  `mcp-codegen::progressive::ProgressiveGenerator`,
+  `mcp-files::FilesBuilder`, `mcp-skill::{scan_tools_directory,
+  build_skill_context, render_skill_md, validate_server_id,
+  MAX_SERVER_ID_LENGTH}`.
+- Shares the exact `RawServerArgs`/`resolve_server_config` code path
+  between `introspect` and `generate` — any transport-resolution fix
+  applies to both simultaneously by construction.
+
+## 15. Edge Cases & Notable Behaviors
+
+- `generate` on a tool-less server is a **success**, not an error — a
+  deliberate "nothing to do" outcome, distinct from every failure path.
+- `--dry-run` and `server list` are the only two places in the CLI that
+  intentionally avoid a real filesystem write / a full-timeout network
+  call, respectively, in favor of a fast, bounded preview.
+- `mcp.json`'s `McpServerEntry` deserialization warns (not fails) on
+  unrecognized keys, so this project's CLI can coexist with a config file
+  shared by other MCP-aware tools.
+
+## 16. See Also
+
+- [[../core/spec]] — shared config/redaction/exit-code primitives
+- [[../introspector/spec]], [[../codegen/spec]], [[../files/spec]], [[../skill/spec]] — crates this CLI drives directly, without going through [[../server/spec]]

--- a/specs/codegen/spec.md
+++ b/specs/codegen/spec.md
@@ -1,0 +1,235 @@
+---
+aliases:
+  - mcp-execution-codegen spec
+  - Codegen/Templating spec
+tags:
+  - sdd
+  - spec
+  - codegen
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../introspector/spec]]"
+  - "[[../files/spec]]"
+---
+
+# Block: Code Generation & Templating (`mcp-execution-codegen`)
+
+> [!abstract]
+> Path: `crates/mcp-codegen`. Renders a `ServerInfo` into a complete,
+> self-contained TypeScript package via Handlebars templates: one `.ts` file
+> per tool, an `index.ts` re-export, a runtime bridge, `package.json`,
+> `tsconfig.json`, and a `_meta.json` metadata sidecar. Depends on
+> `mcp-execution-core` and `mcp-execution-introspector`.
+
+## 1. Responsibility
+
+Convert `ServerInfo`/`ToolInfo` (JSON Schema-based tool definitions) into:
+1. TypeScript source implementing the "progressive loading" pattern —
+   Claude Code discovers tools via `ls`/`cat` on individual files instead of
+   loading one large manifest (~500-1,500 tokens/tool vs. ~30,000 tokens for
+   the whole set, per the crate's own doc comments).
+2. A structured `_meta.json` sidecar (via `mcp-core::metadata`) that lets
+   `mcp-skill`/`mcp-server` recover tool metadata **without re-parsing
+   generated TypeScript** (replacing a fragile regex-based scanner that
+   existed historically — issue #141's fix).
+
+## 2. Public API Surface
+
+```rust
+// mcp_execution_codegen (crate root)
+pub use common::types::{GeneratedCode, GeneratedFile, TemplateContext, ToolDefinition};
+pub use progressive::ProgressiveGenerator;
+pub use template_engine::TemplateEngine;
+
+// mcp_execution_codegen::progressive
+pub struct ProgressiveGenerator<'a> { /* engine: TemplateEngine<'a> */ }
+impl<'a> ProgressiveGenerator<'a> {
+    pub fn new() -> Result<Self>;
+    pub fn generate(&self, server_info: &ServerInfo) -> Result<GeneratedCode>;
+    pub fn generate_with_categories(&self, server_info: &ServerInfo, categorizations: &HashMap<String, ToolCategorization>) -> Result<GeneratedCode>;
+}
+pub struct ToolCategorization { pub category: String, pub keywords: String, pub short_description: String }
+pub struct BridgeContext { pub forbidden_chars: Vec<String>, pub forbidden_env_names: Vec<String>, pub forbidden_env_prefix: String }
+// BridgeContext::default() populates from mcp_execution_core::forbidden_chars()/forbidden_env_names()/forbidden_env_prefix() — hand-written, no derive(Default), so it can never render a fail-open (empty) bridge.
+
+pub const MAX_GENERATED_FILES: usize; // = introspector::MAX_TOOL_COUNT + 5 (fixed files)
+pub const MAX_GENERATED_BYTES: usize; // = 2 * MAX_TOOL_COUNT * (MAX_TOOL_NAME_LEN + MAX_TOOL_DESCRIPTION_LEN + MAX_SCHEMA_SIZE_BYTES)
+
+// mcp_execution_codegen::common::typescript
+pub fn to_camel_case(s: &str) -> String;
+pub fn to_pascal_case(s: &str) -> String;
+pub fn sanitize_ts_identifier(s: &str) -> String; // collapses invalid-char runs to one '_'; prefixes '_' if leading digit/empty
+pub fn json_type_to_typescript(json_type: &str) -> &'static str;
+pub fn json_schema_to_typescript(schema: &serde_json::Value) -> String;
+pub fn extract_properties(schema: &serde_json::Value) -> Vec<serde_json::Value>;
+
+// mcp_execution_codegen::template_engine
+pub struct TemplateEngine<'a> { /* handlebars: Handlebars<'a> */ }
+impl<'a> TemplateEngine<'a> {
+    pub fn new() -> Result<Self>; // strict_mode(true), no_escape (see below)
+    pub fn render<T: Serialize>(&self, template_name: &str, context: &T) -> Result<String>;
+    pub fn register_template_string(&mut self, name: &str, template: &str) -> Result<()>;
+}
+```
+
+`TemplateEngine::new` **disables Handlebars' default HTML-escaping**
+(`register_escape_fn(handlebars::no_escape)`), since output is
+TypeScript/JSDoc, not HTML. Injection safety is instead the responsibility
+of the sanitizers documented below, run **before** rendering.
+
+## 3. Input Contract
+
+`generate`/`generate_with_categories` accept `&ServerInfo` (from
+[[../introspector/spec]]) and an optional `HashMap<String, ToolCategorization>`
+keyed by raw tool name (`ToolCategorization.category`/`.keywords`
+comma-separated/`.short_description` — supplied by Claude via
+`mcp-server`'s `save_categorized_tools`, or absent for the CLI's plain
+`generate` command). `generate` delegates to `generate_with_categories` with
+an **empty** map — this must produce byte-identical `index.ts` category
+behavior to "no categorization at all" (regression-tested: an empty-but-
+`Some` map must not synthesize a spurious "uncategorized" `CategoryInfo`
+group).
+
+## 4. Output: Generated File Set
+
+For a server with N tools, exactly `N + 5` files:
+
+| File | Content |
+|---|---|
+| `{typescriptName}.ts` × N | One per tool: JSDoc header, exported async function, `{Name}Params`/`{Name}Result` types, CLI-mode self-execution block (`if (import.meta.url === ...)`) |
+| `index.ts` | Re-exports every tool (grouped by category if provided) + `callMCPTool` from the runtime bridge |
+| `_runtime/mcp-bridge.ts` | Connection management + JSON-RPC client (see [[#Runtime bridge]]) |
+| `package.json` | `{"type":"module","devDependencies":{"@types/node":"^22"}}` |
+| `tsconfig.json` | `target: ES2022`, `module`/`moduleResolution: NodeNext`, `strict: true`, `noEmit: true`, `allowImportingTsExtensions: true`, `skipLibCheck: true`, `types: ["node"]` |
+| `_meta.json` | `mcp_execution_core::metadata::ServerMetadata` (schema_version, server_id/name/version, per-tool metadata incl. **raw, unsanitized** parameter descriptions) |
+
+`package.json`/`tsconfig.json` are regenerated on every `generate` call —
+documented as **read-only, not meant to be extended** (e.g. via
+`tsconfig.json`'s `"extends"`, which would silently inherit `noEmit: true`
+into a consumer's own build).
+
+## 5. TypeScript Identifier Resolution
+
+- `resolve_typescript_names(tools)` computes a collision-free
+  `typescript_name` per tool, seeded with JS/TS reserved words (so a tool
+  literally named `delete` becomes `delete_2`, not a syntax error) and
+  disambiguated via `disambiguate_identifier` (numeric suffix `_2`, `_3`,
+  ...). Indexed by **position**, not by raw name, since two tools can share
+  an identical raw name.
+- `json_schema_to_typescript`/`extract_properties` similarly disambiguate
+  sibling property names that sanitize to the same identifier (e.g. `a-b`
+  and `a.b` both → `a_b`) — the second becomes `a_b_2`.
+
+## 6. Injection Defense (Sanitization Pipeline)
+
+All of the following run **before** any Handlebars render, and are the
+actual injection-safety mechanism given `no_escape` is set:
+
+| Function | Neutralizes | Applied to |
+|---|---|---|
+| `sanitize_jsdoc(s, max_len)` | `*/` (JSDoc comment terminator, escaped to `*\/`), all newline-class chars (incl. U+2028/U+2029) flattened to space, truncated to `max_len` chars | tool/server descriptions, categories, keywords rendered into `.ts` JSDoc comments |
+| `sanitize_ts_string_literal(s)` | backslash, single-quote, `\r`/`\n`, U+2028/U+2029 | tool name / server id embedded as single-quoted TS string literals (`callMCPTool('{{{server_id_literal}}}', ...)`) |
+| `sanitize_schema_jsdoc_descriptions(value)` | recursively applies `sanitize_jsdoc` to every `"description"` key in the input JSON Schema before it's embedded in a tool's JSDoc | `input_schema` field of `ToolContext` |
+
+> [!warning]
+> The `_meta.json` sidecar deliberately uses the **raw, unsanitized** MCP
+> values (name/description/parameter descriptions) — it's a data contract
+> consumed by Rust code, not a JS comment, so JSDoc-safety sanitization
+> would only lose fidelity (regression-tested against issue #141, where the
+> old regex-based parser could not recover parameter descriptions at all).
+
+## 7. Runtime Bridge (`_runtime/mcp-bridge.ts`)
+
+Generated once per server (identical content regardless of tool count,
+except for the forbidden-char/env-name lists rendered from `BridgeContext`).
+Responsibilities:
+- Loads `~/.claude/mcp.json` at **call time** (not generation time) and
+  **re-validates** the resolved server config on every connection —
+  mirroring `mcp_execution_core::validate_server_config` (command
+  metacharacters, forbidden env names, URL scheme, header safety) to the
+  same depth, since the config file can be hand-edited after generation to
+  add e.g. `LD_PRELOAD`.
+- `FORBIDDEN_CHARS`/`FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` are
+  rendered **directly from the Rust constants** at generation time (via
+  `BridgeContext`), not hand-copied, so the TS copy cannot silently drift
+  from `mcp-core`'s source of truth.
+- Connection caching per `serverId` (`serverConnections: Map<string,
+  Promise<ServerConnection>>`), caching the **in-flight promise** so
+  concurrent cold-start callers share one spawn rather than racing.
+- JSON-RPC request/response demultiplexing by numeric id over a single
+  stdio child's stdout, with a configurable per-request timeout
+  (`MCPBRIDGE_REQUEST_TIMEOUT_MS`, default 30s).
+- Only **stdio** transport is actually executable by this bridge today —
+  an http/sse `mcp.json` entry is validated to the same depth as stdio
+  (so a bad URL/header is reported precisely) but then rejected as
+  "unsupported transport" (forward-compatibility groundwork noted in the
+  source for a future http/sse bridge).
+- Result extraction handles: JSON-shaped text content (parsed), plain text,
+  `structuredContent`-only responses (MCP spec 2025-06-18+), and a
+  documented gap — a genuinely empty (`content: []`, no
+  `structuredContent`) success response is currently indistinguishable from
+  a misbehaving server and is surfaced as a thrown error.
+
+## 8. Resource-Exhaustion Bounds (CWE-400)
+
+- `enforce_tool_count_bound` rejects before any per-tool rendering if
+  `tools.len() + 5 > MAX_GENERATED_FILES`.
+- `add_tracked` checks both the running byte total (`MAX_GENERATED_BYTES`)
+  and file count (`MAX_GENERATED_FILES`) **incrementally, as each file is
+  produced** — not only after the whole `GeneratedCode` is assembled — so
+  an oversized `ServerInfo` (or a `_meta.json` sidecar re-embedding every
+  tool's schema, pushing the total over the edge) is rejected as soon as
+  the offending file is generated, never holding the full amplified output
+  in memory first.
+- Both bounds are **derived from**, not independently chosen relative to,
+  `mcp-introspector`'s own `MAX_TOOL_COUNT`/`MAX_TOOL_NAME_LEN`/etc. — a
+  `ServerInfo` that already cleared introspection's bounds can never be
+  deterministically rejected here for simply being "as large as
+  introspection already allows."
+
+## 9. Error Conditions
+
+| Condition | `Error` variant |
+|---|---|
+| Tool count would exceed `MAX_GENERATED_FILES` | `ResourceLimitExceeded { resource: "tool count for server '{id}'", .. }` |
+| Running byte total exceeds `MAX_GENERATED_BYTES` | `ResourceLimitExceeded { resource: "generated output size", .. }` |
+| Malformed property schema (`name`/`type` not a string) | `ValidationError` |
+| Handlebars render failure | `SerializationError` (message embeds Handlebars' own error text) |
+| `_meta.json` serialization failure | `SerializationError` |
+| Any per-tool failure above | Re-wrapped as `ScriptGenerationError { tool, message, source: Some(...) }` via `wrap_tool_generation_error`, preserving the original error's own classification (e.g. a wrapped `ResourceLimitExceeded` still reports as such downstream — see [[../cli/spec#classify_core_error]]) |
+
+## 10. Cross-Crate Contracts
+
+- **Consumes**: `mcp-core::metadata`/error types/forbidden-char constants;
+  `mcp-introspector::{ServerInfo, ToolInfo}` and its `MAX_TOOL_COUNT`/
+  `MAX_TOOL_NAME_LEN`/`MAX_TOOL_DESCRIPTION_LEN`/`MAX_SCHEMA_SIZE_BYTES`.
+- **Produced for** `mcp-files`: `GeneratedCode`/`GeneratedFile` are the
+  direct input to `FilesBuilder::from_generated_code` — see
+  [[../files/spec#Input contract]]. `mcp-files::MAX_EXPORT_FILES`/
+  `MAX_EXPORT_BYTES` are set **equal to** this crate's
+  `MAX_GENERATED_FILES`/`MAX_GENERATED_BYTES`, not independently chosen.
+- **Produced for** `mcp-skill`/`mcp-server`: the `_meta.json` sidecar
+  (schema owned by `mcp-core::metadata`).
+
+## 11. Edge Cases & Notable Behaviors
+
+- A tool name containing only invalid identifier characters (e.g. all
+  non-ASCII) sanitizes to a bare `_`, then gets disambiguated if colliding.
+- A schema property whose sanitized name collides with a JS/TS reserved
+  word is *not* itself special-cased (only the top-level tool function name
+  is reserved-word-aware); collision handling there is purely
+  sibling-vs-sibling.
+- `disambiguate_identifier`'s `used` set is scoped per schema object level —
+  two independent nested objects can each reuse the same disambiguated name
+  without conflict (verified by
+  `test_disambiguate_identifier_reuses_base_across_independent_scopes`).
+
+## 12. See Also
+
+- [[../introspector/spec]] — source of `ServerInfo`/`ToolInfo`
+- [[../files/spec]] — consumer of `GeneratedCode`
+- [[../server/spec#save_categorized_tools]] — MCP-tool caller of `generate_with_categories`
+- [[../cli/spec#generate]] — CLI caller of `generate`

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -1,0 +1,172 @@
+---
+aliases:
+  - Project Constitution
+  - mcp-execution Constitution
+tags:
+  - sdd
+  - constitution
+created: 2026-07-27
+status: permanent
+related:
+  - "[[README]]"
+---
+
+# Project Constitution (Reverse-Engineered)
+
+> [!important]
+> This constitution was **derived from reading the actual codebase**, not authored
+> up front. It documents the principles the existing code already enforces —
+> consistently, across every crate — so future specs and changes stay
+> compatible with the patterns already in place. Treat it as a description of
+> observed reality, not an aspirational document.
+
+## I. Architecture
+
+- **Layered workspace, strict dependency direction (low → high)**:
+  `mcp-core` → `mcp-introspector` → `mcp-codegen` → `mcp-files` → `mcp-skill` →
+  `mcp-server`/`mcp-cli`. Higher crates depend on lower ones; lower crates never
+  depend on higher ones (`mcp-core` has zero intra-workspace dependencies).
+- **Strong types over primitives** (`ServerId`, `ToolName`, `FilePath`,
+  `ServerConnectionString`, `ExitCode`) — never a raw `String`/`i32` for a
+  domain concept. See [[core/spec#ServerId and ToolName|core spec]].
+- **Builder + validate-at-construction**: types that require invariants
+  (`ServerConfig`) are only constructible through a builder whose `build()`
+  runs full validation, so an invalid instance cannot exist via the sanctioned
+  path (though `pub` fields + `Deserialize` mean a struct literal or
+  `serde_json::from_str` can still bypass it — every consumer that might
+  receive such a value re-validates defensively; see
+  [[core/spec#Defense in depth|core spec]]).
+- **In-memory VFS before real I/O**: codegen output is staged as
+  `GeneratedCode` → `FileSystem` (in-memory) → exported to disk only at the
+  end, via a staged-directory-then-atomic-rename pattern. See
+  [[files/spec]].
+
+## II. Technology Stack
+
+- Language: Rust, edition 2024, MSRV 1.91 (`Cargo.toml` `workspace.package`).
+- Async runtime: `tokio` throughout.
+- MCP protocol: `rmcp` (official Rust SDK), both as client (`mcp-introspector`)
+  and server (`mcp-server`).
+- Templating: `handlebars`, HTML-escaping disabled (`no_escape`) because output
+  is TypeScript/JSDoc, not HTML — injection safety is handled upstream by
+  hand-written sanitizers instead.
+- Schema/validation: `schemars` for JSON-Schema-derived MCP tool parameter
+  schemas; `serde`/`serde_json` for wire types; `serde_norway` for YAML
+  (SKILL.md frontmatter) — never `serde_yaml`/`serde_yml`.
+- Error handling: `thiserror` in every library crate; `anyhow` only in
+  `mcp-execution-cli`.
+- CLI: `clap` (derive API) + `clap_complete`.
+
+## III. Testing (NON-NEGOTIABLE)
+
+- Every crate carries an extensive `#[cfg(test)] mod tests` in the same file
+  as the code under test, plus `tests/` integration suites for
+  cross-component behavior (process spawning, filesystem export, HTTP
+  transport).
+- `cargo nextest run` is the canonical runner (CI-enforced), not `cargo test`.
+- Doc comments on every `pub` item include a runnable `# Examples` section
+  (`cargo test --doc`), which doubles as executable API documentation.
+- Regressions are tracked by issue number in comments and test names (e.g.
+  `test_build_and_export_rejects_empty_top_level_component` cites the exact
+  bug it guards against) — the test suite is also a changelog of past
+  security/correctness incidents.
+- Fakeable time: `mcp-server` injects a `Clock` trait (`SystemClock` in
+  production, `TestClock` in tests) rather than calling `Utc::now()`
+  directly, so expiry logic is deterministically testable.
+
+## IV. Code Style
+
+- Clippy `all`, `cargo`, `nursery`, `pedantic` are `deny` at workspace level;
+  narrow, per-crate `#[allow(...)]`s are used only where the lint's intent
+  doesn't apply (e.g. `too_many_lines` allowed workspace-wide;
+  `unused_async` allowed in `mcp-cli` for uniformly-dispatched handlers).
+- `#![deny(unsafe_code)]` in every crate except `mcp-server`/`mcp-cli` (which
+  don't need it) — no crate in this workspace uses `unsafe`.
+- `#![warn(missing_docs, missing_debug_implementations)]` everywhere: every
+  `pub` item is documented, every `pub` type derives or hand-implements
+  `Debug`.
+- Every `pub` type and function must be `Send + Sync` where it can reasonably
+  be (explicitly tested via `assert_send`/`assert_sync` helpers in several
+  crates).
+
+## V. Security (the dominant concern of this codebase)
+
+This is not a generic principle here — it is the single most heavily invested
+area of the entire project, evidenced by the volume of doc comments, tests,
+and issue-number references dedicated to it.
+
+- **Command-injection defense in depth**: `mcp-core::command` validates
+  shell metacharacters, forbidden environment variables (dynamic-linker and
+  interpreter hijack vectors), URL schemes, and HTTP header safety —
+  enforced both in Rust (`validate_server_config`) and mirrored line-for-line
+  in the generated TypeScript runtime bridge
+  (`crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs`), rendered
+  directly from the same Rust constants so the two copies cannot drift.
+- **Resource-exhaustion (CWE-400) bounds at every layer**: tool count, tool
+  name/description length, schema size, generated file count/bytes, VFS
+  export file count/bytes, pending-session count/aggregate bytes, request
+  line size, request concurrency — each layer derives its bound from the
+  layer below it rather than choosing an independent number, specifically so
+  that data which already cleared a lower layer's bound can never be
+  rejected by a higher layer for merely being "as large as already allowed."
+- **Prompt-injection / Markdown-injection defense**: any text that
+  originates from an introspected (untrusted) MCP server and is later shown
+  to an LLM or embedded in a document (tool names, descriptions, keywords,
+  categories) is sanitized (`mcp_execution_core::untrusted`) and, where it
+  reaches an LLM-facing prompt, wrapped in an explicit
+  `<untrusted-data>...</untrusted-data>` boundary that cannot be forged from
+  within.
+- **Debug-redaction of secrets**: any type carrying environment variables,
+  HTTP headers, CLI args, or URLs implements `Debug` by hand (never
+  `#[derive(Debug)]`) to redact values while keeping keys — because these
+  routinely carry bearer tokens and API keys, and get printed by `tracing`,
+  `anyhow`, or `eprintln!`. `Serialize` deliberately does **not** redact
+  (round-tripping a config store requires the real values); this asymmetry
+  is documented, not accidental.
+- **Path confinement**: every filesystem write derived from caller/attacker
+  input (`save_skill`'s `output_path`, `introspect_server`'s `output_dir`,
+  `list_generated_servers`'s `base_dir`) is confined to a base directory with
+  symlink-aware, component-by-component validation — not a single
+  `canonicalize`-then-`starts_with` check, because that alone misses a
+  symlink planted at the exact confinement boundary.
+- **Atomic, non-destructive filesystem export**: every write to
+  `~/.claude/servers/...` / `~/.claude/skills/...` stages content in a
+  sibling temp directory and publishes via rename, so a killed process never
+  leaves a half-written tree, and a failed export never touches a
+  previously-published one.
+
+## VI. Performance
+
+- Progressive loading's entire raison d'être is a **token-budget
+  performance goal**: one file per tool so Claude Code loads only what it
+  needs (~500-1,500 tokens/tool vs. ~30,000 tokens for the whole tool set).
+- `FileSystem::export_to_filesystem` targets <50ms for a 30-file export
+  (documented target in `crates/mcp-files/src/filesystem.rs`), achieved via
+  single-pass directory pre-creation and an optional `rayon`-parallel write
+  path (`parallel` feature).
+- `criterion` benchmarks exist for codegen (`mcp-codegen/benches`) and VFS
+  export (`mcp-files/benches`), plus a `dhat`-based memory-profiling example
+  in `mcp-files/examples/profile_memory.rs`.
+
+## VII. Simplicity
+
+- No dependency on an LLM API for tool categorization: `mcp-server`'s
+  `introspect_server`/`save_categorized_tools` split exists specifically so
+  the *calling* Claude Code session does the categorization via natural
+  language, not a second, separately-billed LLM call.
+- Generated output is a self-contained package (own `package.json`,
+  `tsconfig.json`) meant to be run via `tsx`/`deno`/Node's native TS
+  stripping — not merged into a consumer's own TypeScript build.
+
+## VIII. Git Workflow
+
+- Conventional Commits (see `.claude/rules/commits-and-issues.md` — not part
+  of this reverse-engineered constitution, but the enclosing repo's own
+  convention).
+- CHANGELOG.md maintained under `[Unreleased]` until a version is cut.
+
+## See Also
+
+- [[README]] — cross-block index and end-to-end data flow
+- [[core/spec]], [[introspector/spec]], [[codegen/spec]], [[files/spec]],
+  [[skill/spec]], [[server/spec]], [[cli/spec]]

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -1,0 +1,289 @@
+---
+aliases:
+  - mcp-execution-core spec
+  - Core Types and Security
+tags:
+  - sdd
+  - spec
+  - core
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../README]]"
+  - "[[../introspector/spec]]"
+---
+
+# Block: Core Types & Security (`mcp-execution-core`)
+
+> [!abstract]
+> Foundation crate for the whole workspace. Path: `crates/mcp-core`.
+> Zero intra-workspace dependencies — every other crate depends on this one,
+> directly or transitively. Provides strong domain types, the shared error
+> hierarchy, `ServerConfig` + its security validation, and small
+> cross-cutting utility modules (`cli`, `metadata`, `path`, `redact`,
+> `untrusted`) that other crates rely on for **consistency**, not just
+> convenience — several of these exist specifically so two crates (or Rust
+> and generated TypeScript) can't drift apart on the same security rule.
+
+## 1. Responsibility
+
+`mcp-execution-core` owns:
+
+1. Domain newtypes (`ServerId`, `ToolName`) — never pass a raw `String` where
+   one of these is expected.
+2. The single `Error`/`Result` type used by every crate in the workspace.
+3. `ServerConfig` (+ builder) — the one way to describe how to reach an MCP
+   server (stdio subprocess, or HTTP/SSE endpoint), and the security
+   validation (`validate_server_config`) that must pass before that
+   description is used to spawn a process or open a connection.
+4. Small shared modules used by more than one downstream crate to avoid two
+   independent (and driftable) implementations of the same rule:
+   - `cli` — `OutputFormat`, `ExitCode`, `ServerConnectionString` (used by
+     `mcp-cli`).
+   - `metadata` — the `_meta.json` sidecar schema shared by `mcp-codegen`
+     (producer) and `mcp-skill`/`mcp-server` (consumers).
+   - `path` — `sanitize_path_for_error` (used by `mcp-skill` and
+     `mcp-server` for identical error-message redaction) and
+     `validate_path_segment` (used by both for identical `server_id`
+     path-segment validation).
+   - `redact` — `Debug`-redaction wrapper types (`RedactedItems`,
+     `RedactedMapValues`, `RedactedUrl`) used by `ServerConfig` itself and
+     by `mcp-cli`'s CLI-argument types.
+   - `untrusted` — sanitization/boundary-wrapping helpers for
+     attacker-controlled MCP-server metadata embedded into Markdown/LLM
+     prompts, used by `mcp-skill` and `mcp-server`.
+
+## 2. Public API Surface
+
+### `ServerId` / `ToolName` (`src/types.rs`)
+
+```rust
+pub struct ServerId(String);
+pub struct ToolName(String);
+```
+Both: `new(impl Into<String>) -> Self`, `as_str(&self) -> &str`,
+`into_inner(self) -> String`, `Display`, `From<String>`, `From<&str>`,
+`Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize`. No format
+validation at this layer (unlike `cli::ServerConnectionString` or
+`mcp-skill::validate_server_id`, which are the actual gatekeepers) — these
+are pure newtype wrappers for type safety, not validated value objects.
+
+### `Error` / `Result<T>` (`src/error.rs`)
+
+```rust
+pub enum Error {
+    ConnectionFailed { server: String, source: Box<dyn Error+Send+Sync> },
+    SecurityViolation { reason: String },
+    Timeout { operation: String, duration_secs: u64 },
+    SerializationError { message: String, source: Option<serde_json::Error> },
+    InvalidArgument(String),
+    ValidationError { field: String, reason: String },
+    ScriptGenerationError { tool: String, message: String, source: Option<Box<dyn Error+Send+Sync>> },
+    ResourceLimitExceeded { resource: String, actual: usize, limit: usize },
+}
+pub type Result<T> = std::result::Result<T, Error>;
+```
+Each variant has an `is_*` predicate (`is_connection_error`,
+`is_security_error`, `is_timeout`, `is_validation_error`,
+`is_script_generation_error`, `is_resource_limit_exceeded`). No predicate
+exists for `InvalidArgument`/`SerializationError` — callers match directly.
+`ScriptGenerationError.source` is the vehicle for preserving an inner
+`Error`'s own classification through wrapping (see
+`mcp-cli`'s `classify_core_error`, which recurses into it — [[../cli/spec]]).
+
+### `ServerConfig` / `ServerConfigBuilder` / `TransportType` (`src/server_config.rs`)
+
+```rust
+pub enum TransportType { Stdio, Http, Sse } // #[default] Stdio
+pub struct ServerConfig {
+    pub transport: TransportType,
+    pub command: String,           // stdio only
+    pub args: Vec<String>,         // stdio only
+    pub env: HashMap<String,String>,   // stdio only
+    pub cwd: Option<PathBuf>,      // stdio only
+    pub url: Option<String>,       // http/sse only
+    pub headers: HashMap<String,String>, // http/sse only
+    pub connect_timeout: Duration, // default 30s, all transports
+    pub discover_timeout: Duration, // default 30s, all transports
+}
+```
+Builder methods: `command`, `arg`, `args`, `env`, `environment`, `cwd`,
+`http_transport(url)`, `sse_transport(url)`, `url`, `header`, `headers`,
+`connect_timeout`, `discover_timeout`, `build() -> Result<ServerConfig>`.
+
+`build()` = `build_structural()` (presence checks: `command` required
+non-empty for stdio, `url` required for http/sse) **then**
+`validate_server_config(&config)` — full security validation runs
+unconditionally inside `build()`, so a `ServerConfig` obtained through the
+builder cannot exist without having passed it. This is a **builder-level**
+guarantee, not type-level: every field is `pub` and the type derives
+`Deserialize`, so a struct literal or `serde_json::from_str` bypasses it —
+see [[#Defense in depth]].
+
+`ServerConfig` and `ServerConfigBuilder` both hand-write `Debug` to redact
+`args` (wholesale, via `RedactedItems`), `env`/`headers` (values only, keys
+kept, via `RedactedMapValues`), and `url` (userinfo + query stripped, via
+`RedactedUrl`); `command`/`cwd` go through `sanitize_path_for_error`.
+**`Serialize` is not redacted** — a serialized `ServerConfig` carries real
+secrets and must never be logged.
+
+### `validate_server_config` and friends (`src/command.rs`)
+
+```rust
+pub fn validate_server_config(config: &ServerConfig) -> Result<()>;
+pub fn validate_url_scheme(url: &str) -> Result<()>;
+pub const fn forbidden_chars() -> &'static [char];
+pub const fn forbidden_env_names() -> &'static [&'static str];
+pub const fn forbidden_env_prefix() -> &'static str; // "DYLD_"
+```
+Constants (all `pub`): `MAX_ARG_COUNT` (256), `MAX_ARG_LEN` (4096),
+`MAX_ENV_COUNT` (256), `MAX_ENV_VALUE_LEN` (32 KiB), `MAX_HEADER_COUNT`
+(128), `MAX_HEADER_VALUE_LEN` (8 KiB), `MAX_URL_LEN` (8 KiB).
+
+Validation order inside `validate_server_config` (all run unconditionally,
+regardless of transport, before transport-specific checks):
+
+1. `validate_size_bounds` — command/url/arg/env/header count and length
+   caps (CWE-400 backstop; runs even for a hand-crafted `ServerConfig` whose
+   fields don't match its declared transport, since every field is
+   `#[serde(default)]` and populated independent of transport at the type
+   level).
+2. Transport dispatch:
+   - `Stdio` → `validate_command_string` (forbidden shell metachars:
+     `; | & > < \` $ ( ) \n \r`) on `command` and each `arg`; absolute-path
+     commands additionally require existence + executable bit (Unix); env
+     names checked against `forbidden_env_names()`/`forbidden_env_prefix()`.
+   - `Http`/`Sse` → `validate_network_config`: `url` required,
+     `validate_url_scheme` (must be `http://`/`https://`, case-insensitive),
+     header name (RFC 7230 `tchar` charset) and value (no control chars)
+     checks, duplicate header names rejected case-insensitively.
+3. `validate_timeout` on `connect_timeout`/`discover_timeout` — must be
+   `> 0` and `<= MAX_TIMEOUT` (10 minutes); **no infinite-timeout option is
+   supported by design** (an unbounded wait would let a hung server block
+   this non-interactive tool forever).
+
+Forbidden env names (exact match): `LD_PRELOAD`, `LD_LIBRARY_PATH`,
+`LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`,
+`DYLD_FRAMEWORK_PATH`, `PATH`, `NODE_OPTIONS`, `BASH_ENV`, `PYTHONPATH`,
+`PYTHONSTARTUP`, `RUBYOPT`, `PERL5OPT`, `JAVA_TOOL_OPTIONS`; plus any name
+with prefix `DYLD_`. This list is explicitly documented as an
+**accidental-misconfiguration guard, not a sandbox boundary** — it does not
+protect against a malicious command/binary itself.
+
+Every rejection error omits the offending value from its message when that
+value could be secret-shaped (a misparsed `--api-key sk-...` argument, a
+header name/value) — this is enforced by tests, not just convention.
+
+### `cli` module (`src/cli.rs`)
+
+```rust
+pub enum OutputFormat { Json, Text, #[default] Pretty } // FromStr, Display
+pub struct ExitCode(i32); // SUCCESS=0, ERROR=1, INVALID_INPUT=2, SERVER_ERROR=3, TIMEOUT=4
+pub struct ServerConnectionString(String); // charset [A-Za-z0-9-_./:], <=256 chars, no control chars
+```
+`ServerConnectionString::new` is a defense-in-depth CLI-input validator
+(command-injection / CRLF-injection prevention); note it is **not** what
+`mcp-cli` actually uses for `--from-config`/`server` values today (those
+flow through `ServerId`/`ServerConfig` instead) — it exists as reusable,
+tested infrastructure in this crate's public surface.
+
+### `metadata` module (`src/metadata.rs`)
+
+```rust
+pub const METADATA_SCHEMA_VERSION: u32 = 1;
+pub const METADATA_FILE_NAME: &str = "_meta.json";
+pub struct ServerMetadata { schema_version, server_id, server_name, server_version, tools: Vec<ToolMetadata> }
+pub struct ToolMetadata { name, typescript_name, category: Option<String>, keywords: Vec<String>, description: Option<String>, parameters: Vec<ParameterMetadata> }
+pub struct ParameterMetadata { name, typescript_type, required, description: Option<String> }
+```
+This is the **wire contract** between `mcp-codegen` (producer, writes
+`_meta.json`) and `mcp-skill`/`mcp-server` (consumers). Bumping
+`METADATA_SCHEMA_VERSION` is the intended way to signal a breaking shape
+change; consumers compare it and fail loudly on mismatch (see
+[[../skill/spec#ScanError]]).
+
+### `path` module (`src/path.rs`)
+
+```rust
+pub fn sanitize_path_for_error(path: &Path) -> String; // redacts home dir to "~", falls back to scrubbing bare username
+pub fn validate_path_segment(segment: &str) -> Option<Component<'_>>; // single plain component, no "..", no separator
+```
+`validate_path_segment` is the shared building block for both
+`mcp-skill::resolve_skill_output_path` and
+`mcp-server::output_dir::resolve_output_dir`'s `server_id` confinement — a
+`..` or embedded separator in `server_id` is rejected identically by both.
+
+### `redact` module (`src/redact.rs`)
+
+```rust
+pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
+pub struct RedactedMapValues<'a>(pub &'a HashMap<String,String>); // Debug: keys visible, values redacted
+pub struct RedactedItems<'a>(pub &'a [String]);                  // Debug: every entry redacted wholesale
+pub struct RedactedUrl<'a>(pub &'a str);                         // Debug: userinfo + query redacted, host/path kept
+```
+`RedactedUrl` is deliberately parse-free (no `url` crate dependency) and
+redacts the **whole** input if it cannot unambiguously identify the
+authority boundary (e.g. an unencoded `/` or `?` inside userinfo) or if the
+scheme contains an invalid character — fails closed toward over-redaction
+rather than partial leakage.
+
+### `untrusted` module (`src/untrusted.rs`)
+
+```rust
+pub const MAX_UNTRUSTED_FIELD_LEN: usize = 500;
+pub fn sanitize_untrusted_text(s: &str, max_len: usize) -> String; // flattens all control chars + U+2028/U+2029 to spaces, truncates by char count
+pub fn wrap_untrusted_block(context: &str, body: &str) -> String;  // escapes &, <, > in body; wraps in <untrusted-data>...</untrusted-data>
+```
+Threat model: an introspected MCP server's tool names/descriptions/keywords
+are attacker-controlled from this project's perspective. Both functions
+exist because `mcp-skill` (SKILL.md + prompt generation) and
+`mcp-server` (introspection summaries returned to Claude) both embed this
+data into text an LLM later reads as instructions — see
+[[../server/spec#Prompt injection defense]] and
+[[../skill/spec#Prompt injection defense]].
+
+## 3. Cross-Crate Contracts
+
+| Consumer | What it depends on from `mcp-core` |
+|---|---|
+| `mcp-introspector` | `ServerConfig`, `ServerId`, `ToolName`, `TransportType`, `validate_server_config`, `Error`/`Result` |
+| `mcp-codegen` | `Error`/`Result`, `metadata::*` (writes `_meta.json`), `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix` (renders them into the generated runtime bridge template) |
+| `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen` |
+| `mcp-skill` | `sanitize_path_for_error`, `validate_path_segment`, `untrusted::*`, `metadata::*` |
+| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `validate_path_segment`, `untrusted::*` |
+| `mcp-cli` | `cli::{OutputFormat, ExitCode}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |
+
+## 4. Defense in Depth
+
+`ServerConfig`'s "always validated" guarantee is a **builder-level**
+property, not a type-level one. Every downstream consumer that might
+receive a `ServerConfig` from somewhere other than the builder
+re-validates:
+
+- `mcp-introspector::Introspector::discover_server` calls
+  `validate_server_config` again before spawning/connecting.
+- Test code (`command.rs`'s own tests) deliberately constructs an
+  unvalidated `ServerConfig` via `serde_json::from_str` to exercise this
+  gap directly (e.g. an HTTP-transport config missing `url`, which
+  deserializes fine because every field is `#[serde(default)]`).
+
+## 5. Edge Cases & Notable Behaviors (from tests)
+
+| Scenario | Behavior |
+|---|---|
+| Header names differing only by case (`Authorization` vs `authorization`) | Rejected as duplicate (case-insensitive comparison), since `http::HeaderName` would otherwise silently collapse them |
+| Header name containing space/`:`/`@` | Rejected — not a control character, but outside RFC 7230 `tchar` |
+| `mcp.json` with `"transport": "http"` and no `url` | Deserializes successfully (all fields `#[serde(default)]`); caught by `validate_network_config`, not by deserialization |
+| Timeout of exactly `0` | Always rejected — no "infinite timeout" sentinel exists |
+| Timeout of `601s` (`MAX_TIMEOUT` = 600s) | Rejected; `600s` itself is accepted |
+| Absolute-path command that exists but lacks the execute bit | Rejected (Unix only) |
+| `sanitize_path_for_error` on a mounted/bind-mounted home directory | Falls back to scrubbing the bare username substring when the leading-prefix match fails |
+| `RedactedUrl` on `https://user:p/w@host/mcp` (unencoded `/` in password) | Whole URL redacted — the authority-terminator ambiguity check fires |
+
+## 6. See Also
+
+- [[../introspector/spec]] — primary consumer of `ServerConfig`/`validate_server_config`
+- [[../cli/spec]] — consumer of `cli::{OutputFormat,ExitCode}` and the error-classification contract
+- [[../constitution]] — security principles this crate embodies workspace-wide

--- a/specs/files/spec.md
+++ b/specs/files/spec.md
@@ -1,0 +1,256 @@
+---
+aliases:
+  - mcp-execution-files spec
+  - Virtual Filesystem spec
+tags:
+  - sdd
+  - spec
+  - files
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../codegen/spec]]"
+  - "[[../server/spec]]"
+---
+
+# Block: Virtual Filesystem & Export (`mcp-execution-files`)
+
+> [!abstract]
+> Path: `crates/mcp-files`. An in-memory, read-only VFS for generated tool
+> files, plus a high-performance, **atomic** export to the real filesystem.
+> Depends on `mcp-execution-codegen` (for `GeneratedCode` and its derived
+> resource bounds).
+
+## 1. Responsibility
+
+Stage `mcp-codegen`'s `GeneratedCode` (or any hand-built file set) entirely
+in memory as a `FileSystem`, validate every path, then publish it to disk
+such that:
+- a process killed mid-export never leaves a half-written tree at the
+  target path, and
+- a failed export never corrupts a previously-published one.
+
+## 2. Public API Surface
+
+```rust
+// crate root
+pub use builder::FilesBuilder;
+pub use filesystem::{ExportOptions, FileSystem};
+pub use types::{FileEntry, FilePath, FilesError, Result};
+
+pub struct FilePath(String); // validated: absolute ('/'-prefixed), no "..", no empty/"." components, Unix-style on all platforms
+impl FilePath {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self>;
+    pub fn as_path(&self) -> &Path;
+    pub fn as_str(&self) -> &str;
+    pub fn parent(&self) -> Option<Self>;
+}
+
+pub struct FileEntry { /* content: String */ }
+impl FileEntry {
+    pub fn new(content: impl Into<String>) -> Self;
+    pub fn content(&self) -> &str;
+    pub fn size(&self) -> usize;
+}
+
+pub struct FileSystem { /* files: HashMap<FilePath, FileEntry> */ }
+impl FileSystem {
+    pub fn new() -> Self;
+    pub fn add_file(&mut self, path: impl AsRef<Path>, content: impl Into<String>) -> Result<()>;
+    pub fn read_file(&self, path: impl AsRef<Path>) -> Result<&str>;
+    pub fn exists(&self, path: impl AsRef<Path>) -> bool;
+    pub fn list_dir(&self, path: impl AsRef<Path>) -> Result<Vec<FilePath>>;
+    pub fn file_count(&self) -> usize;
+    pub fn all_paths(&self) -> Vec<&FilePath>; // sorted
+    pub fn files(&self) -> impl Iterator<Item = (&FilePath, &FileEntry)>;
+    pub fn clear(&mut self);
+    pub fn export_to_filesystem(&self, base_path: impl AsRef<Path>) -> Result<()>;
+    pub fn export_to_filesystem_with_options(&self, base_path: impl AsRef<Path>, options: &ExportOptions) -> Result<()>;
+    #[cfg(feature = "parallel")]
+    pub fn export_to_filesystem_parallel(&self, base_path: impl AsRef<Path>) -> Result<()>;
+}
+
+pub struct ExportOptions { pub atomic: bool } // default: atomic=true
+
+pub struct FilesBuilder { /* vfs: FileSystem, errors: Vec<FilesError> */ }
+impl FilesBuilder {
+    pub fn new() -> Self;
+    pub fn from_generated_code(code: GeneratedCode, base_path: impl AsRef<Path>) -> Self;
+    pub fn add_file(self, path: impl AsRef<Path>, content: impl Into<String>) -> Self;
+    pub fn add_files<P,C>(self, files: impl IntoIterator<Item=(P,C)>) -> Self;
+    pub fn build(self) -> Result<FileSystem>;
+    pub fn build_and_export(self, base_path: impl AsRef<Path>) -> Result<FileSystem>;
+    pub fn file_count(&self) -> usize;
+}
+
+pub const MAX_EXPORT_FILES: usize; // = mcp_execution_codegen::progressive::generator::MAX_GENERATED_FILES
+pub const MAX_EXPORT_BYTES: usize; // = mcp_execution_codegen::progressive::generator::MAX_GENERATED_BYTES
+```
+
+## 3. Input Contract
+
+`FilesBuilder::from_generated_code(code, base_path)` prefixes every
+`GeneratedFile.path` with `base_path` (string concatenation, always
+forward-slash, so VFS paths stay Unix-style even on Windows) and adds each
+as a VFS file. `base_path` is typically `/mcp-tools/servers/<server-id>` or,
+for `mcp-server`'s `save_categorized_tools`, the VFS root `/` (with the real
+disk target supplied later to `export_to_filesystem`).
+
+## 4. `FilePath` Validation Rules
+
+Rejects (as `FilesError::PathNotAbsolute` or `InvalidPathComponent`):
+not starting with `/`; containing `..`; an empty component (doubled `//` or
+trailing `/`); a bare `.` component. The **root path `/` itself** is valid
+(no components to check). This validation exists specifically to close a
+real bug (issue referenced in tests): an empty top-level component from
+`"//x.ts"` used to make `base.join("")` resolve to `base` itself, letting a
+single-file "group" swap the shared base directory wholesale in
+`FilesBuilder::build_and_export`.
+
+## 5. Atomic Export (`export_to_filesystem_with_options`)
+
+1. `check_export_bounds()` — file count ≤ `MAX_EXPORT_FILES`, total content
+   bytes ≤ `MAX_EXPORT_BYTES` (CWE-400).
+2. `stage_export(target)`:
+   - Sweeps stale sibling artifacts from a **previous crashed** export of
+     the *same* target (`sweep_stale_artifacts`, age-gated — see
+     [[#Stale-artifact sweep]]).
+   - Creates a fresh sibling temp directory via `tempfile::Builder`
+     (prefix `.{target-stem}.staging-...`), canonicalizes it.
+   - Pre-creates every directory the file set needs, in one pass.
+3. Writes every file into the staging directory
+   (`write_file_atomic` per file: temp-file → `fsync` → rename, when
+   `options.atomic`).
+4. `publish_staged_export`: renames the staging directory into `target`.
+   - If `target` doesn't exist yet: a single `rename`.
+   - If it does: `target` is moved aside to a unique `.{stem}.stale-{pid}-{nanos}-{seq}`
+     sibling first (a directory rename can't replace a non-empty
+     destination on any supported platform), the staged directory is
+     renamed into `target`, then the displaced original is removed.
+     If the *second* rename fails, the displaced original is renamed
+     **back** into `target` — so a caller of `swap_into_place` never
+     observes `target` missing, except across the narrow window between
+     the two renames if the process is killed there (see
+     [[#Non-goals / accepted gaps]]).
+5. On any failure before step 4 completes, the staging `TempDir`'s own
+   `Drop` removes the partial tree — `target` is never touched.
+
+This gives **per-call atomicity for a single `export_to_filesystem` call**,
+and (via `FilesBuilder::build_and_export`, see below)
+**per-top-level-group atomicity** for a multi-group batch — not
+whole-batch atomicity across groups.
+
+### Stale-artifact sweep
+
+`sweep_stale_artifacts` removes orphaned `.{stem}.staging-*`/`.{stem}.stale-*`
+siblings left by a **previous process that was killed** before its own
+`Drop`/rollback ran. Scoped to the exact target's name (`target_stem`), so
+it never touches a concurrent sibling export's own in-flight artifacts.
+Gated by `STALE_ARTIFACT_MIN_AGE` = 5 minutes (by mtime): a genuinely
+concurrent sibling's staging/displaced directories are always younger than
+this within a single export call's real-world duration, so the sweep can
+only ever reclaim true crash leftovers, never a live export's artifacts —
+this closes a real data-loss race (issue referenced in tests) where a
+name-only match could delete a concurrent in-flight export's staging *or*
+displaced-backup directory, defeating rollback and permanently losing the
+target.
+
+### Non-goals / accepted gaps
+
+- Concurrent exports of the **same** `base_path` from different processes
+  are not locked against each other; the last writer wins (a "lost
+  update"), though the sweep guarantees neither loses its own staging/
+  rollback artifacts to the other. `mcp-server` mitigates this at a higher
+  layer with a per-output-directory `Mutex` — see
+  [[../server/spec#Per-resource locking]].
+- A process killed **between** `swap_into_place`'s two renames leaves
+  `target` transiently absent, with the previous export sitting at a
+  `.stale-*` sibling until a later export's sweep reclaims it — accepted as
+  a louder failure mode (a visibly missing directory) than the silent
+  broken-import bug this design replaces.
+
+## 6. `FilesBuilder::build_and_export`
+
+Unlike `FileSystem::export_to_filesystem` (which treats `base_path` as
+exclusively owned, replacing it wholesale), `build_and_export` treats
+`base_path` as a **shared** directory (e.g. `~/.claude/servers/`) that other
+independent batches (other servers) already occupy:
+
+1. Whole-batch bound check (`vfs.check_export_bounds()`) up front — a
+   payload crafted as many small per-group files could otherwise bypass the
+   per-group check each `export_to_filesystem` call performs on its own.
+2. Splits the VFS by top-level path component into a `BTreeMap<String,
+   FileSystem>` of groups (deterministic alphabetical publish order) plus a
+   list of bare top-level files (no subdirectory).
+3. Each **group** (a real subtree, e.g. `github/createIssue.ts`) is
+   published via `FileSystem::export_to_filesystem` into
+   `base_path/<group-name>` — inheriting that method's atomic
+   staging/swap, and therefore its **replace-not-merge semantics for that
+   one group**: re-exporting `github/` with a smaller tool set deletes any
+   file previously under `base_path/github` absent from the new batch.
+   Sibling groups are unaffected.
+4. Each **bare top-level file** (e.g. `/manifest.json`) is written directly
+   via its own atomic temp-file-then-rename — always additive/overwriting,
+   never deleting.
+
+This gives **per-top-level-group atomicity, not whole-batch atomicity**: if
+one group's publish fails partway through a multi-group batch, groups
+already published (or bare files already written) remain in place, and the
+failure is surfaced to the caller — the batch as a whole is not rolled
+back.
+
+## 7. Error Conditions (`FilesError`)
+
+```rust
+pub enum FilesError {
+    FileNotFound { path },
+    NotADirectory { path },
+    InvalidPath { path },
+    PathNotAbsolute { path },
+    InvalidPathComponent { path },
+    IoError { path, source: std::io::Error },
+    ResourceLimitExceeded { resource, actual, limit }, // is_resource_limit_exceeded()
+}
+```
+
+## 8. Cross-Crate Contracts
+
+- **Consumes** `mcp-codegen::GeneratedCode`/`GeneratedFile`; derives
+  `MAX_EXPORT_FILES`/`MAX_EXPORT_BYTES` **equal to**
+  `mcp-codegen`'s `MAX_GENERATED_FILES`/`MAX_GENERATED_BYTES` (not
+  independently chosen) so a `FileSystem` built from that crate's normal
+  output can never be rejected here for merely being "as large as codegen
+  already allows."
+- **Used by** `mcp-server::save_categorized_tools` (via
+  `FilesBuilder::from_generated_code(code, "/").build()` then
+  `vfs.export_to_filesystem(&output_dir)` inside `spawn_blocking`, guarded
+  by a per-`output_dir` lock — see [[../server/spec#save_categorized_tools]]).
+- **Used by** `mcp-cli generate` (via
+  `FilesBuilder::from_generated_code(code, "/").build_and_export(base_dir)`
+  — see [[../cli/spec#generate]]).
+
+## 9. Edge Cases & Notable Behaviors
+
+- Displacing an existing **file** (not directory) at the group-collision
+  boundary (e.g. `base/sub` already exists as a plain file, but this batch
+  wants `/sub/nested.ts`) is handled: `remove_artifact_best_effort` falls
+  back to `fs::remove_file` when `remove_dir_all` fails with
+  `NotADirectory`, preventing a permanently-unremovable `.stale-*` artifact
+  (a real bug found in review, per test comments).
+  `touch_dir` similarly handles both directory (marker-file trick) and
+  plain-file (`File::set_modified`) mtime refresh, since the thing being
+  displaced isn't always a directory.
+- `export_to_filesystem`'s documented performance target is **<50ms for a
+  30-file export** (typical GitHub-server case).
+- `#[cfg(feature = "parallel")]` `export_to_filesystem_parallel` shares the
+  exact same staging/atomic-rename mechanism, writing files via `rayon`
+  instead — faster for >50 files, may not preserve write order (order
+  doesn't matter for a flat file tree).
+
+## 10. See Also
+
+- [[../codegen/spec]] — source of `GeneratedCode` and derived resource bounds
+- [[../server/spec#Per-resource locking]] — higher-layer serialization for concurrent exports to the same target
+- [[../cli/spec#generate]] — CLI-side consumer via `build_and_export`

--- a/specs/introspector/spec.md
+++ b/specs/introspector/spec.md
@@ -1,0 +1,185 @@
+---
+aliases:
+  - mcp-execution-introspector spec
+  - Introspection spec
+tags:
+  - sdd
+  - spec
+  - introspector
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../core/spec]]"
+  - "[[../codegen/spec]]"
+---
+
+# Block: MCP Server Introspection (`mcp-execution-introspector`)
+
+> [!abstract]
+> Path: `crates/mcp-introspector`. Connects to a target MCP server (stdio
+> subprocess, or Streamable HTTP for both `Http`/`Sse` transports) using the
+> official `rmcp` SDK, discovers its tools/capabilities, and returns a bounded
+> `ServerInfo`. Depends only on `mcp-execution-core` within the workspace.
+
+## 1. Responsibility
+
+Given a `ServerId` + `ServerConfig`, spawn/connect to the described server,
+run the MCP handshake, page through `tools/list`, and produce a `ServerInfo`
+that downstream `mcp-codegen` can turn into TypeScript. Also caches discovered
+servers in-process (`Introspector` holds a `HashMap<ServerId, ServerInfo>`).
+
+## 2. Public API Surface
+
+```rust
+pub struct Introspector { /* private: HashMap<ServerId, ServerInfo> */ }
+impl Introspector {
+    pub fn new() -> Self;
+    pub async fn discover_server(&mut self, server_id: ServerId, config: &ServerConfig) -> Result<ServerInfo>;
+    pub fn get_server(&self, server_id: &ServerId) -> Option<&ServerInfo>;
+    pub fn list_servers(&self) -> Vec<&ServerInfo>;
+    pub fn server_count(&self) -> usize;
+    pub fn remove_server(&mut self, server_id: &ServerId) -> bool;
+    pub fn clear(&mut self);
+}
+// Default: same as new()
+
+pub struct ServerInfo { pub id: ServerId, pub name: String, pub version: String, pub tools: Vec<ToolInfo>, pub capabilities: ServerCapabilities }
+pub struct ToolInfo { pub name: ToolName, pub description: String, pub input_schema: serde_json::Value, pub output_schema: Option<serde_json::Value> }
+pub struct ServerCapabilities { pub supports_tools: bool, pub supports_resources: bool, pub supports_prompts: bool }
+```
+
+Resource-limit constants (all `pub`):
+
+| Constant | Value | Guards |
+|---|---|---|
+| `MAX_TOOL_COUNT` | 1000 | total tools returned by `tools/list` (paged) |
+| `MAX_TOOL_NAME_LEN` | 256 | bytes, per tool name |
+| `MAX_TOOL_DESCRIPTION_LEN` | 8 KiB | bytes, per tool description |
+| `MAX_SCHEMA_SIZE_BYTES` | 64 KiB | serialized bytes, per input **or** output schema |
+
+`MAX_SCHEMA_SIZE_BYTES` is the dominant term multiplied through every
+downstream derived budget (`mcp-codegen::MAX_GENERATED_BYTES`,
+`mcp-files::MAX_EXPORT_BYTES`, `mcp-server::state::MAX_TOTAL_PENDING_BYTES`)
+— it was deliberately shrunk 4x (from 256 KiB) specifically to shrink those
+derived budgets proportionally without touching their own formulas.
+
+## 3. Discovery Flow (`discover_server`)
+
+1. `validate_server_config(config)` — defense in depth, even though a
+   builder-constructed `ServerConfig` is already validated (see
+   [[../core/spec#Defense in depth]]).
+2. Dispatch on `config.transport()`:
+   - `Stdio` → `discover_via_stdio_process`: spawns the child
+     (`kill_on_drop(true)` as a backstop against a dropped future leaking the
+     process — deliberately *not* relying on `rmcp`'s own `TokioChildProcess`
+     cleanup, whose `tokio::spawn`-based `Drop` can be starved under a
+     short-lived runtime); wires stdout through a **size-bounded** decoder
+     (`bounded_response_stream`, see [[#Response-line bounding (stdio)]])
+     instead of `rmcp`'s default unbounded `AsyncRwTransport`; always kills
+     the child afterward regardless of outcome.
+   - `Http`/`Sse` → `discover_via_http`: builds a `StreamableHttpClientTransport`
+     with caller headers converted to `http::HeaderValue`/`HeaderName`. **No
+     response-size bound exists on this path** — see
+     [[#Known gap HTTP response size]].
+3. `client.serve(transport)` bounded by `config.connect_timeout()` →
+   `Error::Timeout { operation: "connect to {id}", .. }` on expiry.
+4. `list_tools_bounded(&client)` — pages via `list_tools`, bailing out as
+   soon as the running total exceeds `MAX_TOOL_COUNT` **without** buffering
+   every page first (unlike `rmcp`'s own `list_all_tools`, which would hold
+   an arbitrarily large response in memory before any bound is checked).
+   Bounded overall by `config.discover_timeout()` →
+   `Error::Timeout { operation: "list_all_tools for {id}", .. }`.
+5. `extract_peer_meta` — pulls server name/version/capability flags from the
+   handshake `InitializeResult`; falls back to
+   `config.command`/`config.url()` and `"unknown"` version if the server
+   sent no peer info.
+6. `build_server_info` → per-tool `build_tool_info`, enforcing
+   `MAX_TOOL_NAME_LEN`/`MAX_TOOL_DESCRIPTION_LEN`/`MAX_SCHEMA_SIZE_BYTES` and
+   the overall `MAX_TOOL_COUNT` — returns `Error::ResourceLimitExceeded` on
+   any violation, naming the specific tool.
+7. Cache result in `self.servers`, return `ServerInfo`.
+
+## 4. Response-Line Bounding (stdio)
+
+`rmcp`'s default `(ChildStdout, ChildStdin)` transport reads lines via an
+unbounded `BufReader::read_until`, bypassing `JsonRpcMessageCodec`'s own
+`max_length` entirely. This crate replaces that with an explicit
+`FramedRead` over a custom `BoundedResponseDecoder` wrapping
+`JsonRpcMessageCodec`, capped at `MAX_RESPONSE_LINE_SIZE` = 4 MiB (private
+constant, matches `mcp-server`'s `MAX_REQUEST_LINE_SIZE` for consistency,
+not derivation — this bounds an **untrusted server's** responses, that one
+bounds an already-trusted local client's requests).
+
+- An oversized/malformed/skipped line is **dropped, logged at WARN**, not
+  treated as a hard error — the request it was answering then runs out its
+  timeout and surfaces as `Error::Timeout` rather than a distinct
+  size-limit error (there is no request id to correlate a dropped, unparsed
+  line back to).
+- A genuine I/O error still ends the session immediately (not retried).
+- Blank/whitespace-only lines are silently skipped without a WARN log
+  (avoids log-volume amplification from noisy stdout).
+- `tokio_util`'s internal buffer grows by doubling, so peak buffer capacity
+  during an oversized-line attack can reach ~4x `MAX_RESPONSE_LINE_SIZE`
+  before rejection — still strictly bounded, just not 1:1 with the cap.
+
+## 5. Known Gap: HTTP Response Size
+
+`rmcp` 2.2.0's Streamable HTTP client transport buffers each JSON response
+body and each SSE event **fully in memory** before this crate's own
+`MAX_TOOL_COUNT`/`MAX_SCHEMA_SIZE_BYTES` checks ever run, with no
+`rmcp`-provided config knob to bound that buffering. The only mitigation is
+`ServerConfig::discover_timeout` (bounds *how long* an unbounded response
+can be read, not *how large* it can grow). This is documented as a known
+upstream limitation, not something fixable without reimplementing a large
+part of `rmcp`'s HTTP transport client-side; `rmcp` 3.0.0-beta.2 adds a
+`max_sse_event_size` knob (SSE only, not JSON bodies) — revisit once a
+3.0.0 stable ships.
+
+## 6. Error Conditions
+
+| Condition | `Error` variant |
+|---|---|
+| `validate_server_config` fails | `SecurityViolation` / `ValidationError` (from `mcp-core`) |
+| Process spawn fails (stdio) | `ConnectionFailed { server, source }` |
+| Connect handshake exceeds `connect_timeout` | `Timeout { operation: "connect to {id}", duration_secs }` |
+| `tools/list` exceeds `discover_timeout` | `Timeout { operation: "list_all_tools for {id}", duration_secs }` |
+| Accumulated tool count > `MAX_TOOL_COUNT` during paging | `ResourceLimitExceeded { resource: "tool count from server '{id}'", .. }` |
+| Single tool's name/description/schema exceeds its bound | `ResourceLimitExceeded { resource: "<field> for tool '{name}'", .. }` |
+| HTTP header name/value invalid (introspection-time) | `ConnectionFailed` (header construction failure) |
+
+## 7. Edge Cases & Notable Behaviors
+
+- A server that sends no `peer_info` on handshake still produces a usable
+  `ServerInfo` (fallback name from `config`, version `"unknown"`,
+  capabilities all `false` except `supports_tools` which is derived from
+  whether any tools were found).
+- Two tools sharing an identical raw name are *not* deduplicated at this
+  layer — collision handling (via `resolve_typescript_names`) is
+  `mcp-codegen`'s responsibility.
+- Dropping the `Introspector::discover_server` future (e.g. a caller racing
+  it against its own cancellation via `tokio::select!`) still reliably
+  kills the spawned stdio child, via `kill_on_drop(true)` set at spawn time
+  — not via any code inside `discover_server` itself.
+- `list_tools_bounded` bails out **as soon as** the page that first pushes
+  the running total over `MAX_TOOL_COUNT` is fetched — at most one page's
+  worth of tools beyond the limit is ever held in memory at once, not the
+  server's entire (potentially huge) full response.
+
+## 8. Cross-Crate Contracts
+
+- **Consumes** `mcp-core`: `ServerConfig`, `ServerId`, `ToolName`,
+  `TransportType`, `validate_server_config`, `Error`/`Result`.
+- **Produced for** `mcp-codegen`: `ServerInfo`/`ToolInfo` are the direct
+  input to `ProgressiveGenerator::generate`/`generate_with_categories` — see
+  [[../codegen/spec#Input contract]]. `MAX_TOOL_COUNT`,
+  `MAX_TOOL_NAME_LEN`, `MAX_TOOL_DESCRIPTION_LEN`, `MAX_SCHEMA_SIZE_BYTES`
+  are referenced **by value** (not independently re-chosen) in
+  `mcp-codegen`'s and `mcp-files`'s own derived resource bounds.
+
+## 9. See Also
+
+- [[../core/spec]] — `ServerConfig`/security validation this crate re-checks
+- [[../codegen/spec]] — consumer of `ServerInfo`/`ToolInfo`
+- [[../server/spec#introspect_server]] — MCP-tool-level wrapper around this crate

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -1,0 +1,361 @@
+---
+aliases:
+  - mcp-execution-server spec
+  - MCP Server Exposure spec
+tags:
+  - sdd
+  - spec
+  - server
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../introspector/spec]]"
+  - "[[../codegen/spec]]"
+  - "[[../files/spec]]"
+  - "[[../skill/spec]]"
+---
+
+# Block: MCP Server Exposure (`mcp-execution-server`)
+
+> [!abstract]
+> Path: `crates/mcp-server`. Binary + library that exposes progressive-loading
+> generation and skill generation **as an MCP server itself** — i.e. Claude
+> Code can drive this project's own functionality over MCP, using the calling
+> Claude session's own natural-language understanding for tool
+> categorization instead of a second, separately-billed LLM call. Depends on
+> `mcp-execution-core`, `mcp-execution-introspector`, `mcp-execution-codegen`,
+> `mcp-execution-files`, `mcp-execution-skill`.
+>
+> Not merely a "progressive loading" server as CLAUDE.md's crate table
+> summarizes it — see [[../README#Discrepancies vs CLAUDE.md]].
+
+## 1. Responsibility
+
+Expose five MCP tools via `rmcp`'s `#[tool_router]`/`#[tool_handler]`
+machinery, backed by an in-process session store
+(`StateManager`) that bridges a two-call protocol
+(`introspect_server` → `save_categorized_tools`) so Claude can inspect tool
+metadata, categorize it via its own language understanding, and hand the
+categorization back for code generation — without this project needing its
+own LLM API key.
+
+## 2. Public API Surface (Types)
+
+```rust
+// crate root re-exports
+pub use clock::{Clock, SystemClock};
+pub use service::GeneratorService;
+pub use state::StateManager;
+pub use types::{CategorizedTool, GeneratedServerInfo, IntrospectServerParams,
+    IntrospectServerResult, IntrospectedToolSummary, ListGeneratedServersParams,
+    ListGeneratedServersResult, PendingGeneration, SaveCategorizedToolsParams,
+    SaveCategorizedToolsResult, ToolGenerationError};
+// re-exported from mcp_execution_skill for the generate_skill/save_skill tools:
+pub use mcp_execution_skill::{GenerateSkillParams, GenerateSkillResult,
+    SaveSkillParams, SaveSkillResult, SkillCategory, SkillMetadata, SkillTool, ToolExample};
+
+pub trait Clock: Send + Sync + Debug { fn now(&self) -> DateTime<Utc>; }
+pub struct SystemClock; // production
+#[cfg(test)] pub struct TestClock; // injectable fake, Arc<Mutex<DateTime<Utc>>>
+
+pub struct GeneratorService {
+    state: Arc<StateManager>,
+    introspectors: Arc<Mutex<HashMap<ServerId, Arc<Mutex<Introspector>>>>>,
+    exports: Arc<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>>,
+    clock: Arc<dyn Clock>,
+    skills_base_dir: Option<PathBuf>,  // test-only override; production = ~/.claude/skills
+    servers_base_dir: Option<PathBuf>, // test-only override; production = ~/.claude/servers
+    tool_router: ToolRouter<Self>,
+}
+impl GeneratorService { pub fn new() -> Self; } // Default too
+
+pub struct StateManager { /* pending: Arc<RwLock<PendingTable>>, clock */ }
+impl StateManager {
+    pub fn new() -> Self; // real clock
+    pub async fn store(&self, generation: PendingGeneration) -> Result<Uuid, StateError>;
+    pub async fn take(&self, session_id: Uuid) -> Option<PendingGeneration>;
+    pub async fn get(&self, session_id: Uuid) -> Option<PendingGeneration>;
+    pub async fn pending_count(&self) -> usize;
+    pub async fn cleanup_expired(&self) -> usize;
+}
+pub const MAX_PENDING_SESSIONS: usize = 1000;
+pub const MAX_TOTAL_PENDING_BYTES: usize; // = 4 * per-session-estimate (see below)
+
+pub struct PendingGeneration {
+    pub server_id: ServerId, pub server_info: ServerInfo, pub config: ServerConfig,
+    pub output_dir_override: Option<PathBuf>, pub created_at: DateTime<Utc>, pub expires_at: DateTime<Utc>,
+}
+impl PendingGeneration {
+    pub const DEFAULT_TIMEOUT_MINUTES: i64 = 30;
+    pub fn new(server_id, server_info, config, output_dir_override, clock: &dyn Clock) -> Self;
+    pub fn is_expired(&self, clock: &dyn Clock) -> bool; // strict `>`, not `>=`
+}
+```
+
+## 3. MCP Tools Exposed
+
+| Tool | Purpose | Cancellation-aware? |
+|---|---|---|
+| [[#introspect_server]] | Connect to a target server, discover tools, return a session id | Yes |
+| [[#save_categorized_tools]] | Generate + export TypeScript from a prior session's categorization | No (deliberately) |
+| [[#list_generated_servers]] | Enumerate previously-generated servers under `~/.claude/servers` | No (single bounded scan) |
+| [[#generate_skill]] | Scan a generated server's tools, return an LLM-facing SKILL.md generation prompt | Yes |
+| [[#save_skill]] | Write Claude-composed SKILL.md content, confined to `~/.claude/skills/{server_id}/` | No (deliberately) |
+
+`get_info()` (`ServerHandler`) advertises protocol version `2025-06-18`,
+tools capability enabled, and an `instructions` string describing the
+introspect→categorize→save workflow.
+
+### `introspect_server`
+
+`IntrospectServerParams { server_id, command, args, env, output_dir: Option<PathBuf>, connect_timeout_secs: Option<u64>, discover_timeout_secs: Option<u64> }`
+→ `IntrospectServerResult { server_id, server_name, tools_found, tools: Vec<IntrospectedToolSummary>, session_id: Uuid, expires_at }`.
+
+- **Always builds a stdio `ServerConfig`** (`build_stdio_server_config`) —
+  `IntrospectServerParams` has **no** field capable of selecting HTTP/SSE
+  transport (`url`/`http`/`sse`/`headers`), and a dedicated test
+  (`introspect_server_params_shape_is_pinned`) uses an exhaustive struct
+  destructure with no `..` rest pattern so **adding such a field is a
+  compile error** unless the destructure is updated too — a structural
+  guard against reintroducing SSRF risk, since `ServerConfig`'s own docs
+  note this crate is exactly the kind of server-context embedder expected
+  to add SSRF allowlisting before ever setting Http/Sse transport.
+- `server_id` validated via `mcp_execution_skill::validate_server_id`
+  before anything else; the tracing span's `server_id` field is left empty
+  on early validation failure (never logging unvalidated attacker input
+  into a structured field).
+- `output_dir`, if given, is checked with the cheap, I/O-free
+  `relative_subpath` (rejects absolute/`..`) — **not** the full
+  filesystem-touching confinement walk, which is deliberately deferred to
+  `save_categorized_tools` (see [[#Output directory resolution]]).
+- Introspection itself races `Introspector::discover_server` against the
+  request's `CancellationToken` via `tokio::select! { biased; ... }` (see
+  [[#Per-resource locking]]).
+- Result is stored as a `PendingGeneration` in `StateManager`; response is
+  wrapped via `mcp_execution_core::untrusted::wrap_untrusted_block`
+  (`wrap_introspect_result`) since the tool summaries it contains are
+  server-reported, attacker-controlled text now shown to Claude.
+
+### `save_categorized_tools`
+
+`SaveCategorizedToolsParams { session_id: Uuid, categorized_tools: Vec<CategorizedTool> }`
+→ `SaveCategorizedToolsResult { success, files_generated, output_dir, categories: HashMap<String,usize>, errors: Vec<ToolGenerationError> }`.
+
+1. `state.take(session_id)` — session must exist and not be expired, or
+   `invalid_params`.
+2. Validates `categorized_tools` against the session's own introspected
+   tool names, **sanitized the same way `introspect_server` sanitized them
+   for Claude** (`sanitize_untrusted_text`) — so a well-behaved caller
+   echoing back exactly what it was shown never fails a raw-vs-sanitized
+   name mismatch. Rejects: more entries than `min(introspected count,
+   MAX_TOOL_FILES)` (reusing `mcp_execution_skill::MAX_TOOL_FILES` so this
+   stage can never generate more tool files than `generate_skill` will
+   later accept); a name not in the introspected set; a duplicate name;
+   any field (`name`/`category`/`keywords`/`short_description`) over its
+   own byte cap (`MAX_CATEGORIZED_TOOL_NAME_LEN`=128,
+   `MAX_CATEGORY_LEN`=100, `MAX_KEYWORDS_LEN`=500,
+   `MAX_SHORT_DESCRIPTION_LEN`=320).
+3. `ProgressiveGenerator::generate_with_categories` → `FilesBuilder::from_generated_code(code, "/")` → `vfs.file_count()` captured.
+4. **Resolves `output_dir` fresh, right here** — not from any value cached
+   on the session — via `output_dir::resolve_output_dir` (see
+   [[#Output directory resolution]]).
+5. Exports inside `spawn_blocking`, holding a **per-`output_dir`** lock for
+   the duration (see [[#Per-resource locking]]).
+6. Does **not** observe request cancellation — a documented, deliberate
+   choice: an earlier version raced the *lock wait* (not the export
+   itself, which was already excluded) against cancellation, but that
+   produced two successive correctness bugs (a leaked lock-table entry, or
+   an evicted entry pulled out from under the still-running holder,
+   reopening the exact data-loss race the lock exists to prevent) for
+   little benefit, since the export itself was never interruptible anyway.
+
+### `list_generated_servers`
+
+`ListGeneratedServersParams { base_dir: Option<String> }` → `ListGeneratedServersResult { servers: Vec<GeneratedServerInfo>, total_servers }`.
+
+`base_dir`, if given, is confined to `servers_base_dir` via
+`resolve_list_base_dir` (issue #236's fix — previously an absolute or
+escaping `base_dir` silently fell back to the default instead of being
+rejected). Confinement is lexical first (`Path::join` + `starts_with`, which
+catches even a non-existent target and a Windows root-without-prefix path
+like `\pwn\evil`), then, if the joined path exists, re-checked via
+canonicalization against the canonicalized root (catches a symlink planted
+inside it). The scan itself (`spawn_blocking`, nested `read_dir`) counts
+`.ts` files per subdirectory (excluding `_`-prefixed and `_runtime`) and the
+subdirectory's mtime as `generated_at`.
+
+### `generate_skill`
+
+Thin MCP-tool wrapper around `mcp_execution_skill::scan_tools_directory` +
+`build_skill_context`, observing cancellation via the same
+`tokio::select! { biased; ... }` pattern as `introspect_server` (the scan
+walks every tool file, so a large directory can take a while). A missing
+server directory or scan failure (`MissingMetadata`/`UnsupportedSchema`/
+`StaleMetadata`) is reported as `invalid_params` (caller's fault: "run
+`generate` first"), not `internal_error`. Non-fatal drift warnings from the
+scan (`ScanResult::warnings`) are copied into the structured
+`GenerateSkillResult::warnings` field, not just logged.
+
+### `save_skill`
+
+Thin MCP-tool wrapper around `mcp_execution_skill::resolve_skill_output_path`
++ `extract_skill_metadata`. Validates `server_id`, content size
+(`MAX_SKILL_CONTENT_SIZE` = 100 KiB), and that content starts with `---`
+before the more expensive frontmatter parse. Rejects overwriting an existing
+file unless `overwrite: true`. **Deliberately does not observe
+cancellation**: `tokio::fs::write` on the blocking-pool cannot actually be
+interrupted once queued — racing it against `ct.cancelled()` would make the
+response lie (telling a cancelled client the write never happened while it
+still lands on disk moments later), which is worse than not attempting
+cancellation. The content-size bound (100 KiB) is not what actually caps the
+synchronous parse cost — `extract_skill_metadata`'s own
+`MAX_FRONTMATTER_SIZE` (8 KiB) on the extracted block is what keeps that
+bounded regardless of overall content size, since YAML parsing isn't
+linear-time on pathological input.
+
+## 4. State Management (`StateManager`)
+
+Sessions expire after `PendingGeneration::DEFAULT_TIMEOUT_MINUTES` = 30
+minutes and are swept **lazily** — only as a side effect of `store`/`take`
+(no background timer). Two independent resource-exhaustion bounds, both
+required:
+
+- `MAX_PENDING_SESSIONS` = 1000 — structural backstop against unbounded
+  `HashMap` growth (and its iteration cost), independent of session size.
+- `MAX_TOTAL_PENDING_BYTES` = 4 × a derived per-session estimate
+  (`MAX_TOOL_COUNT × (MAX_TOOL_NAME_LEN + MAX_TOOL_DESCRIPTION_LEN + 2 ×
+  MAX_SCHEMA_SIZE_BYTES)`, from `mcp-introspector`'s constants) — the count
+  cap alone doesn't bound memory, since a single session's real footprint
+  can vary by orders of magnitude with tool count; 1000 sessions at a
+  worst-case few-hundred-MB each could otherwise reach hundreds of GB.
+  Session size is estimated via `serde_json::to_vec(&server_info).len()`
+  (a serialization failure is treated as `usize::MAX`, i.e. always
+  exceeding any bound, rather than silently under-counting).
+
+`StateManager::store`/`take`/`get`/`pending_count`/`cleanup_expired` all
+consult the **injected** `Clock`, not `Utc::now()` directly — verified by a
+dedicated test that jumps a shared `TestClock` far past the TTL and asserts
+every one of those methods observes the same jump.
+
+## 5. Per-Resource Locking
+
+Two independent lock tables, both following the identical pattern:
+
+- `introspectors: HashMap<ServerId, Arc<Mutex<Introspector>>>` — a slow or
+  hung downstream server only blocks `introspect_server` calls for that
+  *same* server id, never unrelated ids. The outer map lock is released
+  before the per-id handle is awaited.
+- `exports: HashMap<PathBuf, Arc<Mutex<()>>>` — an export for one
+  `output_dir` never blocks a different one; holding the per-target lock
+  across `FileSystem::export_to_filesystem` serializes two concurrent
+  `save_categorized_tools` calls targeting the **same** `output_dir`,
+  narrowing (though not eliminating across 3+ overlapping calls) the
+  data-loss race `mcp-files`'s own age-gated artifact sweep is the final
+  backstop against.
+
+Both tables use **identity-checked eviction** (`Arc::ptr_eq`) after use —
+`server_id`/`output_dir` are caller-supplied, so without eviction the map
+grows unboundedly; an unconditional `remove` keyed by value alone is a
+TOCTOU bug (it could evict a fresh handle a *third*, concurrent caller
+already inserted after a *second* caller's own eviction).
+
+## 6. Output Directory Resolution (`output_dir.rs`)
+
+Mirrors `mcp-skill`'s `resolve_skill_output_path` for a directory target
+rather than a file:
+
+- `relative_subpath` (I/O-free) is all `introspect_server` runs — reject
+  fast, commit to nothing, create nothing.
+- `resolve_output_dir` (filesystem-touching: creates and confinement-checks
+  every intermediate directory, symlink-strict at `server_id`'s own
+  directory) is called **only from `save_categorized_tools`**, immediately
+  before `export_to_filesystem` — not once at `introspect_server` time with
+  the result cached on the session. Caching it would leave a window (up to
+  the full 30-minute session lifetime) in which a symlink planted after
+  resolution is never re-checked, and would create directories for any
+  `introspect_server` call regardless of whether a matching
+  `save_categorized_tools` ever follows.
+- The **final** target directory is confinement-checked but deliberately
+  **not created** here — `FileSystem::export_to_filesystem` publishes it
+  atomically via a staged rename, and pre-creating it would defeat that
+  atomicity on a first-time `generate`.
+
+## 7. Prompt Injection Defense
+
+Any server-reported tool metadata surfaced back to the calling Claude
+session — `introspect_server`'s tool summaries — is wrapped via
+`mcp_execution_core::untrusted::wrap_untrusted_block` before being returned
+as `CallToolResult` text (issue #292's fix), the same primitive
+`mcp-skill` uses for its LLM-facing generation prompt.
+
+## 8. Transport & Framing (`main.rs`, binary only)
+
+The binary wires stdio through a **size-bounded** codec
+(`JsonRpcMessageCodec::new_with_max_length`) instead of `rmcp`'s default
+`stdio()`, since that default reads lines via an unbounded
+`BufReader::read_until`. `MAX_REQUEST_LINE_SIZE` = 4 MiB (headroom over the
+largest legitimate payload, both well under 1 MiB); actual peak buffer
+capacity can reach ~4x that under attack due to `tokio_util`'s
+doubling-growth buffer.
+
+Additionally gates **request** admission (not notifications/responses,
+which always flow) behind a `Semaphore` of `MAX_CONCURRENT_REQUESTS` = 8,
+since `rmcp` 2.2.0 spawns an unbounded `tokio::spawn` per inbound request
+with no concurrency knob of its own. A bounded decode-ahead queue (also
+capped at 8) lets the stream keep decoding notifications/responses behind
+an as-yet-unadmitted request rather than stalling the whole connection
+behind it (FIFO admission order preserved). `RecoveringCodec` folds a
+malformed/oversized/skipped line into a logged-and-continued outcome rather
+than a terminal stream error, closing a `tokio_util` "stranded buffered
+request" stall (issue #273) that could otherwise leave a valid,
+already-buffered request undelivered forever if it shared a chunk with a
+preceding bad line.
+
+## 9. Error Conditions
+
+`StateError`: `AtCapacity { limit }`, `MemoryBudgetExceeded { limit }`.
+
+`OutputDirError`: `InvalidServerId`, `AbsolutePath`, `ParentTraversal`,
+`ServerDirIsSymlink`, `Escape`, `NotADirectory`, `CreateDir`, `Io`.
+
+Every tool method maps its internal errors to `rmcp::ErrorData` via either
+`McpError::invalid_params` (caller's fault — bad input, missing session,
+confinement violation) or `McpError::internal_error` (this project's/the
+environment's fault — I/O failure, task join error, serialization failure).
+
+## 10. Cross-Crate Contracts
+
+- **Consumes**: `mcp-introspector::Introspector`/`ServerInfo`,
+  `mcp-codegen::ProgressiveGenerator`, `mcp-files::FilesBuilder`/
+  `FileSystem`, `mcp-skill::{scan_tools_directory, build_skill_context,
+  resolve_skill_output_path, extract_skill_metadata, validate_server_id,
+  MAX_TOOL_FILES}`, `mcp-core::{ServerConfig, ServerId,
+  sanitize_path_for_error, validate_path_segment, untrusted::*}`.
+- **Schema drift guards**: `service.rs`'s own tests assert the `schemars`-
+  derived schema for `CategorizedTool`/`SaveCategorizedToolsParams`/
+  `IntrospectServerParams` matches the real runtime constants
+  (`MAX_CATEGORIZED_TOOL_NAME_LEN` etc., `mcp_execution_skill::MAX_TOOL_FILES`,
+  `mcp_execution_core::MAX_ARG_COUNT`/`MAX_ARG_LEN`) byte-for-byte.
+
+## 11. Edge Cases & Notable Behaviors
+
+- `test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id`
+  guards a subtle interaction between rmcp's async-fn span-instrumentation
+  heuristic and `#[tool]`'s macro-generated boxing — if that heuristic ever
+  stops matching, the `server_id` tracing field silently stops being
+  recorded, and this test is the only thing that would catch it.
+- `PendingGeneration::is_expired` uses **strict** `>`, so a session checked
+  at exactly its `expires_at` instant is *not* yet expired.
+- `resolve_list_base_dir`'s confinement check runs even when the joined
+  path doesn't exist yet (lexical `starts_with`), matching every other
+  confinement check in this crate rather than being the one path that
+  skips it.
+
+## 12. See Also
+
+- [[../introspector/spec]] — wrapped by `introspect_server`
+- [[../codegen/spec]] / [[../files/spec]] — wrapped by `save_categorized_tools`
+- [[../skill/spec]] — wrapped by `generate_skill`/`save_skill`
+- [[../cli/spec]] — the CLI-driven alternative path to the same underlying crates

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -1,0 +1,237 @@
+---
+aliases:
+  - mcp-execution-skill spec
+  - Skill Generation spec
+tags:
+  - sdd
+  - spec
+  - skill
+  - security
+created: 2026-07-27
+status: documented
+related:
+  - "[[../constitution]]"
+  - "[[../core/spec]]"
+  - "[[../server/spec]]"
+  - "[[../cli/spec]]"
+---
+
+# Block: Skill Generation (`mcp-execution-skill`)
+
+> [!abstract]
+> Path: `crates/mcp-skill`. Generates Claude Code `SKILL.md` files from a
+> server's already-generated tool set (reading the `_meta.json` sidecar, not
+> the `.ts` source). Used by both `mcp-cli skill` (directly renders SKILL.md)
+> and `mcp-server`'s `generate_skill`/`save_skill` tools (returns a prompt for
+> Claude to compose SKILL.md, then confines/writes the result). Depends on
+> `mcp-execution-core` only.
+
+## 1. Responsibility
+
+1. **Scan** (`parser`): read a server directory's `_meta.json` sidecar,
+   cross-check it against the `.ts` files actually on disk, and produce
+   `ParsedToolFile`/`ParsedParameter` structures.
+2. **Contextualize** (`context`): group tools by category, pick
+   representative examples, sanitize every untrusted field, and build an
+   LLM-facing generation prompt wrapped in an explicit untrusted-data
+   boundary.
+3. **Render** (`template`): turn that context into either the LLM prompt or
+   a directly-rendered `SKILL.md` (no LLM required), via embedded Handlebars
+   templates.
+4. **Confine** (`output_path`): validate and confine a caller-supplied
+   `save_skill` output path to its base directory, symlink-aware.
+
+## 2. Public API Surface
+
+```rust
+// crate root re-exports
+pub use context::build_skill_context;
+pub use output_path::{OutputPathError, resolve_skill_output_path};
+pub use parser::{MAX_FILE_SIZE, MAX_FRONTMATTER_SIZE, MAX_TOOL_FILES,
+    ParsedParameter, ParsedToolFile, ScanError, ScanResult, SkillMetadataError,
+    extract_skill_metadata, scan_tools_directory};
+pub use template::{TemplateError, render_generation_prompt, render_skill_md};
+pub use types::{GenerateSkillParams, GenerateSkillResult, MAX_SERVER_ID_LENGTH,
+    SaveSkillParams, SaveSkillResult, ServerIdError, SkillCategory, SkillMetadata,
+    SkillTool, ToolExample, validate_server_id};
+
+pub const MAX_SERVER_ID_LENGTH: usize = 64;
+pub fn validate_server_id(server_id: &str) -> Result<(), ServerIdError>;
+// Rules: non-empty, <= 64 bytes, only [a-z0-9-]
+
+pub const MAX_TOOL_FILES: usize = 500;
+pub const MAX_FILE_SIZE: u64 = 1024 * 1024;       // 1 MiB, _meta.json size cap
+pub const MAX_FRONTMATTER_SIZE: usize = 8 * 1024; // 8 KiB, extracted YAML block cap
+pub async fn scan_tools_directory(dir: &Path) -> Result<ScanResult, ScanError>;
+pub struct ScanResult { pub tools: Vec<ParsedToolFile>, pub warnings: Vec<String> }
+
+pub fn build_skill_context(server_id: &str, tools: &[ParsedToolFile], use_case_hints: Option<&[String]>) -> GenerateSkillResult;
+
+pub fn render_generation_prompt(context: &GenerateSkillResult) -> Result<String, TemplateError>;
+pub fn render_skill_md(context: &GenerateSkillResult) -> Result<String, TemplateError>;
+
+pub fn extract_skill_metadata(content: &str) -> Result<SkillMetadata, SkillMetadataError>;
+
+pub async fn resolve_skill_output_path(base_dir: &Path, server_id: &str, output_path: Option<&Path>) -> Result<PathBuf, OutputPathError>;
+```
+
+Key types (`types.rs`): `GenerateSkillParams`/`GenerateSkillResult` (the
+MCP-tool-shaped request/response — `GenerateSkillResult` doubles as the
+Handlebars render context for both templates), `SkillCategory`/`SkillTool`/
+`ToolExample`, `SaveSkillParams`/`SaveSkillResult`/`SkillMetadata`.
+
+## 3. `scan_tools_directory` — Sidecar-Backed Scanning
+
+Replaces a historical regex-based `.ts`-file scanner (issue #141: it could
+never recover parameter descriptions). Now:
+
+1. Canonicalizes `dir`, then canonicalizes `dir/_meta.json` and requires it
+   to `starts_with(canonical_base)` — defends against a symlinked
+   `_meta.json` escaping the directory (path-traversal via symlink).
+2. Size-checks the sidecar (`MAX_FILE_SIZE`), parses as
+   `mcp_core::metadata::ServerMetadata`, checks
+   `schema_version == METADATA_SCHEMA_VERSION`, checks tool count ≤
+   `MAX_TOOL_FILES`.
+3. `verify_tool_files_on_disk`: every sidecar entry's `{typescript_name}.ts`
+   must exist on disk, or the whole scan fails with
+   `ScanError::StaleMetadata` (naming the tool, the missing file, and
+   telling the caller to re-run `generate`) — first missing entry in
+   sidecar order, not an exhaustive scan. A `.ts` file present on disk but
+   **not** referenced by the sidecar is non-fatal: logged via
+   `tracing::warn!`, excluded from the result, and surfaced as a
+   human-readable string in `ScanResult::warnings` (issue #161's fix — the
+   drift must be visible to a structured caller, not just server-side
+   tracing). `index.ts` (the aggregator) is never treated as an "extra"
+   file.
+4. Tools returned sorted by name.
+
+## 4. `build_skill_context` — Sanitization & Grouping
+
+`group_by_category` treats every field on `ParsedToolFile` as **untrusted**
+(it originates from the introspected MCP server, stored raw in `_meta.json`
+by `mcp_execution_codegen::create_tool_metadata`) and sanitizes each via
+`mcp_core::untrusted::sanitize_untrusted_text(_, MAX_UNTRUSTED_FIELD_LEN)`
+**before** it can reach either the SKILL.md body (rendered with
+triple-stash `{{{...}}}`, so HTML-escaping doesn't help) or the LLM-facing
+prompt: `name`, `description`, `category` (sanitized *before*
+`humanize_category` derives `display_name`, so the heading can't
+reintroduce a control character), `keywords`, parameter names. Tools
+without a category are grouped under `"uncategorized"`, sorted last.
+
+`select_example_tools` prioritizes tools whose name starts with `create`,
+`list`, `get`, `search`, `update` (in that order), one per not-yet-seen
+category, then fills remaining slots.
+
+## 5. Prompt Injection Defense
+
+`build_generation_prompt` accumulates the categorized-tool-metadata section
+separately and wraps it via `mcp_core::untrusted::wrap_untrusted_block`
+(escaping `&`/`<`/`>` in the body, so a hostile description cannot forge the
+boundary's own `<untrusted-data>`/`</untrusted-data>` delimiters) —
+regression-tested end to end with a description attempting exactly that
+forgery. Sanitization alone (flattening control characters) stops
+structural Markdown breakout; the explicit boundary additionally tells the
+LLM reader the enclosed text is inert data, not an instruction to follow —
+these are two distinct, both-necessary defenses (issue #288's fix).
+
+## 6. `render_skill_md` — Direct Rendering (No LLM)
+
+Renders `GenerateSkillResult` through the embedded `skill-md.hbs` template
+with triple-stash interpolation (no HTML-escaping needed/wanted). Before
+rendering, `server_description` is **YAML-quoted** (`yaml_quote`: escapes
+`\`, `"`, strips `\r`) so a `:`, leading `-`, or embedded newline in
+server-supplied metadata cannot corrupt the frontmatter or inject a sibling
+YAML key (issue's S3 fix). Output is CRLF-normalized to LF for
+cross-platform (Windows CI) consistency.
+
+## 7. `extract_skill_metadata` — Frontmatter Parsing
+
+Extracts the `---`-delimited YAML block via a pre-compiled regex, then
+parses it with **`serde_norway`** (a real YAML parser — block/folded
+scalars, quoted scalars all handled correctly, unlike a naive single-line
+regex capture that an earlier version used). The extracted block is
+size-capped at `MAX_FRONTMATTER_SIZE` (8 KiB) **before** parsing, since
+`serde_norway` (like other libyaml-based parsers) is not linear-time on
+pathologically nested input — bounding only the overall `SKILL.md` size
+would not bound parse latency. `name`/`description` are required and
+treated as invalid if absent, `null`/`~`, or blank-after-trim. A
+`serde_norway` deserialization error's line number is corrected to be
+file-relative (the block starts one line after the file's opening `---`).
+
+## 8. `resolve_skill_output_path` — Path Confinement
+
+Confines `save_skill`'s optional `output_path` to `base_dir/server_id`
+(issue #184's fix — without this, an absolute path, `..`, or a
+symlink-planted-inside-`base_dir` path could write anywhere the process can
+reach):
+
+- `server_id` and `output_path` walk the **same** checked, one-component-
+  at-a-time loop, rooted at a once-canonicalized `base_dir`.
+- `server_id`'s own directory is checked **first** and rejected outright if
+  it already exists as a symlink, regardless of where it points — including
+  at a *sibling* server's own directory, which would otherwise pass a
+  plain resolve-and-confine check since it still resolves under
+  `base_dir` (issue #217's fix).
+- Every subsequent directory component (up to but not including the final
+  file) is confinement-checked and created eagerly; a pre-existing symlink
+  there is followed only if it still resolves inside `server_id`'s
+  directory.
+- The final path component is rejected outright if it exists as a symlink,
+  **dangling or not** — a dangling symlink makes `canonicalize` fail, which
+  must not be treated as "safe, doesn't exist yet" (a subsequent write
+  would still follow it).
+- This is a check against **pre-existing** state at call time — not a
+  concurrency guarantee against a symlink planted by a racing process
+  between this check and the caller's write.
+
+## 9. Error Conditions
+
+`ScanError`: `Io`, `DirectoryNotFound`, `MissingMetadata`,
+`MetadataParse`, `UnsupportedSchema`, `TooManyFiles`, `FileTooLarge`,
+`StaleMetadata`.
+
+`SkillMetadataError`: `MissingFrontmatter`, `FrontmatterTooLarge`,
+`InvalidYaml`, `MissingField`.
+
+`OutputPathError`: `InvalidServerId`, `AbsolutePath`, `ParentTraversal`,
+`InvalidPath`, `ServerIdIsSymlink`, `Escape`, `NotADirectory`, `NotAFile`,
+`CreateDir`, `Io`.
+
+`ServerIdError`: `Empty`, `TooLong { len, limit }`, `InvalidCharacters`.
+
+## 10. Cross-Crate Contracts
+
+- **Consumes** `mcp-core`: `metadata::{METADATA_FILE_NAME,
+  METADATA_SCHEMA_VERSION, ServerMetadata}`, `sanitize_path_for_error`,
+  `validate_path_segment`, `untrusted::*`.
+- **Used by** `mcp-cli skill` (directly calls `scan_tools_directory` +
+  `build_skill_context` + `render_skill_md`, no LLM/prompt step — see
+  [[../cli/spec#skill]]).
+- **Used by** `mcp-server`'s `generate_skill`/`save_skill` tools (returns
+  the LLM-facing prompt via `generate_skill`, writes Claude's composed
+  content via `save_skill` — see [[../server/spec#generate_skill]] and
+  [[../server/spec#save_skill]]).
+- **Schema shape checks**: `types.rs`'s own tests assert the `schemars`-
+  derived JSON Schema for `GenerateSkillParams`/`SaveSkillParams` declares
+  bounds matching the real runtime constants (`MAX_SERVER_ID_LENGTH`) — a
+  drift-guard, since `schemars` attributes cannot reference a Rust `const`
+  directly and must mirror it as a literal.
+
+## 11. Edge Cases & Notable Behaviors
+
+- `SaveSkillParams::content`'s declared JSON-Schema `maxLength` (102,400)
+  and the runtime byte cap it mirrors (`MAX_SKILL_CONTENT_SIZE`, owned by
+  `mcp-server::service`) only coincide exactly for ASCII input — JSON
+  Schema's `maxLength` counts Unicode code points, not bytes, so the
+  runtime byte check can reject legitimate multi-byte UTF-8 content the
+  declared schema would still accept (never the reverse).
+- A category string itself can carry an injected heading
+  (`"issues\n### Injected Heading"`) — sanitized the same way as
+  description text, verified by a dedicated regression test distinct from
+  the tool-description case.
+
+## 12. See Also
+
+- [[../core/spec]] — shared path-confinement and untrusted-text primitives
+- [[../server/spec]] — MCP-tool-level `generate_skill`/`save_skill` wrappers
+- [[../cli/spec#skill]] — CLI-level direct SKILL.md rendering


### PR DESCRIPTION
## Summary

- Adds a full specification package under `specs/`, reverse-engineered from the existing codebase rather than designed from a new idea.
- Groups documentation by functional block: one spec per crate (`core`, `introspector`, `codegen`, `files`, `skill`, `server`, `cli`), plus a top-level `README.md` index describing end-to-end data flow and cross-block contracts, and a `constitution.md` capturing observed project principles.
- Adds formal BRD, SRS, and NFR documents grounded in `README.md`, `CHANGELOG.md`, `Cargo.toml`, `SECURITY.md`, `deny.toml`, and CI config, cross-linked from `specs/README.md`. Every requirement traces back to real code, tests, or repo docs; unresolved discrepancies (e.g. conflicting token-savings figures between README and CHANGELOG, absence of a named business stakeholder) are flagged as open questions rather than invented.
- No source code changes — documentation only.

## Test plan

- [ ] Review `specs/README.md` as the entry point
- [ ] Spot-check per-crate specs against the corresponding crate's public API
- [ ] Review open questions in BRD/SRS/NFR and resolve or accept as known gaps