### PR TITLE
fix(cli): sanitize server id derivation in generate to prevent path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deduping on the submitted string alone missed a caller submitting both forms for the same tool,
   letting the second entry silently overwrite the first's categorization (#307).
 
+- **`mcp-execution-cli`**: `generate`'s stdio transport derived its output directory name
+  directly from an unvalidated `ServerId` built from the raw stdio `command`, unlike its
+  http/sse sibling which already sanitized the URL first. Since `PathBuf::join` discards its
+  base entirely when the joined component is absolute, a `command` containing `..` segments or
+  an absolute path could write generated files outside `~/.claude/servers/`. This fix is scoped
+  to `generate`: the stdio path now routes through a new sanitizing helper
+  (`derive_server_id_from_path_or_name`) that strips path separators and `..` the same way the
+  URL-derivation helper already did; a `--name` override is instead validated with
+  `validate_server_id` and rejected outright when invalid rather than silently rewritten, since
+  it's meant to match an identity the caller already has in mind (typically an `mcp.json` key)
+  rather than being a free-form path; and, as a final invariant check right before the id is
+  joined onto the output directory, `generate` now validates the fully-resolved id regardless of
+  which of these paths produced it. `introspect`/`server`, which read the same `mcp.json` keys
+  but never turn them into a directory name, are unaffected (#311).
+- **`mcp-execution-files`**: `FileSystem::export_to_filesystem_with_options` gained an optional
+  confinement check (`ExportOptions::with_confine_to`) that rejects an export target whose
+  canonicalized parent directory resolves outside a caller-supplied base directory. Wired into
+  `mcp-execution-cli`'s `generate` as defense-in-depth alongside the fix above (#311).
 - **`mcp-execution-skill`**: `scan_tools_directory` discarded the real `io::Error` from both of
   its `canonicalize` calls (the server directory and the `_meta.json` sidecar) and mislabeled
   every failure as `DirectoryNotFound`/`MissingMetadata` respectively, even when the underlying

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -445,6 +445,15 @@ pub(crate) fn list_mcp_servers() -> Result<Vec<(String, McpServerEntry)>> {
 ///
 /// Returns an error if the config file is missing, malformed, or the named
 /// server is not present.
+///
+/// Deliberately does *not* validate `name` against
+/// [`validate_server_id`](mcp_execution_skill::validate_server_id): this
+/// function is shared by `introspect` and `server list`/`server show`, which
+/// have no need for `name` to be a filesystem-safe slug — only `generate`
+/// turns it into a directory name, so that check lives at `generate`'s own
+/// sink (`resolve_server_dir_name`) instead. Enforcing it here would hard-fail
+/// `introspect --from-config` for entirely legitimate `mcp.json` keys that
+/// aren't already `[a-z0-9-]` (e.g. `claude_ai_Gmail`).
 pub(crate) fn get_mcp_server(name: &str) -> Result<(ServerId, ServerConfig, McpServerEntry)> {
     let config = load_mcp_config()?;
 
@@ -821,7 +830,7 @@ pub(crate) fn build_server_config(
     discover_timeout_secs: Option<u64>,
 ) -> Result<(ServerId, ServerConfig)> {
     let server_id = match &transport {
-        TransportArgs::Stdio { command, .. } => ServerId::new(command),
+        TransportArgs::Stdio { command, .. } => derive_server_id_from_path_or_name(command),
         TransportArgs::Http { url, .. } | TransportArgs::Sse { url, .. } => {
             derive_server_id_from_url(url)
         }
@@ -960,39 +969,21 @@ pub(crate) fn resolve_server_config(raw: RawServerArgs) -> Result<(ServerId, Ser
     }
 }
 
-/// Derives a filesystem- and `validate_server_id`-safe [`ServerId`] slug from
-/// an Http/Sse transport URL.
+/// Lowercases `input`, collapses every run of characters outside
+/// `[a-z0-9-]` to a single `-`, and trims leading/trailing `-`, producing a
+/// filesystem- and `validate_server_id`-safe [`ServerId`] slug.
 ///
-/// Using the raw URL as the id (the previous behavior) is unsafe once Http/Sse
-/// configs can actually reach `generate`: the id flows into a directory name
-/// under `~/.claude/servers/{id}/` and into generated `tool.ts` literals, so a
-/// raw URL there breaks `mcp_execution_skill::validate_server_id`'s
-/// lowercase/digit/hyphen requirement, can smuggle `..` path segments through
-/// `PathBuf::join`, and — if the URL carries `user:token@host` userinfo —
-/// leaks the credential into a directory name and generated source.
-///
-/// Only `host` and `path` are used (never `userinfo`, so credentials are
-/// structurally excluded). The result is lowercased, every run of characters
-/// outside `[a-z0-9-]` collapses to a single `-`, and leading/trailing `-` are
-/// trimmed. Falls back to [`FALLBACK_SERVER_ID_SLUG`] if the URL fails to
-/// parse or the result would otherwise be empty (e.g. a bare `https://` URL
-/// with no host). The slug is truncated to fit `validate_server_id`'s length
-/// limit.
-fn derive_server_id_from_url(url: &str) -> ServerId {
-    // On parse failure, fall through to the empty-slug case below rather than
-    // sanitizing the raw string: a URL that failed to parse is about to be
-    // rejected by `validate_url_scheme`/the connection attempt anyway, and
-    // preserving any part of it here would defeat the credential-exclusion
-    // guarantee above for inputs like `https://user:pass@evil.com:99999/x`
-    // (a mistyped port is a realistic `Url::parse` failure, not just an
-    // adversarial one).
-    let host_and_path = Url::parse(url)
-        .ok()
-        .map(|parsed| format!("{}{}", parsed.host_str().unwrap_or_default(), parsed.path()))
-        .unwrap_or_default();
-
-    let mut slug = String::with_capacity(host_and_path.len());
-    for ch in host_and_path.chars() {
+/// Shared by [`derive_server_id_from_url`] (applied to a URL's host+path) and
+/// [`derive_server_id_from_path_or_name`] (applied directly to a stdio
+/// command or `--name` override). Since path separators (`/`, `\`) and `.`
+/// are outside the whitelist, they can never survive into the slug — a
+/// leading `/` or a `..` segment is dropped entirely rather than preserved,
+/// which is what makes this safe to use directly on untrusted filesystem-path-shaped
+/// input. Falls back to [`FALLBACK_SERVER_ID_SLUG`] if the result would
+/// otherwise be empty, and truncates to `MAX_SERVER_ID_LENGTH`.
+fn slugify(input: &str) -> ServerId {
+    let mut slug = String::with_capacity(input.len());
+    for ch in input.chars() {
         let lower = ch.to_ascii_lowercase();
         if lower.is_ascii_lowercase() || lower.is_ascii_digit() {
             slug.push(lower);
@@ -1010,6 +1001,52 @@ fn derive_server_id_from_url(url: &str) -> ServerId {
     } else {
         slug
     })
+}
+
+/// Derives a filesystem- and `validate_server_id`-safe [`ServerId`] slug from
+/// an Http/Sse transport URL.
+///
+/// Using the raw URL as the id (the previous behavior) is unsafe once Http/Sse
+/// configs can actually reach `generate`: the id flows into a directory name
+/// under `~/.claude/servers/{id}/` and into generated `tool.ts` literals, so a
+/// raw URL there breaks `mcp_execution_skill::validate_server_id`'s
+/// lowercase/digit/hyphen requirement, can smuggle `..` path segments through
+/// `PathBuf::join`, and — if the URL carries `user:token@host` userinfo —
+/// leaks the credential into a directory name and generated source.
+///
+/// Only `host` and `path` are used (never `userinfo`, so credentials are
+/// structurally excluded) before delegating to [`slugify`].
+fn derive_server_id_from_url(url: &str) -> ServerId {
+    // On parse failure, fall through to the empty-slug case below rather than
+    // sanitizing the raw string: a URL that failed to parse is about to be
+    // rejected by `validate_url_scheme`/the connection attempt anyway, and
+    // preserving any part of it here would defeat the credential-exclusion
+    // guarantee above for inputs like `https://user:pass@evil.com:99999/x`
+    // (a mistyped port is a realistic `Url::parse` failure, not just an
+    // adversarial one).
+    let host_and_path = Url::parse(url)
+        .ok()
+        .map(|parsed| format!("{}{}", parsed.host_str().unwrap_or_default(), parsed.path()))
+        .unwrap_or_default();
+
+    slugify(&host_and_path)
+}
+
+/// Derives a filesystem- and `validate_server_id`-safe [`ServerId`] slug from
+/// a stdio transport command or a `--name` override.
+///
+/// `command`/`name` are attacker-influenced (a CLI argument, or free text an
+/// operator might paste from a shared script) and — unlike an Http/Sse URL —
+/// commonly *are* legitimate filesystem paths (e.g. `./bin/my-server` or
+/// `/usr/local/bin/mcp-server`). Constructing `ServerId` directly from them
+/// (the previous behavior) is unsafe because the id flows unmodified into a
+/// directory name under `~/.claude/servers/{id}/`
+/// (`base_dir.join(&server_dir_name)`): a leading `/` makes `PathBuf::join`
+/// discard `base_dir` entirely, and `..` segments walk back out of it.
+/// Delegates to [`slugify`], which strips path separators and `..` by
+/// construction.
+pub(crate) fn derive_server_id_from_path_or_name(raw: &str) -> ServerId {
+    slugify(raw)
 }
 
 #[cfg(test)]
@@ -2270,6 +2307,98 @@ mod tests {
         assert!(!id.as_str().contains("token"));
     }
 
+    // ── derive_server_id_from_path_or_name / issue #311 (stdio command and
+    // `--name` override are also joined onto a filesystem base directory and
+    // must be sanitized the same way `derive_server_id_from_url` already is) ──
+
+    #[test]
+    fn test_derive_server_id_from_path_or_name_rejects_parent_traversal() {
+        let id = derive_server_id_from_path_or_name("../../../../etc/passwd");
+        assert!(!id.as_str().contains(".."));
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_derive_server_id_from_path_or_name_rejects_absolute_path() {
+        let id = derive_server_id_from_path_or_name("/etc/cron.d/evil");
+        assert!(!id.as_str().starts_with('/'));
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_derive_server_id_from_path_or_name_join_never_escapes_base_dir() {
+        // Literal reproduction of how `generate.rs` uses the id: joined onto
+        // a base directory via `PathBuf::join`, which discards the base
+        // entirely if the joined component is absolute. Since the sanitized
+        // slug can only ever contain `[a-z0-9-]`, that can never happen.
+        let base_dir = PathBuf::from("/home/user/.claude/servers");
+        let malicious_inputs = [
+            "../../../../etc/passwd",
+            "/etc/cron.d/evil",
+            "/../../escape",
+            "..",
+            "./../escape",
+        ];
+
+        for input in malicious_inputs {
+            let id = derive_server_id_from_path_or_name(input);
+            let joined = base_dir.join(id.as_str());
+            assert!(
+                joined.starts_with(&base_dir),
+                "joining derived id {:?} (from {input:?}) onto {base_dir:?} escaped it: {joined:?}",
+                id.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn test_derive_server_id_from_path_or_name_preserves_ordinary_commands() {
+        // Ordinary stdio commands (already lowercase alnum-hyphen) must be
+        // unaffected by sanitization.
+        assert_eq!(
+            derive_server_id_from_path_or_name("github-mcp-server").as_str(),
+            "github-mcp-server"
+        );
+        assert_eq!(
+            derive_server_id_from_path_or_name("docker").as_str(),
+            "docker"
+        );
+    }
+
+    #[test]
+    fn test_derive_server_id_from_path_or_name_strips_path_components() {
+        // A legitimate absolute/relative binary path still produces a safe,
+        // single-segment id rather than being rejected outright.
+        let id = derive_server_id_from_path_or_name("/usr/local/bin/mcp-server");
+        assert_eq!(id.as_str(), "usr-local-bin-mcp-server");
+        assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_build_server_config_stdio_traversal_command_never_escapes_base_dir() {
+        // Regression test for #311: a stdio `command` used to flow straight
+        // into `ServerId::new` unsanitized, then into a directory name under
+        // `~/.claude/servers/{id}/`. Covers both a relative command
+        // containing `..` (skips `ServerConfigBuilder`'s absolute-path
+        // existence check entirely) and a legitimate absolute path (which
+        // must exist to pass that check, so `/bin/sh` is used) — both are
+        // realistic stdio `command` shapes.
+        let base_dir = PathBuf::from("/home/user/.claude/servers");
+        for command in ["../../../../etc/passwd", "/bin/sh"] {
+            let (id, _config) =
+                build_server_config(stdio_transport(command, vec![], vec![], None), None, None)
+                    .unwrap();
+
+            assert!(mcp_execution_skill::validate_server_id(id.as_str()).is_ok());
+            let joined = base_dir.join(id.as_str());
+            assert!(
+                joined.starts_with(&base_dir),
+                "joining derived id {:?} (from command {command:?}) escaped {base_dir:?}: {joined:?}",
+                id.as_str()
+            );
+        }
+    }
+
     /// Serializes tests in this module that mutate the `HOME` env var so
     /// they cannot race each other when run in the same process (relevant
     /// under plain `cargo test`, which runs a crate's tests in one process;
@@ -2336,5 +2465,47 @@ mod tests {
             entry.transport,
             McpTransport::Stdio { ref command, .. } if command == "node"
         ));
+    }
+
+    /// Regression test for #311 review S4: `get_mcp_server` must accept a
+    /// legitimate `mcp.json` key that isn't already `[a-z0-9-]` (mixed case,
+    /// underscores) — it is shared by `introspect`/`server`, which have no
+    /// need for the id to be a filesystem-safe slug. Only `generate`'s own
+    /// sink (`resolve_server_dir_name` in `generate.rs`) enforces that
+    /// constraint, since only `generate` turns the id into a directory name.
+    #[cfg(unix)]
+    #[test]
+    fn test_get_mcp_server_accepts_non_slug_shaped_config_key() {
+        let _guard = HOME_ENV_LOCK.lock().unwrap();
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let claude_dir = temp.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("mcp.json"),
+            r#"{"mcpServers": {"claude_ai_Gmail": {"command": "node", "args": ["server.js"]}}}"#,
+        )
+        .unwrap();
+
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: guarded by `HOME_ENV_LOCK`; no other test in this process
+        // reads or writes `HOME` while the guard is held.
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+        }
+
+        let get_result = get_mcp_server("claude_ai_Gmail");
+
+        // SAFETY: see above.
+        unsafe {
+            match &original_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let (id, _config, _entry) =
+            get_result.expect("get_mcp_server must not reject a non-slug-shaped mcp.json key");
+        assert_eq!(id.as_str(), "claude_ai_Gmail");
     }
 }

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -6,15 +6,16 @@
 //! 2. Generates TypeScript files for progressive loading (one file per tool)
 //! 3. Saves files to `~/.claude/servers/{server-id}/` directory
 
-use super::common::{RawServerArgs, resolve_server_config};
+use super::common::{RawServerArgs, derive_server_id_from_path_or_name, resolve_server_config};
 use crate::formatters::escape_display;
 use anyhow::{Context, Result};
 use mcp_execution_codegen::GeneratedCode;
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use mcp_execution_core::{ServerConfig, ServerId};
-use mcp_execution_files::FilesBuilder;
+use mcp_execution_files::{ExportOptions, FilesBuilder};
 use mcp_execution_introspector::{Introspector, ServerInfo};
+use mcp_execution_skill::validate_server_id;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
@@ -115,6 +116,12 @@ pub async fn run(
     dry_run: bool,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
+    // Captured before `raw` is consumed below: an id resolved from
+    // `--from-config` without a `--name` override is the one case
+    // `resolve_server_dir_name` isn't a redundant backstop for (see its doc
+    // comment) — `--name` always overrides `server_info.id`, so if it was
+    // given the id came from its own, already-validated value instead.
+    let id_from_unvalidated_config_key = raw.from_config.is_some() && name.is_none();
     let (server_id, server_config) = resolve_server_config(raw)?;
 
     let server_info = discover_server_info(server_id, &server_config, name.as_deref()).await?;
@@ -124,7 +131,7 @@ pub async fn run(
         return Ok(ExitCode::SUCCESS);
     }
 
-    let server_dir_name = server_info.id.to_string();
+    let server_dir_name = resolve_server_dir_name(&server_info, id_from_unvalidated_config_key)?;
     let generated_code = generate_code(&server_info)?;
 
     let base_dir = resolve_base_dir(output_dir)?;
@@ -144,12 +151,29 @@ pub async fn run(
 ///
 /// # Errors
 ///
-/// Returns an error if the connection or tool discovery fails.
+/// Returns an error if `name` fails [`validate_server_id`](mcp_execution_skill::validate_server_id),
+/// or if the connection or tool discovery fails.
 async fn discover_server_info(
     server_id: ServerId,
     server_config: &ServerConfig,
     name: Option<&str>,
 ) -> Result<ServerInfo> {
+    // Validated up front, before spending a network round trip: unlike a
+    // stdio command (sanitized via `derive_server_id_from_path_or_name`
+    // because it commonly *is* a legitimate path), `--name` is documented as
+    // overriding the id to match an identity the caller already has in mind
+    // (typically an `mcp.json` key) — silently rewriting an invalid value
+    // (e.g. stripping `..`/`/`) would produce a directory name the caller
+    // didn't ask for and that may no longer match anything, so it is
+    // rejected outright instead.
+    let override_id = name
+        .map(|custom_name| {
+            validate_server_id(custom_name)
+                .with_context(|| format!("invalid --name '{custom_name}'"))
+                .map(|()| ServerId::new(custom_name))
+        })
+        .transpose()?;
+
     info!("Connecting to MCP server: {}", server_id);
 
     let mut introspector = Introspector::new();
@@ -164,10 +188,10 @@ async fn discover_server_info(
         server_info.name
     );
 
-    // Override server_info.id with custom name if provided
-    // This ensures generated code uses the correct server_id that matches mcp.json
-    if let Some(custom_name) = name {
-        server_info.id = ServerId::new(custom_name);
+    // Override server_info.id with custom name if provided.
+    // This ensures generated code uses the correct server_id that matches mcp.json.
+    if let Some(id) = override_id {
+        server_info.id = id;
     }
 
     Ok(server_info)
@@ -190,6 +214,62 @@ fn generate_code(server_info: &ServerInfo) -> Result<GeneratedCode> {
     );
 
     Ok(generated_code)
+}
+
+/// Resolves `server_info.id` to a directory name, guaranteeing it is safe to
+/// join onto `base_dir`.
+///
+/// This is `generate`'s own sink — the single point where the id is turned
+/// into a directory name — rather than a shared helper like
+/// [`get_mcp_server`](super::common::get_mcp_server), because `generate` is
+/// the only command that needs the id to be a filesystem-safe slug;
+/// `introspect`/`server` read the same `mcp.json` key without that
+/// constraint (#311).
+///
+/// For the stdio arm (`derive_server_id_from_path_or_name`), the http/sse arm
+/// (`derive_server_id_from_url`), and `--name` (its own `validate_server_id`
+/// check in `discover_server_info`), this check is a redundant backstop:
+/// each of those already guarantees the id is valid before it ever reaches
+/// here, so failing here for one of them would indicate a bug in that arm's
+/// own check, not in the user's input. It is **not** redundant for
+/// `--from-config` without a `--name` override — `get_mcp_server` is
+/// deliberately unvalidated (shared by commands that don't need a
+/// filesystem-safe id), so `is_from_unvalidated_config_key` being `true`
+/// means this is the *sole* enforcement point for that arm. Do not delete
+/// this check on the theory that every arm upstream already covers it — that
+/// theory is false for `--from-config`, and removing it would silently
+/// reopen #311 for that specific case.
+///
+/// # Errors
+///
+/// Returns an error if `server_info.id` fails
+/// [`validate_server_id`](mcp_execution_skill::validate_server_id). When
+/// `is_from_unvalidated_config_key` is `true`, the error names
+/// `~/.claude/mcp.json` and suggests the `--name` override (with a
+/// filesystem-safe slug derived from the offending id) as a fix, since the
+/// fault is the user's config, not this tool. Otherwise it is framed as an
+/// internal error, since reaching it would mean one of the other arms' own
+/// checks has a bug.
+fn resolve_server_dir_name(
+    server_info: &ServerInfo,
+    is_from_unvalidated_config_key: bool,
+) -> Result<String> {
+    let server_dir_name = server_info.id.to_string();
+    validate_server_id(&server_dir_name).map_err(|source| {
+        if is_from_unvalidated_config_key {
+            let suggested_name = derive_server_id_from_path_or_name(&server_dir_name);
+            anyhow::anyhow!(
+                "server '{server_dir_name}' in ~/.claude/mcp.json is not a valid directory name \
+                 ({source}); use --name {suggested_name} to override it"
+            )
+        } else {
+            anyhow::Error::from(source).context(format!(
+                "internal error: resolved server id '{server_dir_name}' is not a valid \
+                 directory name"
+            ))
+        }
+    })?;
+    Ok(server_dir_name)
 }
 
 /// Resolves the base directory generated servers are exported under, defaulting to
@@ -303,7 +383,13 @@ fn export_generated_code(
     // stage-then-swap on regeneration), so pre-creating it here would just
     // force the slower regeneration path even on a brand-new server.
     std::fs::create_dir_all(base_dir).context("failed to create output directory")?;
-    vfs.export_to_filesystem(output_path)
+    // Defense-in-depth: `output_path` is built by joining a server-id-derived
+    // directory name onto `base_dir` (see `derive_server_id_from_path_or_name`,
+    // which is the primary guard); confining the export here means a future
+    // caller that skips that sanitization fails loudly instead of writing
+    // outside `base_dir`.
+    let options = ExportOptions::new().with_confine_to(base_dir);
+    vfs.export_to_filesystem_with_options(output_path, &options)
         .context("failed to export files to filesystem")?;
 
     Ok(())
@@ -683,5 +769,129 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("failed to introspect MCP server"));
+    }
+
+    // ── issue #311 (S1): `--name` override must be rejected outright when
+    // invalid, not silently rewritten into a different id ──
+
+    #[tokio::test]
+    async fn test_name_override_rejects_traversal_and_absolute_paths() {
+        // Regression test for #311: the `--name` override used to construct
+        // `ServerId::new(custom_name)` directly with no validation at all, so
+        // a malicious `--name` flowed unmodified into a directory name under
+        // `~/.claude/servers/{id}/`. Unlike a stdio command (sanitized, since
+        // it commonly *is* a legitimate path), `--name` is meant to match an
+        // identity the caller already has in mind, so it must be rejected
+        // rather than silently transformed. Validation happens before any
+        // connection attempt, so this never reaches the network.
+        let server_config = ServerConfig::builder()
+            .command("nonexistent-command-for-name-validation-test".to_string())
+            .build()
+            .unwrap();
+
+        for bad_name in [
+            "../../../../etc/passwd",
+            "/etc/cron.d/evil",
+            "..",
+            "UPPER_CASE",
+        ] {
+            let result =
+                discover_server_info(ServerId::new("placeholder"), &server_config, Some(bad_name))
+                    .await;
+
+            assert!(
+                result.is_err(),
+                "expected --name {bad_name:?} to be rejected"
+            );
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("invalid --name"),
+                "expected a validation error for {bad_name:?}, got: {err_msg}"
+            );
+        }
+    }
+
+    // ── issue #311 (S4): `resolve_server_dir_name` is the sink-level
+    // invariant check, independent of which arm produced `server_info.id` ──
+
+    #[test]
+    fn test_resolve_server_dir_name_accepts_valid_id() {
+        let server_info = create_mock_server_info();
+        assert_eq!(
+            resolve_server_dir_name(&server_info, false).unwrap(),
+            "test-server"
+        );
+    }
+
+    #[test]
+    fn test_resolve_server_dir_name_rejects_traversal_and_absolute_ids() {
+        // Even though every arm that constructs `server_info.id` already
+        // guarantees this holds, this sink-level check must independently
+        // reject an unsafe id rather than trust its caller.
+        for bad_id in ["../../../../etc/passwd", "/etc/cron.d/evil", "UPPER_CASE"] {
+            let mut server_info = create_mock_server_info();
+            server_info.id = ServerId::new(bad_id);
+
+            let result = resolve_server_dir_name(&server_info, false);
+            assert!(result.is_err(), "expected id {bad_id:?} to be rejected");
+        }
+    }
+
+    #[test]
+    fn test_resolve_server_dir_name_non_config_error_is_framed_as_internal() {
+        // Regression test for #311 review M10/M11: when the id did NOT come
+        // from an unvalidated `--from-config` lookup, reaching this check at
+        // all would mean one of the other arms' own validation has a bug —
+        // the error must say so, not blame a user-supplied mcp.json key that
+        // was never involved.
+        let mut server_info = create_mock_server_info();
+        server_info.id = ServerId::new("UPPER_CASE");
+
+        let err = resolve_server_dir_name(&server_info, false).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("internal error"), "got: {err_msg}");
+        assert!(!err_msg.contains("mcp.json"), "got: {err_msg}");
+    }
+
+    #[test]
+    fn test_resolve_server_dir_name_from_config_error_names_mcp_json_and_suggests_name_override() {
+        // Regression test for #311 review M10: a `claude_ai_Gmail`-style
+        // legitimate mcp.json key fails `validate_server_id`'s stricter
+        // filesystem-safety charset. The error must name the actual fault
+        // (the user's config) and point at the `--name` workaround with a
+        // ready-to-use slug, not blame this tool.
+        let mut server_info = create_mock_server_info();
+        server_info.id = ServerId::new("claude_ai_Gmail");
+
+        let err = resolve_server_dir_name(&server_info, true).unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("mcp.json"), "got: {err_msg}");
+        assert!(err_msg.contains("--name claude-ai-gmail"), "got: {err_msg}");
+        assert!(!err_msg.contains("internal error"), "got: {err_msg}");
+    }
+
+    #[test]
+    fn test_export_generated_code_confines_output_to_base_dir() {
+        // End-to-end reproduction of the vulnerable call site
+        // (`export_generated_code`): even if a caller upstream failed to
+        // sanitize the id, the confinement check wired in via
+        // `ExportOptions::with_confine_to` must reject an `output_path` that
+        // escapes `base_dir`, rather than silently writing outside it.
+        let temp = tempfile::TempDir::new().unwrap();
+        let base_dir = temp.path().join("servers");
+        std::fs::create_dir_all(&base_dir).unwrap();
+        let escape_target = temp.path().join("escaped");
+
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = create_mock_server_info();
+        let generated_code = generator.generate(&server_info).unwrap();
+
+        let result = export_generated_code(generated_code, &base_dir, &escape_target);
+
+        assert!(result.is_err());
+        assert!(
+            !escape_target.exists(),
+            "confinement check must reject the export before anything is written outside base_dir"
+        );
     }
 }

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -250,6 +250,7 @@ fn classify_exit_code(error: &anyhow::Error) -> ExitCode {
             | FilesError::InvalidPath { .. }
             | FilesError::PathNotAbsolute { .. }
             | FilesError::InvalidPathComponent { .. }
+            | FilesError::PathEscapesBase { .. }
             | FilesError::IoError { .. } => ExitCode::ERROR,
         };
     }

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -505,7 +505,8 @@ impl FileSystem {
         self.check_export_bounds()?;
 
         let target = base_path.as_ref();
-        let (staging, canonical_staging) = self.stage_export(target)?;
+        let (staging, canonical_staging) =
+            self.stage_export(target, options.confine_to.as_deref())?;
 
         // Phase 3: Write all files into the staging directory. If this fails,
         // `staging` is dropped here and its `Drop` impl removes the partial
@@ -530,9 +531,10 @@ impl FileSystem {
     /// # Errors
     ///
     /// Returns an error if `target` has no parent directory, the parent does
-    /// not exist, or the staging directory cannot be created or
-    /// canonicalized.
-    fn stage_export(&self, target: &Path) -> Result<(TempDir, PathBuf)> {
+    /// not exist, `confine_to` is set and either it or the parent fails to
+    /// canonicalize or the canonicalized parent is outside `confine_to`, or
+    /// the staging directory cannot be created or canonicalized.
+    fn stage_export(&self, target: &Path, confine_to: Option<&Path>) -> Result<(TempDir, PathBuf)> {
         let parent = target.parent().ok_or_else(|| FilesError::InvalidPath {
             path: format!("Target path has no parent directory: {}", target.display()),
         })?;
@@ -541,6 +543,10 @@ impl FileSystem {
             return Err(FilesError::FileNotFound {
                 path: parent.display().to_string(),
             });
+        }
+
+        if let Some(base_dir) = confine_to {
+            Self::verify_confinement(parent, base_dir)?;
         }
 
         // Best-effort cleanup of orphaned staging/displaced directories left
@@ -580,6 +586,44 @@ impl FileSystem {
         Self::create_directories(&dirs)?;
 
         Ok((staging, canonical_staging))
+    }
+
+    /// Verifies that `parent` (an export target's parent directory, already
+    /// confirmed to exist by [`Self::stage_export`]) resolves inside
+    /// `base_dir` once both are canonicalized.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilesError::IoError`] (not [`FilesError::PathEscapesBase`])
+    /// if `base_dir` or `parent` cannot be canonicalized — that failure is a
+    /// plain I/O problem (missing directory, permission denied, ...)
+    /// unrelated to whether `parent` is confined, and disguising it as a
+    /// security rejection would mislead a caller into thinking a path
+    /// escaped when the check never actually ran. [`FilesError::PathEscapesBase`]
+    /// is reserved for the case where both canonicalize successfully but
+    /// `parent` is not inside `base_dir`.
+    fn verify_confinement(parent: &Path, base_dir: &Path) -> Result<()> {
+        let canonical_base = base_dir
+            .canonicalize()
+            .map_err(|source| FilesError::IoError {
+                path: base_dir.display().to_string(),
+                source,
+            })?;
+        let canonical_parent = parent
+            .canonicalize()
+            .map_err(|source| FilesError::IoError {
+                path: parent.display().to_string(),
+                source,
+            })?;
+
+        if canonical_parent.starts_with(&canonical_base) {
+            Ok(())
+        } else {
+            Err(FilesError::PathEscapesBase {
+                path: canonical_parent.display().to_string(),
+                base: canonical_base.display().to_string(),
+            })
+        }
     }
 
     /// Exports VFS contents using parallel writes (requires 'parallel' feature).
@@ -634,7 +678,7 @@ impl FileSystem {
         self.check_export_bounds()?;
 
         let target = base_path.as_ref();
-        let (staging, canonical_staging) = self.stage_export(target)?;
+        let (staging, canonical_staging) = self.stage_export(target, None)?;
 
         // Write files in parallel into the staging directory. If this fails,
         // `staging` is dropped here and its `Drop` impl removes the partial
@@ -1017,6 +1061,8 @@ impl Default for FileSystem {
 pub struct ExportOptions {
     /// Use atomic writes (write to temp file, then rename)
     pub atomic: bool,
+    /// Optional confinement base directory; see [`Self::with_confine_to`].
+    confine_to: Option<PathBuf>,
 }
 
 impl ExportOptions {
@@ -1024,15 +1070,48 @@ impl ExportOptions {
     ///
     /// Defaults:
     /// - atomic: true (safer)
+    /// - `confine_to`: unset (no confinement check)
     #[must_use]
     pub const fn new() -> Self {
-        Self { atomic: true }
+        Self {
+            atomic: true,
+            confine_to: None,
+        }
     }
 
     /// Sets whether to use atomic writes.
     #[must_use]
     pub const fn with_atomic_writes(mut self, atomic: bool) -> Self {
         self.atomic = atomic;
+        self
+    }
+
+    /// Requires the export target to resolve inside `base_dir`.
+    ///
+    /// Defense-in-depth against a caller passing a `target` built by joining
+    /// untrusted input onto a base directory: `PathBuf::join` silently
+    /// discards the base entirely when the joined component is absolute, and
+    /// `..` segments can walk back out of it even for a relative join. Once
+    /// `target`'s parent directory exists, both it and `base_dir` are
+    /// canonicalized: if either canonicalization fails (missing directory,
+    /// permission denied, ...), the export fails with [`FilesError::IoError`];
+    /// if both succeed but the canonicalized parent is not inside the
+    /// canonicalized `base_dir`, the export fails with
+    /// [`FilesError::PathEscapesBase`]. Callers are expected to validate
+    /// untrusted input at its source; this exists to fail loudly rather than
+    /// silently escape if a future caller doesn't.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_files::ExportOptions;
+    /// use std::path::PathBuf;
+    ///
+    /// let options = ExportOptions::new().with_confine_to(PathBuf::from("/home/user/.claude/servers"));
+    /// ```
+    #[must_use]
+    pub fn with_confine_to(mut self, base_dir: impl Into<PathBuf>) -> Self {
+        self.confine_to = Some(base_dir.into());
         self
     }
 }
@@ -1626,6 +1705,101 @@ mod tests {
             .filter(|entry| entry.path() != target)
             .collect();
         assert!(siblings.is_empty(), "unexpected siblings: {siblings:?}");
+    }
+
+    // ── ExportOptions::with_confine_to / issue #311 defense-in-depth ──
+
+    #[test]
+    fn test_export_with_confine_to_allows_target_inside_base_dir() {
+        let temp = TempDir::new().unwrap();
+        let base_dir = temp.path().join("base");
+        fs::create_dir_all(&base_dir).unwrap();
+        let target = base_dir.join("server-a");
+
+        let vfs = FilesBuilder::new()
+            .add_file("/tool.ts", "export {}")
+            .build()
+            .unwrap();
+
+        let options = ExportOptions::new().with_confine_to(&base_dir);
+        vfs.export_to_filesystem_with_options(&target, &options)
+            .unwrap();
+
+        assert!(target.join("tool.ts").exists());
+    }
+
+    #[test]
+    fn test_export_with_confine_to_rejects_target_outside_base_dir() {
+        // Reproduces #311 at the `mcp-files` layer: a `target` whose parent
+        // is not inside `base_dir` must be rejected rather than silently
+        // written, even though the parent directory itself exists.
+        let temp = TempDir::new().unwrap();
+        let base_dir = temp.path().join("base");
+        fs::create_dir_all(&base_dir).unwrap();
+        let escaped_target = temp.path().join("escaped");
+
+        let vfs = FilesBuilder::new()
+            .add_file("/tool.ts", "export {}")
+            .build()
+            .unwrap();
+
+        let options = ExportOptions::new().with_confine_to(&base_dir);
+        let result = vfs.export_to_filesystem_with_options(&escaped_target, &options);
+
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), FilesError::PathEscapesBase { .. }),
+            "expected PathEscapesBase"
+        );
+        assert!(
+            !escaped_target.exists(),
+            "nothing should be written outside base_dir"
+        );
+    }
+
+    #[test]
+    fn test_export_with_confine_to_reports_io_error_not_path_escapes_base_when_base_dir_missing() {
+        // Regression test for #311 review S3: a `base_dir` that fails to
+        // canonicalize (e.g. it does not exist — a caller bug, not an
+        // attempted escape) must surface as `FilesError::IoError`, not be
+        // misclassified as `PathEscapesBase`.
+        let temp = TempDir::new().unwrap();
+        let base_dir = temp.path().join("does-not-exist");
+        let target = temp.path().join("target");
+
+        let vfs = FilesBuilder::new()
+            .add_file("/tool.ts", "export {}")
+            .build()
+            .unwrap();
+
+        let options = ExportOptions::new().with_confine_to(&base_dir);
+        let result = vfs.export_to_filesystem_with_options(&target, &options);
+
+        match result.unwrap_err() {
+            FilesError::IoError { path, .. } => {
+                assert_eq!(path, base_dir.display().to_string());
+            }
+            other => panic!("expected IoError attributed to base_dir, got {other:?}"),
+        }
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn test_export_without_confine_to_is_unaffected() {
+        // Default options (no confinement configured) preserve prior
+        // behavior: any target with an existing parent is accepted.
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("anywhere");
+
+        let vfs = FilesBuilder::new()
+            .add_file("/tool.ts", "export {}")
+            .build()
+            .unwrap();
+
+        vfs.export_to_filesystem_with_options(&target, &ExportOptions::default())
+            .unwrap();
+
+        assert!(target.join("tool.ts").exists());
     }
 
     #[test]

--- a/crates/mcp-files/src/types.rs
+++ b/crates/mcp-files/src/types.rs
@@ -91,6 +91,19 @@ pub enum FilesError {
         /// The configured maximum allowed for this resource.
         limit: usize,
     },
+
+    /// An export target's canonicalized parent directory resolved outside a
+    /// caller-supplied confinement base directory (see
+    /// [`ExportOptions::with_confine_to`](crate::ExportOptions::with_confine_to)),
+    /// e.g. because it was built by joining an unsanitized identifier
+    /// containing `..` segments or an absolute path onto the intended base.
+    #[error("path {path} escapes base directory {base}")]
+    PathEscapesBase {
+        /// The canonicalized path that resolved outside `base`.
+        path: String,
+        /// The base directory `path` was required to resolve inside.
+        base: String,
+    },
 }
 
 impl FilesError {


### PR DESCRIPTION
## Summary
- `generate`'s stdio transport and `--name` override built `ServerId` directly from unvalidated input, unlike the http/sse path (which already sanitized derived URLs). Since `PathBuf::join` discards its base when the joined component is absolute, a stdio command or `--name` containing `..` or an absolute path could write generated files outside `~/.claude/servers/`.
- Stdio commands are now routed through a sanitizing helper mirroring the existing URL-derivation logic; an invalid `--name` is rejected outright rather than silently rewritten (it's meant to match an identity the caller already has, e.g. an `mcp.json` key); the fully-resolved id is validated once more at `generate`'s actual sink regardless of which arm produced it, so `--from-config` (which shares an unvalidated lookup with `introspect`/`server`) is covered too without regressing those commands.
- Added an optional export confinement check in `mcp-execution-files` (`ExportOptions::with_confine_to`) as defense-in-depth, wired into `generate`.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1024/1024)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Regression tests for stdio traversal/absolute-path commands, `--name` rejection, `--from-config` sink validation, and export confinement

Closes #311