### PR TITLE
fix(codegen,server): tool-name collision and categorization desync bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   functions, not a fix for a reachable live-server exploit: a schema arriving over the wire is
   already bounded to well under this cap by `serde_json`'s own default deserialization
   recursion limit before it ever reaches these functions (#303).
+- **`mcp-execution-codegen`**: a tool whose name sanitized to `index` (literally `index`, or a
+  case-insensitive variant like `Index`/`INDEX`) had its generated `.ts` file silently
+  overwritten by the always-emitted `index.ts` re-export, permanently losing the tool's own
+  generated code — and on a case-insensitive filesystem (macOS APFS, Windows NTFS by default),
+  a case-variant name like `Index` collided with `index.ts` too, since the two are the same file
+  there regardless of case; two tools named e.g. `Index` and `index` collided with each other the
+  same way. `resolve_typescript_names` now disambiguates output filenames case-insensitively
+  (against JS/TS reserved words, this generator's own reserved output filenames, and each other),
+  while still emitting each tool's original casing, so a colliding name gets the same
+  numeric-suffix disambiguation (`index_2`, `Index_2`, ...) a genuine same-case collision already
+  received — this also incidentally disambiguates any two tool names that differ only by case
+  (e.g. `getUser`/`GetUser`), not just names colliding with a reserved name (#312).
+- **`mcp-execution-server`**: `save_categorized_tools` built its codegen categorization map
+  keyed by the *display* form of a tool name Claude was shown by `introspect_server`
+  (control-character-sanitized, and — for a name containing `&`/`<`/`>` — additionally
+  entity-escaped as part of delimiting untrusted MCP metadata), while codegen looks up
+  categorization by the tool's *raw* name. For any tool name containing a control character,
+  line terminator, or `&`/`<`/`>`, this desync silently dropped its category, keywords, and
+  short description with no error surfaced. `save_categorized_tools` now resolves each
+  `categorized_tools` entry to its raw tool name before building the categorization map, so
+  identity comparisons stay keyed by what Claude actually saw while codegen lookups stay keyed
+  by the raw value. Several refinements to that resolution: a caller may echo back either the
+  literally-shown escaped form (`a&lt;b`) or the same name with `&`/`<`/`>` entities decoded
+  back to their original characters (`a<b`) — `wrap_untrusted_block`'s own preamble invites
+  exactly that decoding, and only accepting the escaped form would have hard-rejected
+  previously-working input; if two distinct raw tool names ever sanitize to the same display
+  form, that shared form is now rejected explicitly as ambiguous rather than a last-write-wins
+  map silently misattributing one tool's categorization to the other; and duplicate-entry
+  detection now dedups on each entry's *resolved raw name* rather than its submitted display
+  string, since a single raw tool can legitimately be named by either of its two display forms —
+  deduping on the submitted string alone missed a caller submitting both forms for the same tool,
+  letting the second entry silently overwrite the first's categorization (#307).
 
 - **`mcp-execution-skill`**: `scan_tools_directory` discarded the real `io::Error` from both of
   its `canonicalize` calls (the server directory and the `_meta.json` sidecar) and mislabeled
@@ -47,6 +79,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented `tsconfig.json` leaf-configuration behavior in `mcp-codegen` crate docs and README: generated `tsconfig.json` is not intended to be `extends`-ed (silent `noEmit` inheritance), is regenerated on every `generate` run, and the generated package should be executed or type-checked as a separate process rather than merged into the consumer's own TypeScript compilation (#258).
 
 ### Breaking
+
+- **`mcp-execution-codegen`**: `GeneratedCode::add_file` now returns
+  `Result<(), mcp_execution_core::Error>` instead of `()`. Adding a file at a path already
+  present in the collection now returns `Error::DuplicateGeneratedFilePath` instead of silently
+  overwriting the earlier entry, so a future gap in reserved-name handling (like #312) fails
+  loudly instead of losing a generated file with no signal to the caller. All in-tree call sites
+  (`mcp-codegen`'s own generator, `mcp-files`'s `FilesBuilder`) have been updated.
 
 - **`mcp-execution-files`**: `FilesError::is_not_found()`, `is_not_directory()`,
   `is_invalid_path()`, and `is_io_error()`, and `FilePath::is_dir_path()` removed — none had any

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -278,7 +278,12 @@ fn classify_core_error(core_error: &CoreError) -> ExitCode {
         CoreError::ValidationError { .. }
         | CoreError::SecurityViolation { .. }
         | CoreError::InvalidArgument(_) => ExitCode::INVALID_INPUT,
-        CoreError::SerializationError { .. } => ExitCode::ERROR,
+        // A duplicate generated-file path indicates a codegen invariant was violated (e.g. a
+        // reserved output filename not seeded into name-collision resolution), not something
+        // caused by the remote server's data or the CLI caller's own arguments.
+        CoreError::SerializationError { .. } | CoreError::DuplicateGeneratedFilePath { .. } => {
+            ExitCode::ERROR
+        }
         CoreError::ScriptGenerationError { source, .. } => source
             .as_deref()
             .and_then(|source| source.downcast_ref::<CoreError>())

--- a/crates/mcp-codegen/src/common/types.rs
+++ b/crates/mcp-codegen/src/common/types.rs
@@ -20,6 +20,7 @@
 //! assert_eq!(code.files.len(), 1);
 //! ```
 
+use mcp_execution_core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -64,6 +65,14 @@ impl GeneratedCode {
 
     /// Adds a generated file to the collection.
     ///
+    /// # Errors
+    ///
+    /// Returns [`Error::DuplicateGeneratedFilePath`] if `file.path` is already present in
+    /// this collection. Silently overwriting an existing entry would discard the file
+    /// already added at that path with no signal to the caller (issue #312); every path
+    /// added here is expected to already be unique by construction, so this only fires
+    /// when that invariant has actually been violated upstream.
+    ///
     /// # Examples
     ///
     /// ```
@@ -73,12 +82,25 @@ impl GeneratedCode {
     /// code.add_file(GeneratedFile {
     ///     path: "index.ts".to_string(),
     ///     content: "export {}".to_string(),
-    /// });
+    /// })
+    /// .unwrap();
     ///
     /// assert_eq!(code.file_count(), 1);
+    ///
+    /// let err = code
+    ///     .add_file(GeneratedFile {
+    ///         path: "index.ts".to_string(),
+    ///         content: "export const x = 1;".to_string(),
+    ///     })
+    ///     .unwrap_err();
+    /// assert!(err.is_duplicate_generated_file_path());
     /// ```
-    pub fn add_file(&mut self, file: GeneratedFile) {
+    pub fn add_file(&mut self, file: GeneratedFile) -> Result<()> {
+        if self.files.iter().any(|existing| existing.path == file.path) {
+            return Err(Error::DuplicateGeneratedFilePath { path: file.path });
+        }
         self.files.push(file);
+        Ok(())
     }
 
     /// Returns the number of generated files.
@@ -280,8 +302,31 @@ mod tests {
         code.add_file(GeneratedFile {
             path: "test.ts".to_string(),
             content: "content".to_string(),
-        });
+        })
+        .unwrap();
         assert_eq!(code.file_count(), 1);
+    }
+
+    #[test]
+    fn test_add_file_rejects_duplicate_path() {
+        let mut code = GeneratedCode::new();
+        code.add_file(GeneratedFile {
+            path: "index.ts".to_string(),
+            content: "first".to_string(),
+        })
+        .unwrap();
+
+        let err = code
+            .add_file(GeneratedFile {
+                path: "index.ts".to_string(),
+                content: "second".to_string(),
+            })
+            .unwrap_err();
+
+        assert!(err.is_duplicate_generated_file_path());
+        // The original file must be left untouched, not silently overwritten.
+        assert_eq!(code.file_count(), 1);
+        assert_eq!(code.files[0].content, "first");
     }
 
     #[test]

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -833,7 +833,11 @@ fn enforce_tool_count_bound(server_info: &ServerInfo) -> Result<()> {
 /// # Errors
 ///
 /// Returns [`Error::ResourceLimitExceeded`] if adding `file` would push the running byte total
-/// past [`MAX_GENERATED_BYTES`], or the file count past [`MAX_GENERATED_FILES`].
+/// past [`MAX_GENERATED_BYTES`], or the file count past [`MAX_GENERATED_FILES`]. Returns
+/// [`Error::DuplicateGeneratedFilePath`] if `file.path` was already added earlier in this
+/// call — see [`GeneratedCode::add_file`]; this is defense-in-depth once
+/// [`resolve_typescript_names`] seeds its collision set with this module's own reserved
+/// output filenames (issue #312), not a path this function expects to hit in practice.
 fn add_tracked(
     code: &mut GeneratedCode,
     total_bytes: &mut usize,
@@ -848,7 +852,7 @@ fn add_tracked(
         });
     }
 
-    code.add_file(file);
+    code.add_file(file)?;
 
     if code.file_count() > MAX_GENERATED_FILES {
         return Err(Error::ResourceLimitExceeded {
@@ -951,6 +955,14 @@ const RESERVED_WORDS: &[&str] = &[
     "yield",
 ];
 
+/// Output filenames (without extension) that [`ProgressiveGenerator`] itself always emits
+/// alongside per-tool files, regardless of the introspected tool list. Seeded into
+/// [`resolve_typescript_names`]'s collision set for the same reason [`RESERVED_WORDS`] is: a
+/// tool whose sanitized name matches one of these would otherwise silently overwrite this
+/// generator's own fixed output file (issue #312) instead of being disambiguated like any
+/// other name collision.
+const RESERVED_OUTPUT_NAMES: &[&str] = &["index"];
+
 /// Resolves a collision-free TypeScript identifier for each tool, in tool order.
 ///
 /// `sanitize_ts_identifier` can map distinct tool names to the same identifier (e.g.
@@ -964,21 +976,53 @@ const RESERVED_WORDS: &[&str] = &[
 /// resolved identifiers even though both were correctly disambiguated. Callers must look up
 /// entries by the tool's index in the same `tools` slice.
 ///
-/// `used` is seeded with [`RESERVED_WORDS`] before any tool is processed, so a sanitized name
-/// that exactly matches a JS/TS reserved word (e.g. a tool literally named `delete`) is treated
-/// as already taken by [`disambiguate_identifier`] and gets the same numeric-suffix
-/// disambiguation as a collision: `export async function delete(...)` is a hard syntax error,
-/// so it becomes `delete_2` instead.
+/// Collision detection is case-insensitive (via [`disambiguate_output_filename`]'s
+/// case-folded `used_lower` set), even though the *emitted* identifier preserves each tool's
+/// original case. `typescript_name` is not just a language-level identifier — it doubles as an
+/// output filename, and filenames collide regardless of case on a case-insensitive filesystem
+/// (macOS APFS, Windows NTFS by default, this project's primary dev platforms). Folding case for
+/// the collision check alone means: a sanitized name that matches a JS/TS reserved word (e.g. a
+/// tool literally named `delete`) or one of this generator's own fixed output filenames (e.g.
+/// `index`, in any case — `Index`, `INDEX`, ...) is treated as already taken and gets the same
+/// numeric-suffix disambiguation a same-case collision would (`delete` becomes `delete_2`, `index`
+/// or `Index` becomes `index_2`/`Index_2`); and two distinct tools whose names differ only by
+/// case (`getUser`/`GetUser`) are disambiguated from each other too, not just from the reserved
+/// sets (issue #312 S1, N2).
 fn resolve_typescript_names(tools: &[ToolInfo]) -> Vec<String> {
-    let mut used: HashSet<String> = RESERVED_WORDS.iter().map(|&s| s.to_string()).collect();
+    let mut used_lower: HashSet<String> = RESERVED_WORDS
+        .iter()
+        .chain(RESERVED_OUTPUT_NAMES.iter())
+        .map(|&s| s.to_ascii_lowercase())
+        .collect();
     let mut resolved = Vec::with_capacity(tools.len());
 
     for tool in tools {
         let base = sanitize_ts_identifier(&to_camel_case(tool.name.as_str()));
-        resolved.push(disambiguate_identifier(&base, &mut used));
+        resolved.push(disambiguate_output_filename(&base, &mut used_lower));
     }
 
     resolved
+}
+
+/// Disambiguates `base` against `used_lower` case-insensitively, appending a numeric suffix
+/// (`_2`, `_3`, ...) — mirroring [`disambiguate_identifier`]'s suffix scheme — until a
+/// case-insensitively-unique candidate is found, then reserves that candidate's lowercased form
+/// in `used_lower`. The returned identifier preserves `base`'s original casing; only the
+/// collision *check* is case-folded.
+///
+/// A dedicated function rather than reusing [`disambiguate_identifier`]: that one is shared with
+/// property-name disambiguation, which must stay case-sensitive — `name` and `Name` are
+/// legitimately distinct object keys in the generated `Params` interface. Output *filenames* have
+/// no such case-sensitive guarantee once a case-insensitive filesystem is in play, which is what
+/// [`resolve_typescript_names`] uses this for (issue #312 S1/N2).
+fn disambiguate_output_filename(base: &str, used_lower: &mut HashSet<String>) -> String {
+    let mut candidate = base.to_string();
+    let mut suffix = 2;
+    while !used_lower.insert(candidate.to_ascii_lowercase()) {
+        candidate = format!("{base}_{suffix}");
+        suffix += 1;
+    }
+    candidate
 }
 
 fn sanitize_schema_jsdoc_descriptions(mut value: serde_json::Value) -> serde_json::Value {
@@ -1573,6 +1617,231 @@ mod tests {
         assert_eq!(context.tools.len(), 2);
         assert_eq!(context.tools[0].typescript_name, "createIssue");
         assert!(context.categories.is_none());
+    }
+
+    /// Regression guard for #312: a tool whose raw MCP name sanitizes to `index` must not
+    /// collide with the always-emitted `index.ts` re-export. `resolve_typescript_names` seeds
+    /// its collision set with this generator's own reserved output filenames, so the tool gets
+    /// disambiguated (`index_2`) exactly like a JS/TS reserved-word collision would.
+    #[test]
+    fn test_tool_named_index_does_not_collide_with_index_ts() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = ServerInfo {
+            id: ServerId::new("test-server"),
+            name: "Test Server".to_string(),
+            version: "1.0.0".to_string(),
+            tools: vec![ToolInfo {
+                name: ToolName::new("index"),
+                description: "A tool literally named index".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+                output_schema: None,
+            }],
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+        };
+
+        let code = generator.generate(&server_info).unwrap();
+
+        let typescript_names = resolve_typescript_names(&server_info.tools);
+        assert_eq!(
+            typescript_names[0], "index_2",
+            "a tool named `index` must be disambiguated, not collide with the fixed index.ts"
+        );
+
+        let tool_file = code
+            .files
+            .iter()
+            .find(|f| f.path == "index_2.ts")
+            .expect("the tool's own file must exist at its disambiguated path");
+        assert!(
+            tool_file.content.contains("A tool literally named index"),
+            "the tool's own generated content must not have been lost: {}",
+            tool_file.content
+        );
+
+        let index_file = code
+            .files
+            .iter()
+            .find(|f| f.path == "index.ts")
+            .expect("the fixed index.ts re-export must still exist");
+        assert!(
+            index_file.content.contains("index_2"),
+            "index.ts must re-export the tool's disambiguated identifier: {}",
+            index_file.content
+        );
+        assert!(
+            index_file
+                .content
+                .contains("export { callMCPTool } from './_runtime/mcp-bridge.ts';"),
+            "index.ts must be the fixed re-export (with the runtime bridge re-export), \
+             not the overwritten tool file: {}",
+            index_file.content
+        );
+
+        // Exactly one file at each path: the collision never happened.
+        assert_eq!(
+            code.files.iter().filter(|f| f.path == "index.ts").count(),
+            1
+        );
+        assert_eq!(
+            code.files.iter().filter(|f| f.path == "index_2.ts").count(),
+            1
+        );
+    }
+
+    /// Regression guard for #312 S1: `RESERVED_OUTPUT_NAMES` membership alone only catches an
+    /// exact-case match, but `index.ts`/`Index.ts` are the same file on a case-insensitive
+    /// filesystem (macOS APFS, Windows NTFS by default — this project's primary dev platforms).
+    /// A tool named `Index` must be disambiguated the same way a tool literally named `index`
+    /// is, via `disambiguate_output_filename`'s case-insensitive collision check.
+    #[test]
+    fn test_tool_named_index_with_different_case_is_disambiguated() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = ServerInfo {
+            id: ServerId::new("test-server"),
+            name: "Test Server".to_string(),
+            version: "1.0.0".to_string(),
+            tools: vec![ToolInfo {
+                name: ToolName::new("Index"),
+                description: "A tool literally named Index".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+                output_schema: None,
+            }],
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+        };
+
+        let code = generator.generate(&server_info).unwrap();
+
+        let typescript_names = resolve_typescript_names(&server_info.tools);
+        assert_eq!(
+            typescript_names[0], "Index_2",
+            "a tool named `Index` must be disambiguated case-insensitively against the \
+             reserved `index` output name"
+        );
+
+        assert!(
+            code.files.iter().any(|f| f.path == "Index_2.ts"),
+            "the tool's own file must exist at its disambiguated path: {:?}",
+            code.files.iter().map(|f| &f.path).collect::<Vec<_>>()
+        );
+        // Exactly one file at each path: on a case-insensitive filesystem, "index.ts" and
+        // "Index.ts" would otherwise be the same file.
+        assert_eq!(
+            code.files.iter().filter(|f| f.path == "index.ts").count(),
+            1
+        );
+        assert!(!code.files.iter().any(|f| f.path == "Index.ts"));
+    }
+
+    /// Regression guard for #312 N2: a server exposing BOTH `Index` and `index` as distinct
+    /// tools must not have their resolved output filenames collide case-insensitively with
+    /// EACH OTHER, not just with the fixed `index.ts`. Both are already disambiguated away
+    /// from the reserved `index` name; they must additionally be disambiguated from each
+    /// other, since `Index_2`/`index_2` would themselves collide case-insensitively.
+    #[test]
+    fn test_tools_named_index_and_capital_index_do_not_collide_with_each_other() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = ServerInfo {
+            id: ServerId::new("test-server"),
+            name: "Test Server".to_string(),
+            version: "1.0.0".to_string(),
+            tools: vec![
+                ToolInfo {
+                    name: ToolName::new("Index"),
+                    description: "Capitalized".to_string(),
+                    input_schema: json!({"type": "object", "properties": {}, "required": []}),
+                    output_schema: None,
+                },
+                ToolInfo {
+                    name: ToolName::new("index"),
+                    description: "Lowercase".to_string(),
+                    input_schema: json!({"type": "object", "properties": {}, "required": []}),
+                    output_schema: None,
+                },
+            ],
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+        };
+
+        let code = generator.generate(&server_info).unwrap();
+        let typescript_names = resolve_typescript_names(&server_info.tools);
+
+        assert_ne!(
+            typescript_names[0].to_ascii_lowercase(),
+            typescript_names[1].to_ascii_lowercase(),
+            "the two tools' resolved names must not collide case-insensitively: {typescript_names:?}"
+        );
+
+        let paths: Vec<_> = code.files.iter().map(|f| f.path.as_str()).collect();
+        let mut lowercased_paths: Vec<String> =
+            paths.iter().map(|p| p.to_ascii_lowercase()).collect();
+        let before = lowercased_paths.len();
+        lowercased_paths.sort();
+        lowercased_paths.dedup();
+        assert_eq!(
+            lowercased_paths.len(),
+            before,
+            "no two generated file paths may be case-insensitive duplicates of each other: {paths:?}"
+        );
+    }
+
+    /// Regression guard for #312 N2's side effect: two DIFFERENT tools whose sanitized names
+    /// differ only by case (not involving the reserved `index` name at all) must also be
+    /// disambiguated from each other, since a case-insensitive filesystem would otherwise merge
+    /// their output files exactly like the `Index`/`index` case.
+    #[test]
+    fn test_tools_differing_only_by_case_are_disambiguated_from_each_other() {
+        let server_info = ServerInfo {
+            id: ServerId::new("test-server"),
+            name: "Test Server".to_string(),
+            version: "1.0.0".to_string(),
+            tools: vec![
+                ToolInfo {
+                    name: ToolName::new("get_user"),
+                    description: "snake_case".to_string(),
+                    input_schema: json!({"type": "object", "properties": {}, "required": []}),
+                    output_schema: None,
+                },
+                ToolInfo {
+                    name: ToolName::new("GetUser"),
+                    description: "PascalCase".to_string(),
+                    input_schema: json!({"type": "object", "properties": {}, "required": []}),
+                    output_schema: None,
+                },
+            ],
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+        };
+
+        let typescript_names = resolve_typescript_names(&server_info.tools);
+
+        assert_eq!(typescript_names[0], "getUser");
+        assert_ne!(
+            typescript_names[0].to_ascii_lowercase(),
+            typescript_names[1].to_ascii_lowercase(),
+            "getUser/GetUser must not collide case-insensitively: {typescript_names:?}"
+        );
     }
 
     #[test]

--- a/crates/mcp-core/src/error.rs
+++ b/crates/mcp-core/src/error.rs
@@ -126,6 +126,18 @@ pub enum Error {
         /// The configured maximum allowed for this resource.
         limit: usize,
     },
+
+    /// A generated file's path collides with one already present in the same output.
+    ///
+    /// Raised when adding a file to a generated-code collection would silently overwrite
+    /// a file already added at the same path — e.g. a tool name that sanitizes to a
+    /// generator's own reserved output filename (like `index`) slipping past name
+    /// disambiguation and colliding with the fixed `index.ts` re-export (issue #312).
+    #[error("duplicate generated file path: {path}")]
+    DuplicateGeneratedFilePath {
+        /// The path that was already present when a second file was added at it.
+        path: String,
+    },
 }
 
 impl Error {
@@ -237,6 +249,23 @@ impl Error {
     pub const fn is_resource_limit_exceeded(&self) -> bool {
         matches!(self, Self::ResourceLimitExceeded { .. })
     }
+
+    /// Returns `true` if this is a duplicate-generated-file-path error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::Error;
+    ///
+    /// let err = Error::DuplicateGeneratedFilePath {
+    ///     path: "index.ts".to_string(),
+    /// };
+    /// assert!(err.is_duplicate_generated_file_path());
+    /// ```
+    #[must_use]
+    pub const fn is_duplicate_generated_file_path(&self) -> bool {
+        matches!(self, Self::DuplicateGeneratedFilePath { .. })
+    }
 }
 
 /// Result type alias for MCP operations.
@@ -319,6 +348,17 @@ mod tests {
         assert!(display.contains("tool count"));
         assert!(display.contains("1500"));
         assert!(display.contains("1000"));
+    }
+
+    #[test]
+    fn test_duplicate_generated_file_path_detection() {
+        let err = Error::DuplicateGeneratedFilePath {
+            path: "index.ts".to_string(),
+        };
+        assert!(err.is_duplicate_generated_file_path());
+        assert!(!err.is_resource_limit_exceeded());
+        let display = format!("{err}");
+        assert!(display.contains("index.ts"));
     }
 
     #[test]

--- a/crates/mcp-files/src/builder.rs
+++ b/crates/mcp-files/src/builder.rs
@@ -56,7 +56,8 @@ use std::path::{Path, PathBuf};
 /// code.add_file(GeneratedFile {
 ///     path: "manifest.json".to_string(),
 ///     content: "{}".to_string(),
-/// });
+/// })
+/// .unwrap();
 ///
 /// let vfs = FilesBuilder::from_generated_code(code, "/mcp-tools/servers/test")
 ///     .build()
@@ -107,7 +108,8 @@ impl FilesBuilder {
     /// code.add_file(GeneratedFile {
     ///     path: "types.ts".to_string(),
     ///     content: "export type Params = {};".to_string(),
-    /// });
+    /// })
+    /// .unwrap();
     ///
     /// let vfs = FilesBuilder::from_generated_code(code, "/mcp-tools/servers/test")
     ///     .build()
@@ -500,11 +502,13 @@ mod tests {
         code.add_file(GeneratedFile {
             path: "manifest.json".to_string(),
             content: "{}".to_string(),
-        });
+        })
+        .unwrap();
         code.add_file(GeneratedFile {
             path: "types.ts".to_string(),
             content: "export {};".to_string(),
-        });
+        })
+        .unwrap();
 
         let vfs = FilesBuilder::from_generated_code(code, "/mcp-tools/servers/test")
             .build()
@@ -521,7 +525,8 @@ mod tests {
         code.add_file(GeneratedFile {
             path: "tools/sendMessage.ts".to_string(),
             content: "export function sendMessage() {}".to_string(),
-        });
+        })
+        .unwrap();
 
         let vfs = FilesBuilder::from_generated_code(code, "/mcp-tools/servers/test")
             .build()
@@ -572,7 +577,8 @@ mod tests {
         code.add_file(GeneratedFile {
             path: "generated.ts".to_string(),
             content: "// generated".to_string(),
-        });
+        })
+        .unwrap();
 
         let vfs = FilesBuilder::from_generated_code(code, "/mcp-tools/servers/test")
             .add_file("/mcp-tools/servers/test/manual.ts", "// manual")
@@ -953,11 +959,13 @@ mod tests {
         code.add_file(GeneratedFile {
             path: "index.ts".to_string(),
             content: "export {};".to_string(),
-        });
+        })
+        .unwrap();
         code.add_file(GeneratedFile {
             path: "tools/create.ts".to_string(),
             content: "export function create() {}".to_string(),
-        });
+        })
+        .unwrap();
 
         let vfs = FilesBuilder::from_generated_code(code, "/github")
             .build_and_export(temp_dir.path())

--- a/crates/mcp-files/src/lib.rs
+++ b/crates/mcp-files/src/lib.rs
@@ -45,11 +45,13 @@
 //! code.add_file(GeneratedFile {
 //!     path: "manifest.json".to_string(),
 //!     content: r#"{"version": "1.0"}"#.to_string(),
-//! });
+//! })
+//! .unwrap();
 //! code.add_file(GeneratedFile {
 //!     path: "tools/sendMessage.ts".to_string(),
 //!     content: "export function sendMessage() {}".to_string(),
-//! });
+//! })
+//! .unwrap();
 //!
 //! let vfs = FilesBuilder::from_generated_code(code, "/mcp-tools/servers/github")
 //!     .build()

--- a/crates/mcp-files/tests/integration_filesystem.rs
+++ b/crates/mcp-files/tests/integration_filesystem.rs
@@ -60,11 +60,13 @@ fn test_meta_json_sidecar_survives_export() {
     code.add_file(GeneratedFile {
         path: "index.ts".to_string(),
         content: "export {};".to_string(),
-    });
+    })
+    .unwrap();
     code.add_file(GeneratedFile {
         path: "_meta.json".to_string(),
         content: r#"{"schema_version":1,"server_id":"github"}"#.to_string(),
-    });
+    })
+    .unwrap();
 
     let vfs = FilesBuilder::from_generated_code(code, "/github")
         .build_and_export(temp_dir.path())
@@ -91,7 +93,8 @@ fn test_export_github_server_structure() {
     code.add_file(GeneratedFile {
         path: "index.ts".to_string(),
         content: "// GitHub MCP Server\nexport * from './tools';".to_string(),
-    });
+    })
+    .unwrap();
 
     // Simulate 30 GitHub tools
     let tool_names = vec![
@@ -131,14 +134,16 @@ fn test_export_github_server_structure() {
         code.add_file(GeneratedFile {
             path: format!("tools/{tool}.ts"),
             content: format!("export function {tool}(params: any) {{ return {{}}; }}"),
-        });
+        })
+        .unwrap();
     }
 
     // Add manifest
     code.add_file(GeneratedFile {
         path: "manifest.json".to_string(),
         content: format!(r#"{{"version": "1.0.0", "tools": {}}}"#, tool_names.len()),
-    });
+    })
+    .unwrap();
 
     // Export to filesystem
     let vfs = FilesBuilder::from_generated_code(code, "/github")
@@ -175,11 +180,13 @@ fn test_export_multiple_servers() {
         code.add_file(GeneratedFile {
             path: "createIssue.ts".to_string(),
             content: "export function createIssue() {}".to_string(),
-        });
+        })
+        .unwrap();
         code.add_file(GeneratedFile {
             path: "getIssue.ts".to_string(),
             content: "export function getIssue() {}".to_string(),
-        });
+        })
+        .unwrap();
         code
     };
 
@@ -189,11 +196,13 @@ fn test_export_multiple_servers() {
         code.add_file(GeneratedFile {
             path: "sendMessage.ts".to_string(),
             content: "export function sendMessage() {}".to_string(),
-        });
+        })
+        .unwrap();
         code.add_file(GeneratedFile {
             path: "listChannels.ts".to_string(),
             content: "export function listChannels() {}".to_string(),
-        });
+        })
+        .unwrap();
         code
     };
 
@@ -360,19 +369,22 @@ fn test_export_typescript_module() {
         content: r"export * from './types';
 export * from './tools';"
             .to_string(),
-    });
+    })
+    .unwrap();
 
     code.add_file(GeneratedFile {
         path: "types/index.ts".to_string(),
         content: "export type ToolParams = { id: number };".to_string(),
-    });
+    })
+    .unwrap();
 
     code.add_file(GeneratedFile {
         path: "tools/create.ts".to_string(),
         content: r"import type { ToolParams } from '../types';
 export function create(params: ToolParams) { return params.id; }"
             .to_string(),
-    });
+    })
+    .unwrap();
 
     let vfs = FilesBuilder::from_generated_code(code, "/module")
         .build_and_export(temp_dir.path())

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -502,40 +502,60 @@ impl GeneratorService {
 
         // Validate categorized tools match introspected tools.
         //
-        // M1: `pending.server_info.tools[].name` is raw — it's the actual
-        // introspection data, kept unsanitized because it's also used to build the
-        // `.ts` files themselves. But Claude never sees these raw names: it only
-        // ever saw the *sanitized* copies `build_introspected_summaries` returned
-        // from `introspect_server` (issue #292), so it can only ever echo back a
-        // sanitized name. Comparing the echoed name against the raw name would fail
-        // closed on any name containing a control character or line terminator
-        // (`"Tool 'X' not found in introspected tools"`) — not a security bug, but a
-        // misleading error for a well-behaved caller. Applying the identical
-        // sanitization here keeps this set in sync with what Claude actually saw.
-        let introspected_names: HashSet<String> = pending
-            .server_info
-            .tools
-            .iter()
-            .map(|t| sanitize_untrusted_text(t.name.as_str(), MAX_UNTRUSTED_FIELD_LEN))
+        // #307: `pending.server_info.tools[].name` is raw — it's the actual introspection
+        // data, kept unsanitized because it's also used to build the `.ts` files themselves.
+        // Claude never sees these raw names directly: it only ever saw a *display* form of
+        // each one, produced by `build_introspected_summaries` + `wrap_introspect_result`
+        // from `introspect_server` (issues #292, #307). Matching a `categorized_tools` entry
+        // against what was introspected must key off that display form, while codegen
+        // (`generate_with_categorization`, below) must key off the raw name it actually looks
+        // tools up by — conflating the two by using the echoed name as both the match key and
+        // the codegen key desynced categorization from any tool name containing a control
+        // character, line terminator, or `&`/`<`/`>`.
+        //
+        // S2: a raw name can legitimately be echoed back in either of [`display_forms`]'s two
+        // forms (the literal escaped text, or the same text with entities decoded), so both are
+        // accepted as keys for the same raw tool.
+        //
+        // S3: if two DISTINCT raw tool names ever produce the same display key (via either
+        // form), which raw tool a caller meant by that key is genuinely ambiguous. A plain
+        // `HashMap::collect` would silently keep only the last one, misattributing one tool's
+        // categorization to a different tool's `_meta.json` entry with no error surfaced.
+        // Instead, `owners` tracks every raw name that could produce each key, and any key with
+        // more than one distinct owner is dropped from `display_to_raw` entirely, so a caller
+        // trying to use it hits the "not found" branch below explicitly.
+        let mut display_key_owners: HashMap<String, HashSet<&str>> = HashMap::new();
+        for tool in &pending.server_info.tools {
+            let raw = tool.name.as_str();
+            for key in display_forms(raw) {
+                display_key_owners.entry(key).or_default().insert(raw);
+            }
+        }
+        let display_to_raw: HashMap<String, &str> = display_key_owners
+            .into_iter()
+            .filter_map(|(key, owners)| {
+                if owners.len() == 1 {
+                    owners.into_iter().next().map(|raw| (key, raw))
+                } else {
+                    None
+                }
+            })
             .collect();
 
-        // A legitimate call can never submit more entries than there are
-        // introspected tools: every name must be a member of
-        // `introspected_names` (checked below) and duplicates are rejected,
-        // so the entry count is bounded by that set's size. Reject early,
-        // before any per-entry validation, HashMap insertion, or codegen
-        // work (CWE-400 - see issue #197).
+        // A legitimate call can never submit more entries than there are introspected tools.
+        // Reject early, before any per-entry validation, HashMap insertion, or codegen work
+        // (CWE-400 - see issue #197).
         //
-        // `introspected_names.len()` alone is not a trustworthy ceiling: it
-        // comes from whatever tool count the *target* MCP server reported to
-        // `introspect_server`, so a hostile or buggy target could inflate it
-        // arbitrarily. `MAX_TOOL_FILES` is the same per-server tool-count
-        // ceiling `generate_skill` already enforces (via
-        // `mcp_execution_skill::scan_tools_directory`), so reusing it here
-        // keeps the two stages consistent - otherwise this call could
-        // happily generate more tool files than `generate_skill` will later
-        // accept.
-        let max_allowed_tools = introspected_names.len().min(MAX_TOOL_FILES);
+        // Bounded by the true introspected tool count (`pending.server_info.tools.len()`), not
+        // `display_to_raw.len()`: S2 means a single raw tool can legitimately own two display
+        // keys, and S3 means an ambiguous key is excluded from the map entirely — neither of
+        // those should shrink or inflate this bound. `MAX_TOOL_FILES` is the same per-server
+        // tool-count ceiling `generate_skill` already enforces (via
+        // `mcp_execution_skill::scan_tools_directory`), so reusing it here keeps the two stages
+        // consistent - otherwise this call could happily generate more tool files than
+        // `generate_skill` will later accept.
+        let introspected_tool_count = pending.server_info.tools.len();
+        let max_allowed_tools = introspected_tool_count.min(MAX_TOOL_FILES);
         if params.categorized_tools.len() > max_allowed_tools {
             return Err(McpError::invalid_params(
                 format!(
@@ -544,26 +564,47 @@ impl GeneratorService {
                      duplicates are not allowed)",
                     params.categorized_tools.len(),
                     max_allowed_tools,
-                    introspected_names.len(),
+                    introspected_tool_count,
                     MAX_TOOL_FILES,
                 ),
                 None,
             ));
         }
 
-        let mut seen_names: HashSet<&str> = HashSet::with_capacity(params.categorized_tools.len());
-        for cat_tool in &params.categorized_tools {
-            if !introspected_names.contains(cat_tool.name.as_str()) {
-                return Err(McpError::invalid_params(
-                    format!("Tool '{}' not found in introspected tools", cat_tool.name),
-                    None,
-                ));
-            }
+        // Validate each entry and build the codegen categorization map in a single pass,
+        // resolving `cat_tool.name` to its raw tool name once via `display_to_raw` (issue #307
+        // M3) — a prior version re-derived the same lookup in a second pass, relying on an
+        // `expect()` to justify why it couldn't fail there; doing it once removes that panic
+        // path by construction instead of just asserting it unreachable.
+        let tool_count = params.categorized_tools.len();
+        // Keyed by RESOLVED RAW NAME, not by `cat_tool.name` (the submitted display key):
+        // `display_forms` (S2) deliberately lets one raw tool own two distinct display keys
+        // (its escaped and unescaped forms), so two entries with different `name` strings can
+        // still resolve to the same introspected tool. Deduping on the submitted string would
+        // miss that case entirely, letting the second entry silently overwrite the first's
+        // categorization in the map below with no error surfaced (issue #307 N1).
+        let mut seen_raw_names: HashSet<&str> = HashSet::with_capacity(tool_count);
+        let mut categorization: HashMap<String, &CategorizedTool> =
+            HashMap::with_capacity(tool_count);
+        let mut categories: HashMap<String, usize> = HashMap::with_capacity(tool_count);
 
-            if !seen_names.insert(cat_tool.name.as_str()) {
+        for cat_tool in &params.categorized_tools {
+            let Some(&raw_name) = display_to_raw.get(cat_tool.name.as_str()) else {
                 return Err(McpError::invalid_params(
                     format!(
-                        "Tool '{}' appears more than once in categorized_tools",
+                        "Tool '{}' not found in introspected tools (or its sanitized display \
+                         name is ambiguous between two or more introspected tools)",
+                        cat_tool.name
+                    ),
+                    None,
+                ));
+            };
+
+            if !seen_raw_names.insert(raw_name) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "Tool '{}' appears more than once in categorized_tools (resolves to \
+                         the same introspected tool as an earlier entry)",
                         cat_tool.name
                     ),
                     None,
@@ -594,17 +635,9 @@ impl GeneratorService {
                 &cat_tool.short_description,
                 MAX_SHORT_DESCRIPTION_LEN,
             )?;
-        }
 
-        // Build categorization map and category stats in single pass (avoid double iteration)
-        let tool_count = params.categorized_tools.len();
-        let mut categorization: HashMap<String, &CategorizedTool> =
-            HashMap::with_capacity(tool_count);
-        let mut categories: HashMap<String, usize> = HashMap::with_capacity(tool_count);
-
-        for tool in &params.categorized_tools {
-            categorization.insert(tool.name.clone(), tool);
-            *categories.entry(tool.category.clone()).or_default() += 1;
+            categorization.insert(raw_name.to_string(), cat_tool);
+            *categories.entry(cat_tool.category.clone()).or_default() += 1;
         }
 
         // Generate code with categorization
@@ -1238,6 +1271,54 @@ fn wrap_introspect_result(json: &str) -> String {
          parameter names, and the server name)",
         json,
     )
+}
+
+/// Computes the escaped form of `raw_name` that `introspect_server` literally shows Claude for
+/// a tool's `name` field: [`sanitize_untrusted_text`] followed by the same `&`/`<`/`>`
+/// entity-escaping [`wrap_untrusted_block`] applies afterward to the whole serialized response
+/// (see its escaping-order doc comment).
+///
+/// `build_introspected_summaries` deliberately does *not* apply this escaping itself — it only
+/// sanitizes control characters — because `wrap_introspect_result` escapes the entire
+/// already-serialized JSON body exactly once; escaping per-field here as well would double-escape
+/// `&` into `&amp;amp;`. This function exists purely so `save_categorized_tools` can compute,
+/// independently, the identical transformation Claude actually saw, without touching that
+/// production code path.
+///
+/// This is only one of two forms `save_categorized_tools` accepts as a valid echo of a tool
+/// name — see [`display_forms`] and issue #307 S2.
+fn display_tool_name(raw_name: &str) -> String {
+    sanitize_untrusted_text(raw_name, MAX_UNTRUSTED_FIELD_LEN)
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Returns every display-form key `raw_name` might plausibly be echoed back as by Claude
+/// (issue #307 S2).
+///
+/// [`wrap_untrusted_block`]'s own preamble tells its LLM reader that the block's `&`/`<`/`>`
+/// characters "have been escaped as `&lt;`/`&gt;`" — an explicit invitation to decode them back
+/// to the original character, not just an opaque transform. So a well-behaved caller may
+/// legitimately echo back either [`display_tool_name`]'s escaped form (what was literally shown)
+/// or the sanitize-only form with entities decoded (what the escaping represents). Treating only
+/// the escaped form as valid — the pre-issue-307-S2 behavior — hard-rejected the second,
+/// previously-accepted case with an unrecoverable "not found" error.
+///
+/// Returns a single-element vector when `raw_name` contains no `&`/`<`/`>` (the two forms
+/// coincide), so callers can iterate the result uniformly without special-casing.
+///
+/// Used by `save_categorized_tools` to build a display-name-to-raw-name lookup that accepts
+/// either form for a given raw tool, while still detecting when two *different* raw tool names
+/// collide on the same key (issue #307 S3) — see its call site for the ambiguity handling.
+fn display_forms(raw_name: &str) -> Vec<String> {
+    let escaped = display_tool_name(raw_name);
+    let unescaped = sanitize_untrusted_text(raw_name, MAX_UNTRUSTED_FIELD_LEN);
+    if escaped == unescaped {
+        vec![escaped]
+    } else {
+        vec![escaped, unescaped]
+    }
 }
 
 /// Extracts parameter names from a JSON Schema.
@@ -2923,6 +3004,416 @@ mod tests {
             result.is_ok(),
             "the sanitized name Claude actually saw must be accepted: {:?}",
             result.err()
+        );
+    }
+
+    /// Regression guard for #307: `save_categorized_tools` must not just accept a
+    /// `categorized_tools` entry keyed by the *display* form Claude was shown
+    /// (M1's fix, above) — the categorization it carries must actually reach the
+    /// generated output, keyed by the tool's RAW name. A prior version built the
+    /// codegen categorization map keyed by the echoed display name, which desynced
+    /// from `ProgressiveGenerator`'s raw-name lookup for any tool name containing a
+    /// control character, line terminator, or `&`/`<`/`>`.
+    #[tokio::test]
+    async fn test_save_categorized_tools_preserves_categorization_for_control_character_tool_name()
+    {
+        use mcp_execution_core::metadata::{METADATA_FILE_NAME, ServerMetadata};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: ServerId::new("ctrl-char-server"),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![ToolInfo {
+                name: ToolName::new("evil\ntool"),
+                description: "Test tool".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                output_schema: None,
+            }],
+        };
+        let pending = PendingGeneration::new(
+            ServerId::new("ctrl-char-server"),
+            server_info,
+            ServerConfig::builder()
+                .command("echo".to_string())
+                .build()
+                .unwrap(),
+            None,
+            &SystemClock,
+        );
+        let session_id = service.state.store(pending).await.unwrap();
+
+        // The display name Claude actually saw for "evil\ntool" (control character
+        // flattened to a space).
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("evil tool")],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+        let content = result.expect("the display name Claude saw must be accepted");
+        let text = content.content[0].as_text().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+        let output_dir = PathBuf::from(parsed["output_dir"].as_str().unwrap());
+
+        let meta_content = std::fs::read_to_string(output_dir.join(METADATA_FILE_NAME)).unwrap();
+        let meta: ServerMetadata = serde_json::from_str(&meta_content).unwrap();
+
+        assert_eq!(meta.tools.len(), 1);
+        let tool_meta = &meta.tools[0];
+        // The sidecar's `name` field must carry the RAW tool name, not the display form.
+        assert_eq!(tool_meta.name, "evil\ntool");
+        assert_eq!(
+            tool_meta.category,
+            Some("cat".to_string()),
+            "categorization submitted under the display name must reach the raw-named \
+             tool's metadata, not be silently dropped: {meta:?}"
+        );
+        assert_eq!(tool_meta.keywords, vec!["kw".to_string()]);
+    }
+
+    /// Regression guard for #307's second gap: `introspect_server`'s response is
+    /// HTML/XML-entity-escaped (`&`/`<`/`>`) as part of delimiting untrusted MCP
+    /// metadata (issue #292/#310), independent of control-character sanitization.
+    /// A tool name containing `&` must round-trip its categorization the same way.
+    #[tokio::test]
+    async fn test_save_categorized_tools_preserves_categorization_for_ampersand_tool_name() {
+        use mcp_execution_core::metadata::{METADATA_FILE_NAME, ServerMetadata};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: ServerId::new("ampersand-server"),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![ToolInfo {
+                name: ToolName::new("tool&name"),
+                description: "Test tool".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                output_schema: None,
+            }],
+        };
+        let pending = PendingGeneration::new(
+            ServerId::new("ampersand-server"),
+            server_info,
+            ServerConfig::builder()
+                .command("echo".to_string())
+                .build()
+                .unwrap(),
+            None,
+            &SystemClock,
+        );
+        let session_id = service.state.store(pending).await.unwrap();
+
+        // The display name Claude actually saw for "tool&name": `&` entity-escaped by
+        // `wrap_introspect_result`.
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("tool&amp;name")],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+        let content = result.expect("the escaped display name Claude saw must be accepted");
+        let text = content.content[0].as_text().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+        let output_dir = PathBuf::from(parsed["output_dir"].as_str().unwrap());
+
+        let meta_content = std::fs::read_to_string(output_dir.join(METADATA_FILE_NAME)).unwrap();
+        let meta: ServerMetadata = serde_json::from_str(&meta_content).unwrap();
+
+        assert_eq!(meta.tools.len(), 1);
+        let tool_meta = &meta.tools[0];
+        assert_eq!(tool_meta.name, "tool&name");
+        assert_eq!(
+            tool_meta.category,
+            Some("cat".to_string()),
+            "categorization submitted under the escaped display name must reach the \
+             raw-named tool's metadata: {meta:?}"
+        );
+    }
+
+    /// Regression guard for #307's second gap, symmetric with the `&` case above: `<`
+    /// and `>` are entity-escaped by `wrap_introspect_result` independently of `&`
+    /// (`.replace('&', ...)` runs first, then `<`/`>`), so a tool name containing them
+    /// must round-trip its categorization the same way.
+    #[tokio::test]
+    async fn test_save_categorized_tools_preserves_categorization_for_angle_bracket_tool_name() {
+        use mcp_execution_core::metadata::{METADATA_FILE_NAME, ServerMetadata};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: ServerId::new("angle-bracket-server"),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![ToolInfo {
+                name: ToolName::new("tool<name>end"),
+                description: "Test tool".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                output_schema: None,
+            }],
+        };
+        let pending = PendingGeneration::new(
+            ServerId::new("angle-bracket-server"),
+            server_info,
+            ServerConfig::builder()
+                .command("echo".to_string())
+                .build()
+                .unwrap(),
+            None,
+            &SystemClock,
+        );
+        let session_id = service.state.store(pending).await.unwrap();
+
+        // The display name Claude actually saw for "tool<name>end": `<`/`>`
+        // entity-escaped by `wrap_introspect_result`.
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("tool&lt;name&gt;end")],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+        let content = result.expect("the escaped display name Claude saw must be accepted");
+        let text = content.content[0].as_text().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+        let output_dir = PathBuf::from(parsed["output_dir"].as_str().unwrap());
+
+        let meta_content = std::fs::read_to_string(output_dir.join(METADATA_FILE_NAME)).unwrap();
+        let meta: ServerMetadata = serde_json::from_str(&meta_content).unwrap();
+
+        assert_eq!(meta.tools.len(), 1);
+        let tool_meta = &meta.tools[0];
+        assert_eq!(tool_meta.name, "tool<name>end");
+        assert_eq!(
+            tool_meta.category,
+            Some("cat".to_string()),
+            "categorization submitted under the escaped display name must reach the \
+             raw-named tool's metadata: {meta:?}"
+        );
+    }
+
+    /// Regression guard for #307 S2: `wrap_untrusted_block`'s own preamble tells its LLM
+    /// reader that `<`/`>` "have been escaped as `&lt;`/`&gt;`" — an explicit invitation to
+    /// decode them back, not just an opaque transform. A caller that echoes the *decoded*
+    /// literal form (`a<b`) instead of the literally-shown escaped form (`a&lt;b`) must still
+    /// be accepted: the pre-#307-S2 fix only recognized the escaped form and hard-rejected
+    /// this previously-working case with an unrecoverable "not found" error.
+    #[tokio::test]
+    async fn test_save_categorized_tools_accepts_unescaped_form_of_angle_bracket_tool_name() {
+        use mcp_execution_core::metadata::{METADATA_FILE_NAME, ServerMetadata};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: ServerId::new("decoded-form-server"),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![ToolInfo {
+                name: ToolName::new("a<b"),
+                description: "Test tool".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                output_schema: None,
+            }],
+        };
+        let pending = PendingGeneration::new(
+            ServerId::new("decoded-form-server"),
+            server_info,
+            ServerConfig::builder()
+                .command("echo".to_string())
+                .build()
+                .unwrap(),
+            None,
+            &SystemClock,
+        );
+        let session_id = service.state.store(pending).await.unwrap();
+
+        // The DECODED literal form, not the escaped form ("a&lt;b") Claude was literally
+        // shown — a legitimate echo per `wrap_untrusted_block`'s own preamble.
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("a<b")],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+        let content =
+            result.expect("the decoded literal form must be accepted, not just the escaped form");
+        let text = content.content[0].as_text().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+        let output_dir = PathBuf::from(parsed["output_dir"].as_str().unwrap());
+
+        let meta_content = std::fs::read_to_string(output_dir.join(METADATA_FILE_NAME)).unwrap();
+        let meta: ServerMetadata = serde_json::from_str(&meta_content).unwrap();
+
+        assert_eq!(meta.tools.len(), 1);
+        let tool_meta = &meta.tools[0];
+        assert_eq!(tool_meta.name, "a<b");
+        assert_eq!(tool_meta.category, Some("cat".to_string()));
+    }
+
+    /// Regression guard for #307 S3: two distinct raw tool names that sanitize to the same
+    /// display form must not silently misattribute categorization to the wrong tool.
+    /// `evil\ntool` (control character flattened to a space) and `evil tool` (already that
+    /// exact text) both produce the display key `"evil tool"`. Attempting to categorize using
+    /// that ambiguous shared key must fail explicitly instead of a `HashMap`'s last-write-wins
+    /// silently resolving it to whichever raw tool happened to be processed last.
+    #[tokio::test]
+    async fn test_save_categorized_tools_rejects_ambiguous_display_name_instead_of_misattributing()
+    {
+        let service = GeneratorService::new();
+
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: ServerId::new("ambiguous-server"),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![
+                ToolInfo {
+                    name: ToolName::new("evil\ntool"),
+                    description: "First tool".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    output_schema: None,
+                },
+                ToolInfo {
+                    name: ToolName::new("evil tool"),
+                    description: "Second tool".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    output_schema: None,
+                },
+            ],
+        };
+        let pending = PendingGeneration::new(
+            ServerId::new("ambiguous-server"),
+            server_info,
+            ServerConfig::builder()
+                .command("echo".to_string())
+                .build()
+                .unwrap(),
+            None,
+            &SystemClock,
+        );
+        let session_id = service.state.store(pending).await.unwrap();
+
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("evil tool")],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+
+        let err = result.expect_err(
+            "an ambiguous display name shared by two distinct raw tools must be rejected, \
+             not silently resolved to one of them",
+        );
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("not found") || err.message.contains("ambiguous"),
+            "error message should explain the ambiguity: {}",
+            err.message
+        );
+    }
+
+    /// Regression guard for #307 N1: `display_forms` (S2) deliberately lets one raw tool own
+    /// two distinct display keys (its escaped and unescaped forms). A caller submitting BOTH
+    /// forms as separate `categorized_tools` entries for the SAME raw tool must be rejected as
+    /// a duplicate — deduping on the submitted display string (`cat_tool.name`) would miss this,
+    /// since `"a&lt;b"` and `"a<b"` are different strings that both resolve to raw tool `a<b`,
+    /// letting the second entry silently overwrite the first's categorization with no error.
+    #[tokio::test]
+    async fn test_save_categorized_tools_rejects_duplicate_via_two_display_forms_of_same_raw_name()
+    {
+        let service = GeneratorService::new();
+
+        let server_info = mcp_execution_introspector::ServerInfo {
+            id: ServerId::new("dual-form-dup-server"),
+            name: "Test".to_string(),
+            version: "1.0.0".to_string(),
+            capabilities: ServerCapabilities {
+                supports_tools: true,
+                supports_resources: false,
+                supports_prompts: false,
+            },
+            tools: vec![
+                ToolInfo {
+                    name: ToolName::new("a<b"),
+                    description: "Angle bracket tool".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    output_schema: None,
+                },
+                ToolInfo {
+                    name: ToolName::new("plain"),
+                    description: "Plain tool".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    output_schema: None,
+                },
+            ],
+        };
+        let pending = PendingGeneration::new(
+            ServerId::new("dual-form-dup-server"),
+            server_info,
+            ServerConfig::builder()
+                .command("echo".to_string())
+                .build()
+                .unwrap(),
+            None,
+            &SystemClock,
+        );
+        let session_id = service.state.store(pending).await.unwrap();
+
+        // Both entries name the SAME raw tool (`a<b`) via its two different display forms —
+        // the escaped form Claude was literally shown, and the decoded literal form.
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("a&lt;b"), categorized_tool("a<b")],
+        };
+
+        let result = service.save_categorized_tools(Parameters(params)).await;
+
+        let err = result.expect_err(
+            "two entries resolving to the same raw tool via different display forms must be \
+             rejected as duplicates, not silently let the second overwrite the first",
+        );
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("more than once"),
+            "error message should explain the duplicate: {}",
+            err.message
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes #312: a tool whose sanitized TypeScript name collided with the generator's own fixed `index.ts` output (including case-insensitive variants like `Index`/`INDEX`, and on case-insensitive filesystems, two case-variant tool names colliding with each other) silently lost its generated code. `resolve_typescript_names` now disambiguates output filenames case-insensitively against reserved words, this generator's own reserved output names, and each other. `GeneratedCode::add_file` is now fallible, rejecting a duplicate path instead of silently overwriting.
- Fixes #307: `save_categorized_tools` built its codegen categorization map keyed by the sanitized/escaped display form of a tool name shown to Claude, while codegen looked entries up by the raw name — silently dropping category/keywords/short_description for any tool name containing a control character, line terminator, or `&`/`<`/`>`. Categorization now resolves to the raw tool name before lookup, accepts either the escaped or decoded display form a caller may echo back, rejects an ambiguous shared display form explicitly instead of silently misattributing, and dedups submissions by resolved raw name rather than submitted display string.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1019 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Regression tests added for both issues, including case-variant collisions, control-character and `&`/`<`/`>` tool names, and ambiguous-display-form rejection