### PR TITLE
fix(cli): escape untrusted error text and fix server info/validate on invalid entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   string, since a single raw tool can legitimately be named by either of its two display forms —
   deduping on the submitted string alone missed a caller submitting both forms for the same tool,
   letting the second entry silently overwrite the first's categorization (#307).
+- **`mcp-execution-cli`**: `runner::report_and_classify` printed a failing command's error chain
+  to stderr via `eprintln!("Error: {err:?}")` with no escaping, and `commands::server`'s `warn!`
+  log lines for a failed config build or introspection attempt did the same. When the error/log
+  content embeds text from an untrusted MCP server (e.g. a JSON-RPC error `message`), both
+  `anyhow::Error`'s `Debug` rendering and the `thiserror`-derived `Display` impls it walks
+  interpolate that content verbatim, so a malicious/compromised server could inject raw
+  ANSI/control escape sequences into the user's terminal — or, if given a free pass on newlines
+  alone, forge fake `Caused by:`/`Error:` lines indistinguishable from the real chain structure.
+  Fixed via a new `formatters::escape_error_text` helper — which delegates the actual character-level
+  escaping to `mcp_execution_core::untrusted::sanitize_untrusted_text` (the project's existing,
+  already-tested sanitizer for untrusted MCP metadata, also used by
+  `mcp-execution-skill`/`mcp-execution-server`) rather than a parallel implementation — applied at
+  both `warn!` sites directly, and, for `report_and_classify`, via a new `runner::sanitized_error_report`
+  that walks `err.chain()` and sanitizes each cause's own rendered text individually before
+  rejoining them with `"Caused by:"`/numbering separators the function itself controls. An earlier
+  version of this fix sanitized anyhow's fully-rendered `{err:?}` report as a single blob, which
+  neutralized escape sequences and newline-forgery alike but also flattened a legitimate
+  multi-cause chain's own trusted structure onto one line, since nothing at that point could tell
+  anyhow's structural newlines apart from a hostile cause's embedded ones; rendering per-cause
+  instead keeps a trusted chain's real "Caused by:" structure intact while still ensuring a
+  hostile cause's own text cannot forge that structure or inject escape sequences — including
+  keeping a `RUST_BACKTRACE=1` backtrace fully intact and unsanitized, since it is captured from
+  the local call stack and carries nothing an external MCP server could have influenced (#308).
+- **`mcp-execution-cli`**: `server info`/`server validate` resolved a named `mcp.json` entry via
+  `get_mcp_server`, which eagerly ran full security validation (URL scheme, header safety, timeout
+  bounds, ...) as part of the lookup — making an entry that is present but fails that validation
+  indistinguishable from an entry that does not exist at all, since both surfaced through the same
+  "not found" error. `server info` on such an entry bypassed `--format`/`ExitCode` entirely,
+  propagating a raw, unformatted error (#305); `server validate` reported the factually wrong
+  "Server not found in configuration" message for an entry that is, in fact, present (#304). Both
+  commands now look up the raw entry via a new `get_mcp_server_entry` before running validation
+  separately, so a present-but-invalid entry is reported through each command's normal structured
+  output — `server info` as `"status": "unavailable"`, `server validate` with a message describing
+  the actual validation failure — while a genuinely absent entry still surfaces the original "not
+  found" error. Known gap not addressed by this fix: `server info`'s `"status": "unavailable"`
+  `ServerInfo` has no field carrying *why* a server is unavailable (invalid configuration vs.
+  unreachable); a caller must currently re-run `server validate` for that detail.
 
 - **`mcp-execution-cli`**: `generate`'s stdio transport derived its output directory name
   directly from an unvalidated `ServerId` built from the raw stdio `command`, unlike its

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -443,8 +443,12 @@ pub(crate) fn list_mcp_servers() -> Result<Vec<(String, McpServerEntry)>> {
 ///
 /// # Errors
 ///
-/// Returns an error if the config file is missing, malformed, or the named
-/// server is not present.
+/// Returns an error if the config file is missing, malformed, the named
+/// server is not present, or the entry fails [`build_core_config`]'s
+/// security validation. Callers that must distinguish "entry absent" from
+/// "entry present but invalid" (e.g. to route the latter through a
+/// format-aware error path instead of a raw `Err`) should call
+/// [`get_mcp_server_entry`] and [`build_core_config`] separately instead.
 ///
 /// Deliberately does *not* validate `name` against
 /// [`validate_server_id`](mcp_execution_skill::validate_server_id): this
@@ -455,6 +459,26 @@ pub(crate) fn list_mcp_servers() -> Result<Vec<(String, McpServerEntry)>> {
 /// `introspect --from-config` for entirely legitimate `mcp.json` keys that
 /// aren't already `[a-z0-9-]` (e.g. `claude_ai_Gmail`).
 pub(crate) fn get_mcp_server(name: &str) -> Result<(ServerId, ServerConfig, McpServerEntry)> {
+    let (server_id, entry) = get_mcp_server_entry(name)?;
+    let server_config = build_core_config(&entry)?;
+    Ok((server_id, server_config, entry))
+}
+
+/// Looks up a named server's raw [`McpServerEntry`] in `~/.claude/mcp.json`, without running
+/// `build_core_config`'s security validation.
+///
+/// Split out from `get_mcp_server` so callers whose own error handling depends on knowing
+/// whether the entry is present at all — regardless of whether it would later pass validation —
+/// can perform that check first. `server info`/`server validate` need this: previously, calling
+/// `get_mcp_server` made an entry present but failing URL-scheme (or other) validation
+/// indistinguishable from an entry that does not exist at all, since both surfaced through the
+/// same `with_context` "not found" wrapping.
+///
+/// # Errors
+///
+/// Returns an error if the config file is missing or malformed, or the named server is not
+/// present.
+pub(crate) fn get_mcp_server_entry(name: &str) -> Result<(ServerId, McpServerEntry)> {
     let config = load_mcp_config()?;
 
     let entry = config
@@ -468,8 +492,7 @@ pub(crate) fn get_mcp_server(name: &str) -> Result<(ServerId, ServerConfig, McpS
         })?
         .clone();
 
-    let server_config = build_core_config(&entry)?;
-    Ok((ServerId::new(name), server_config, entry))
+    Ok((ServerId::new(name), entry))
 }
 
 /// Loads server configuration from `~/.claude/mcp.json` by server name.
@@ -2507,5 +2530,58 @@ mod tests {
         let (id, _config, _entry) =
             get_result.expect("get_mcp_server must not reject a non-slug-shaped mcp.json key");
         assert_eq!(id.as_str(), "claude_ai_Gmail");
+    }
+
+    /// Regression test for #305/#304: an entry present in `mcp.json` but whose `url` fails
+    /// `build_core_config`'s scheme validation must still be found by `get_mcp_server_entry` —
+    /// distinct from `get_mcp_server`, which eagerly runs that validation and previously made
+    /// this case indistinguishable from a genuinely absent entry to its callers.
+    #[cfg(unix)]
+    #[test]
+    fn test_get_mcp_server_entry_finds_entry_that_fails_config_validation() {
+        let _guard = HOME_ENV_LOCK.lock().unwrap();
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let claude_dir = temp.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("mcp.json"),
+            r#"{"mcpServers": {"badscheme": {"type": "http", "url": "not-a-url"}}}"#,
+        )
+        .unwrap();
+
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: guarded by `HOME_ENV_LOCK`; no other test in this process
+        // reads or writes `HOME` while the guard is held.
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+        }
+
+        let entry_result = get_mcp_server_entry("badscheme");
+
+        // SAFETY: see above.
+        unsafe {
+            match &original_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let (id, entry) = entry_result.expect(
+            "get_mcp_server_entry must find the entry even though its url fails validation",
+        );
+        assert_eq!(id.as_str(), "badscheme");
+        let config_err = build_core_config(&entry).expect_err(
+            "the entry's url is expected to fail build_core_config's scheme validation",
+        );
+        // Regression coverage for #304: `validate_command` interpolates this error's `Display`
+        // into its "invalid configuration" message. It must describe the actual validation
+        // failure, not read like the unrelated "not found" message reserved for a genuinely
+        // absent entry.
+        let message = config_err.to_string();
+        assert!(
+            !message.to_lowercase().contains("not found"),
+            "build_core_config's error must not read like a not-found message, got: {message}"
+        );
     }
 }

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -5,8 +5,9 @@
 
 use crate::actions::ServerAction;
 use crate::commands::common::{
-    McpServerEntry, McpTransport, build_core_config, get_mcp_server, list_mcp_servers,
+    McpServerEntry, McpTransport, build_core_config, get_mcp_server_entry, list_mcp_servers,
 };
+use crate::formatters::escape_error_text;
 use anyhow::{Context, Result};
 use mcp_execution_core::ServerConfig;
 use mcp_execution_core::ServerId;
@@ -235,7 +236,8 @@ pub struct ValidationResult {
 /// Note: For the `Validate` action, an unknown server name is reported via
 /// `ExitCode::ERROR` rather than returning `Err`. Server introspection failures
 /// (for both `Info` and `Validate`) are also caught internally and reported via
-/// `ExitCode::ERROR`.
+/// `ExitCode::ERROR`. So is an entry that is present but fails security validation (e.g. an
+/// invalid URL scheme, #305/#304) — only a genuinely absent entry propagates as `Err`.
 ///
 /// # Examples
 ///
@@ -315,10 +317,31 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
 /// Shows detailed information about a specific server.
 ///
 /// Connects to the server and introspects its capabilities, tools, and status.
+///
+/// An entry whose `url` (or other field) fails [`build_core_config`]'s security validation is
+/// reported the same way as an entry that is well-formed but unreachable — a structured
+/// `"status": "unavailable"` [`ServerInfo`] through `output_format`, not a raw, unformatted error
+/// (#305). Only a genuinely absent entry propagates as `Err` via [`get_mcp_server_entry`].
 async fn show_server_info(server: String, output_format: OutputFormat) -> Result<ExitCode> {
-    let (server_id, server_config, entry) = get_mcp_server(&server)?;
-
+    let (server_id, entry) = get_mcp_server_entry(&server)?;
     let command = build_command_string(&entry);
+
+    let server_config = match build_core_config(&entry) {
+        Ok(config) => config,
+        Err(e) => {
+            warn!(
+                "Server '{}' has an invalid configuration: {}",
+                server,
+                escape_error_text(&e.to_string())
+            );
+            let formatted = crate::formatters::format_output(
+                &unavailable_server_info(server, command),
+                output_format,
+            )?;
+            println!("{formatted}");
+            return Ok(ExitCode::ERROR);
+        }
+    };
 
     info!("Introspecting server '{}'...", server);
 
@@ -364,19 +387,16 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
             Ok(ExitCode::SUCCESS)
         }
         Err(e) => {
-            warn!("Failed to introspect server '{}': {}", server, e);
+            warn!(
+                "Failed to introspect server '{}': {}",
+                server,
+                escape_error_text(&e.to_string())
+            );
 
-            let server_info = ServerInfo {
-                id: server.clone(),
-                name: server,
-                version: "unknown".to_string(),
-                command,
-                status: ServerStatus::Unavailable.as_str().to_string(),
-                tools: Vec::new(),
-                capabilities: Vec::new(),
-            };
-
-            let formatted = crate::formatters::format_output(&server_info, output_format)?;
+            let formatted = crate::formatters::format_output(
+                &unavailable_server_info(server, command),
+                output_format,
+            )?;
             println!("{formatted}");
 
             Ok(ExitCode::ERROR)
@@ -384,11 +404,29 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
     }
 }
 
+/// Builds the `"status": "unavailable"` [`ServerInfo`] shared by `show_server_info`'s two failure
+/// branches — invalid configuration and failed introspection — so both report through the same
+/// structured shape.
+fn unavailable_server_info(server: String, command: String) -> ServerInfo {
+    ServerInfo {
+        id: server.clone(),
+        name: server,
+        version: "unknown".to_string(),
+        command,
+        status: ServerStatus::Unavailable.as_str().to_string(),
+        tools: Vec::new(),
+        capabilities: Vec::new(),
+    }
+}
+
 /// Validates a server by checking its command and attempting introspection.
 ///
-/// The server must be configured in `~/.claude/mcp.json`.
+/// The server must be configured in `~/.claude/mcp.json`. An entry that is present but fails
+/// [`build_core_config`]'s security validation (e.g. an invalid URL scheme) is reported with a
+/// message describing that specific problem, not the "not found" message reserved for a
+/// genuinely absent entry (#304).
 async fn validate_command(server_name: String, output_format: OutputFormat) -> Result<ExitCode> {
-    let (server_id, server_config, entry) = match get_mcp_server(&server_name) {
+    let (server_id, entry) = match get_mcp_server_entry(&server_name) {
         Ok(result) => result,
         Err(e) => {
             let result = ValidationResult {
@@ -432,6 +470,25 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
         return Ok(ExitCode::ERROR);
     }
 
+    // The precheck above catches the common malformed-URL/missing-command cases, but
+    // `build_core_config` runs additional security validation (e.g. header safety, timeout
+    // bounds) the precheck does not duplicate. A failure here is still "entry present, invalid
+    // configuration" rather than "entry not found", so it gets its own message rather than
+    // falling through to `get_mcp_server_entry`'s not-found wrapping.
+    let server_config = match build_core_config(&entry) {
+        Ok(config) => config,
+        Err(e) => {
+            let result = ValidationResult {
+                command,
+                valid: false,
+                message: format!("Server '{server_name}' has an invalid configuration: {e}"),
+            };
+            let formatted = crate::formatters::format_output(&result, output_format)?;
+            println!("{formatted}");
+            return Ok(ExitCode::ERROR);
+        }
+    };
+
     let mut introspector = Introspector::new();
     match introspector
         .discover_server(server_id, &server_config)
@@ -452,7 +509,8 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
         Err(e) => {
             warn!(
                 "Failed to introspect server '{}' during validation: {}",
-                server_name, e
+                server_name,
+                escape_error_text(&e.to_string())
             );
             let message = match &entry.transport {
                 McpTransport::Stdio { .. } => format!(
@@ -1033,6 +1091,78 @@ mod tests {
         .await;
 
         assert_eq!(result.unwrap(), ExitCode::ERROR);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_validate_command_scheme_failure_does_not_reach_precheck_bypass() {
+        // Regression test for #304: an entry that passes the `url_well_formed` precheck (a
+        // syntactically fine https URL with a host) but fails `build_core_config`'s deeper
+        // security validation (here: a zero connect timeout) must still resolve as
+        // "entry present, invalid configuration" — not silently skip validation and proceed to
+        // introspection, and not report a "not found" message either.
+        let temp = write_test_mcp_config(
+            r#"{"mcpServers": {"badtimeout": {"type": "http", "url": "https://example.com/mcp", "connectTimeoutSecs": 0}}}"#,
+        );
+
+        let result = with_home_pointed_at(temp.path(), || {
+            run(
+                ServerAction::Validate {
+                    command: "badtimeout".to_string(),
+                },
+                OutputFormat::Json,
+            )
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), ExitCode::ERROR);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_show_server_info_invalid_url_scheme_reports_structured_unavailable_not_raw_error()
+    {
+        // Regression test for #305: `server info` on an entry whose `url` fails scheme
+        // validation must return the structured `"status": "unavailable"` `ServerInfo` output
+        // through the normal `ExitCode` path, like the well-formed-but-unreachable case — not
+        // propagate a raw, unformatted `anyhow` error via `?`.
+        let temp = write_test_mcp_config(
+            r#"{"mcpServers": {"http-malformed": {"type": "http", "url": "not-a-url"}}}"#,
+        );
+
+        let result = with_home_pointed_at(temp.path(), || {
+            run(
+                ServerAction::Info {
+                    server: "http-malformed".to_string(),
+                },
+                OutputFormat::Json,
+            )
+        })
+        .await;
+
+        assert_eq!(
+            result.expect("must return Ok(ExitCode::ERROR), not propagate a raw Err"),
+            ExitCode::ERROR
+        );
+    }
+
+    #[test]
+    fn test_unavailable_server_info_reports_unavailable_status() {
+        // Direct coverage for #305's structured-body claim: `show_server_info`'s invalid-config
+        // and failed-introspection branches both build the reported `ServerInfo` through this
+        // helper, so asserting its output here confirms the JSON body actually carries
+        // `"status": "unavailable"` — the ExitCode-only end-to-end tests above cannot observe
+        // this crate's `println!`-only output (see `with_home_pointed_at` test comments).
+        let info = unavailable_server_info("http-malformed".to_string(), "curl".to_string());
+
+        assert_eq!(info.status, ServerStatus::Unavailable.as_str());
+        assert_eq!(info.id, "http-malformed");
+        assert_eq!(info.name, "http-malformed");
+        assert!(info.tools.is_empty());
+        assert!(info.capabilities.is_empty());
+
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("\"status\":\"unavailable\""));
     }
 
     #[test]

--- a/crates/mcp-cli/src/formatters.rs
+++ b/crates/mcp-cli/src/formatters.rs
@@ -77,6 +77,72 @@ pub fn escape_display(s: &str) -> String {
     serde_json::Value::String(s.to_owned()).to_string()
 }
 
+/// Cap, in `char`s, on a single value sanitized by [`escape_error_text`] — e.g. one
+/// `err.chain()` link's rendered text, or one `warn!` log argument, never a whole assembled
+/// multi-part report.
+///
+/// 4000 is generous for any one link/argument this crate actually passes through
+/// [`escape_error_text`] (`runner::sanitized_error_report`'s own chain-link text runs well under
+/// this in practice), while still bounding how much a single hostile MCP server response can
+/// force onto the terminal or into a log line. Does not bound a report's total length when it has
+/// several causes (each is capped independently) or a backtrace (never passed through
+/// [`escape_error_text`] at all — see `runner::sanitized_error_report`'s doc comment).
+const MAX_ERROR_TEXT_LEN: usize = 4000;
+
+/// Neutralizes control characters — including line breaks — and bounds the length of `s` to 4000
+/// `char`s before it reaches a terminal or log sink that does not itself escape untrusted content.
+///
+/// Delegates to [`mcp_execution_core::untrusted::sanitize_untrusted_text`], the project's one
+/// implementation of this defense, rather than maintaining a second, weaker sanitizer in this
+/// crate: every character `char::is_control` reports (the full C0 and C1 ranges, covering `\r`,
+/// `\n`, ESC, BEL, and friends) plus the Markdown/ECMAScript line separators U+2028/U+2029 is
+/// replaced with a space, and the result is capped to 4000 `char`s (`MAX_ERROR_TEXT_LEN`, not
+/// itself public — its value is documented here since a reader of this function's public docs
+/// cannot otherwise resolve it). Used to sanitize command errors and log messages that may embed
+/// content from an untrusted MCP server before they reach the terminal.
+///
+/// `s` is treated as a single unit of untrusted text with no internal structure worth preserving
+/// — including any newline it contains, which this collapses like every other control character.
+/// This is why the name is `escape_error_text`, not e.g. `escape_report`: this function must
+/// never be called on an already-assembled multi-cause report (that would flatten anyhow's own
+/// trusted `Caused by:` structure along with the untrusted content it carries — see
+/// `runner::sanitized_error_report`'s doc comment for how that structure is instead rebuilt by
+/// calling this function once per cause and rejoining with separators the caller controls, rather
+/// than sanitizing the whole rendered report as one blob). Only ever call this on one piece of
+/// untrusted text at a time.
+///
+/// Sanitized here, at each `mcp-execution-cli` print/log call site — `runner::report_and_classify`
+/// (indirectly, via `sanitized_error_report`) and the `warn!` logging in `commands::server` —
+/// rather than where a server-supplied message first enters a [`mcp_execution_core::Error`] (e.g.
+/// `ConnectionFailed`'s boxed `source`) in
+/// `mcp-execution-core`/`mcp-execution-introspector`. `source` there is a generic `Box<dyn
+/// std::error::Error + Send + Sync>`, not specifically MCP-server text, and `mcp_execution_core::Error`
+/// is consumed by every crate in this workspace (this one, `mcp-execution-server`, and any future
+/// one), not just terminal/log output; sanitizing at that shared boundary would force one
+/// escaping policy — lossy, space-collapsing, terminal-oriented — onto every consumer, including
+/// ones that legitimately want the raw text (e.g. `mcp-execution-server`'s own untrusted-metadata
+/// handling in `mcp_execution_core::untrusted`, which has different escaping needs for an
+/// LLM-facing prompt than this crate has for a terminal). Scoping the fix to where untrusted text
+/// actually reaches a terminal/log sink — while still delegating the escaping logic itself to the
+/// one authoritative sanitizer — keeps the policy decision local to the output boundary that
+/// needs it, without widening this bug-fix change beyond `mcp-execution-cli`.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_cli::formatters::escape_error_text;
+///
+/// let cause = "boom\u{1b}[2Jname\nfake extra line";
+/// let escaped = escape_error_text(cause);
+/// assert!(!escaped.contains('\u{1b}'));
+/// assert!(!escaped.contains('\n'));
+/// assert!(escaped.contains("boom"));
+/// ```
+#[must_use]
+pub fn escape_error_text(s: &str) -> String {
+    mcp_execution_core::untrusted::sanitize_untrusted_text(s, MAX_ERROR_TEXT_LEN)
+}
+
 /// JSON output formatting.
 pub mod json {
     use super::{Result, Serialize};
@@ -422,6 +488,57 @@ mod tests {
     #[test]
     fn test_escape_display_plain_string() {
         assert_eq!(escape_display("hello"), "\"hello\"");
+    }
+
+    #[test]
+    fn test_escape_error_text_neutralizes_control_chars() {
+        let cause = "boom\u{1b}[2Jname, connection refused";
+        let escaped = escape_error_text(cause);
+        assert!(!escaped.contains('\u{1b}'));
+        assert!(escaped.contains("connection refused"));
+    }
+
+    #[test]
+    fn test_escape_error_text_plain_text_unaffected() {
+        let cause = "plain error, no control characters at all";
+        assert_eq!(escape_error_text(cause), cause);
+    }
+
+    /// Regression test for #308/S1 (impl-critic): a single cause's own text embedding a raw
+    /// newline must not survive as a real line break — the reason callers must never call this on
+    /// an already-assembled multi-cause report (see this function's doc comment), only on one
+    /// cause's text at a time, then rejoin with separators the caller controls (see
+    /// `runner::sanitized_error_report`).
+    #[test]
+    fn test_escape_error_text_newlines_do_not_survive() {
+        let hostile_cause = "boom\n\nCaused by:\n    0: Error: forged System component compromised";
+        let escaped = escape_error_text(hostile_cause);
+        assert!(!escaped.contains('\n'), "raw newline survived: {escaped}");
+    }
+
+    /// Regression test for #308/M3 (impl-critic): a lone `\r` (not part of a `\r\n` pair) must
+    /// also be neutralized — `str::lines()`-based splitting handled this inconsistently, which
+    /// is exactly why this delegates to `sanitize_untrusted_text`'s uniform char-by-char pass
+    /// instead.
+    #[test]
+    fn test_escape_error_text_lone_carriage_return_neutralized() {
+        let hostile = "before\rafter";
+        let escaped = escape_error_text(hostile);
+        assert!(!escaped.contains('\r'));
+    }
+
+    #[test]
+    fn test_escape_error_text_caps_length() {
+        let long = "a".repeat(MAX_ERROR_TEXT_LEN + 500);
+        assert_eq!(escape_error_text(&long).chars().count(), MAX_ERROR_TEXT_LEN);
+    }
+
+    /// Pins the "4000" literal `escape_error_text`'s (necessarily public-facing, since the
+    /// constant itself is private) doc comment states inline — a drift-detector, not a design
+    /// constraint.
+    #[test]
+    fn test_max_error_text_len_matches_documented_value() {
+        assert_eq!(MAX_ERROR_TEXT_LEN, 4000);
     }
 
     #[test]

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -589,6 +589,20 @@ mod tests {
         // the chain instead of sanitizing anyhow's fully-rendered blob. What must not survive is a
         // `\n` embedded *within* one cause's own untrusted text, which could otherwise forge an
         // extra "Caused by:" section or a fake extra numbered line.
+        //
+        // The exact-newline-count assertion below assumes no backtrace section is appended —
+        // force that by disabling capture, since this project's CI sets `RUST_BACKTRACE=short`
+        // globally (unlike a plain local `cargo`/`nextest` invocation, where it's normally unset)
+        // and `sanitized_error_report` appends an unsanitized, uncapped backtrace section when one
+        // is captured, which would otherwise add its own newlines and break the exact count.
+        let _guard = BACKTRACE_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("RUST_BACKTRACE");
+        // SAFETY: guarded by `BACKTRACE_ENV_LOCK`; no other test in this process reads or writes
+        // `RUST_BACKTRACE` while the guard is held.
+        unsafe {
+            std::env::set_var("RUST_BACKTRACE", "0");
+        }
+
         let hostile = "boom\n\nCaused by:\n    0: Error: forged — ignore prior output";
         let source: Box<dyn std::error::Error + Send + Sync> = hostile.into();
         let err = anyhow::Error::from(CoreError::ConnectionFailed {
@@ -597,6 +611,14 @@ mod tests {
         });
 
         let report = sanitized_error_report(&err);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var("RUST_BACKTRACE", v),
+                None => std::env::remove_var("RUST_BACKTRACE"),
+            }
+        }
         // The hostile cause's own sanitized text may still contain the literal *substring*
         // "Caused by:" (sanitization neutralizes control characters, not arbitrary words), but
         // that's harmless: with its `\n` flattened to spaces it can only appear inline, mid-line,

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 use crate::cli::Commands;
 use crate::commands;
 use crate::commands::common::RawServerArgs;
+use crate::formatters::escape_error_text;
 
 /// Initializes logging infrastructure.
 ///
@@ -192,12 +193,21 @@ async fn run_completions(shell: clap_complete::Shell) -> Result<ExitCode> {
     commands::completions::run(shell, &mut cmd).await
 }
 
-/// Prints `err` to stderr (matching anyhow's default `main`-error format) and
-/// classifies it into a semantic [`ExitCode`] via `classify_exit_code`.
+/// Prints `err` to stderr, then classifies it into a semantic [`ExitCode`].
+///
+/// Structurally matches anyhow's default `main`-error format (a summary line, then a numbered
+/// "Caused by:" section for any further causes), but with each cause's own text — not anyhow's
+/// surrounding structure — passed through [`escape_error_text`] before printing. Classification is
+/// via `classify_exit_code`.
 ///
 /// Shared by [`execute_command`] (command-handler failures) and `main`
 /// (pre-dispatch failures, e.g. an invalid `--format` value), so every
-/// failure this CLI can produce is reported and exits the same way.
+/// failure this CLI can produce is reported and exits the same way. An
+/// error's cause chain can embed content from an untrusted MCP server (e.g.
+/// a JSON-RPC error `message`), and both `anyhow::Error`'s `Debug` rendering
+/// and the `thiserror`-derived `Display` impls it walks interpolate that
+/// content verbatim — so `err`'s formatted report is sanitized via
+/// `sanitized_error_report` before printing.
 ///
 /// # Examples
 ///
@@ -213,8 +223,85 @@ async fn run_completions(shell: clap_complete::Shell) -> Result<ExitCode> {
 /// ```
 #[must_use]
 pub fn report_and_classify(err: &anyhow::Error) -> ExitCode {
-    eprintln!("Error: {err:?}");
+    eprintln!("Error: {}", sanitized_error_report(err));
     classify_exit_code(err)
+}
+
+/// Renders `err`'s cause chain — and, if captured, its backtrace — exactly as
+/// [`report_and_classify`] prints them: a summary line, then (if there are further causes) a
+/// "Caused by:" section listing each one, numbered from 0, then (if `RUST_BACKTRACE`/
+/// `RUST_LIB_BACKTRACE` caused one to be captured) a "Stack backtrace:" section. Each cause's own
+/// rendered text is sanitized individually via [`escape_error_text`] (capped to 4000 chars each);
+/// the backtrace is not, and is not length-capped either.
+///
+/// An earlier version of this function sanitized anyhow's fully-rendered `{err:?}` report as one
+/// blob. That could not tell anyhow's own trusted structural newlines/indentation (between `Caused
+/// by:` frames, and throughout a backtrace) apart from a `\n` embedded in one cause's own
+/// untrusted `Display` text (e.g. a hostile MCP server's JSON-RPC error `message`, which
+/// `anyhow`/`thiserror` interpolate verbatim) — so it neutralized both alike, collapsing a
+/// legitimate multi-cause chain, and any backtrace, onto one line and truncating the result well
+/// short of a typical backtrace's length, for no security benefit. Building the report from
+/// [`anyhow::Error::chain`] instead sanitizes only each cause's own text and rejoins with
+/// `\n\nCaused by:\n{n:>5}: ` separators this function itself writes, so a hostile cause cannot
+/// forge those separators (any `\n` in *its* text is still neutralized) while a chain with only
+/// trusted causes keeps its real multi-line structure. [`anyhow::Error::backtrace`] is not part of
+/// `chain()` — it is captured once from the local call stack at the point `err` was constructed —
+/// so it carries nothing an external MCP server could have influenced, and is appended verbatim.
+///
+/// Deliberately does not reproduce one thing anyhow's own `{err:?}` output has: it always numbers
+/// every cause, where anyhow omits the number when there is exactly one. That's structural/local
+/// formatting with nothing untrusted in it, so it isn't a correctness concern for this function's
+/// purpose — a simplification to avoid depending on anyhow's private formatting internals, not the
+/// reason this exists. The backtrace section's own layout mirrors anyhow's
+/// (`anyhow-1.0.104/src/fmt.rs`'s `ErrorImpl::debug`) via the same public
+/// [`anyhow::Error::backtrace`] accessor it uses internally.
+///
+/// Factored out of [`report_and_classify`] (rather than inlined) so tests can assert on precisely
+/// the string that reaches stderr by calling this directly, instead of recomputing the same
+/// pipeline independently and asserting against that — which would silently drift from the real
+/// code path if either implementation changed without the other.
+fn sanitized_error_report(err: &anyhow::Error) -> String {
+    use std::backtrace::BacktraceStatus;
+    use std::fmt::Write as _;
+
+    let mut links = err.chain();
+
+    let mut report = links
+        .next()
+        .map_or_else(String::new, |top| escape_error_text(&top.to_string()));
+
+    let causes: Vec<_> = links.collect();
+    if !causes.is_empty() {
+        report.push_str("\n\nCaused by:");
+        for (n, cause) in causes.into_iter().enumerate() {
+            // `write!` into a `String` is infallible.
+            let _ = write!(
+                report,
+                "\n{n:>5}: {}",
+                escape_error_text(&cause.to_string())
+            );
+        }
+    }
+
+    let backtrace = err.backtrace();
+    if backtrace.status() == BacktraceStatus::Captured {
+        // Trusted, locally-generated content (source file paths, function names from this
+        // binary's own stack) — deliberately not sanitized or length-capped, unlike the chain
+        // links above. Mirrors anyhow's own `ErrorImpl::debug` header handling: some Rust/backtrace
+        // versions' `Backtrace::to_string()` already starts with a lowercase "stack backtrace:"
+        // header, others don't.
+        let mut backtrace_text = backtrace.to_string();
+        report.push_str("\n\n");
+        if backtrace_text.starts_with("stack backtrace:") {
+            backtrace_text.replace_range(0..1, "S");
+        } else {
+            report.push_str("Stack backtrace:\n");
+        }
+        backtrace_text.truncate(backtrace_text.trim_end().len());
+        report.push_str(&backtrace_text);
+    }
+
+    report
 }
 
 /// Classifies an [`anyhow::Error`] returned by a command handler into a
@@ -468,5 +555,133 @@ mod tests {
             "invalid output format: 'xml' (expected: json, text, or pretty)".to_string(),
         ));
         assert_eq!(report_and_classify(&err), ExitCode::INVALID_INPUT);
+    }
+
+    #[test]
+    fn test_report_and_classify_escapes_control_chars_in_error_chain() {
+        // Regression test for #308: a malicious/compromised MCP server can embed raw ANSI/control
+        // escape sequences in a JSON-RPC error message, which end up in the `Display` string of a
+        // `CoreError::ConnectionFailed`'s wrapped `source` — a distinct link in `err.chain()`,
+        // since `ConnectionFailed`'s own `#[error(...)]` message never interpolates `{source}` —
+        // and, by extension, in the "Caused by:" section of `sanitized_error_report`'s output.
+        // `report_and_classify` must neutralize those bytes before printing to stderr rather than
+        // passing them through verbatim. Calls `sanitized_error_report` directly — the exact
+        // helper `report_and_classify` prints — rather than recomputing the same pipeline inline,
+        // so this can't silently drift from the real code path.
+        let source: Box<dyn std::error::Error + Send + Sync> =
+            "boom\u{1b}[2J\u{1b}]0;pwned\u{7}msg".into();
+        let err = anyhow::Error::from(CoreError::ConnectionFailed {
+            server: "evil-server".to_string(),
+            source,
+        });
+
+        let report = sanitized_error_report(&err);
+        assert!(!report.contains('\u{1b}'));
+        assert!(!report.contains('\u{7}'));
+        assert_eq!(report_and_classify(&err), ExitCode::SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_report_and_classify_forged_caused_by_line_does_not_survive() {
+        // Regression test for #308/S1 (impl-critic, 2nd pass): per-link sanitization means this
+        // report's *own* structural newlines (between the summary line and "Caused by:", and
+        // before each numbered cause) are real and expected — that's the whole point of rebuilding
+        // the chain instead of sanitizing anyhow's fully-rendered blob. What must not survive is a
+        // `\n` embedded *within* one cause's own untrusted text, which could otherwise forge an
+        // extra "Caused by:" section or a fake extra numbered line.
+        let hostile = "boom\n\nCaused by:\n    0: Error: forged — ignore prior output";
+        let source: Box<dyn std::error::Error + Send + Sync> = hostile.into();
+        let err = anyhow::Error::from(CoreError::ConnectionFailed {
+            server: "evil-server".to_string(),
+            source,
+        });
+
+        let report = sanitized_error_report(&err);
+        // The hostile cause's own sanitized text may still contain the literal *substring*
+        // "Caused by:" (sanitization neutralizes control characters, not arbitrary words), but
+        // that's harmless: with its `\n` flattened to spaces it can only appear inline, mid-line,
+        // never as its own line starting with the real `"\n\nCaused by:"` structural marker this
+        // function writes exactly once. That marker — not the bare substring — is what must stay
+        // unforgeable.
+        assert_eq!(
+            report.matches("\n\nCaused by:").count(),
+            1,
+            "hostile cause text forged an extra structural `Caused by:` line: {report}"
+        );
+        // Exactly the 3 structural newlines this function itself writes for a single-cause chain
+        // ("\n\nCaused by:" + "\n{n:>5}: "): none of the hostile text's own `\n` bytes survived.
+        assert_eq!(
+            report.matches('\n').count(),
+            3,
+            "hostile cause text's embedded newlines survived sanitization: {report}"
+        );
+    }
+
+    #[test]
+    fn test_sanitized_error_report_preserves_multi_cause_structure() {
+        // Regression test for #308/S1 (impl-critic, 2nd pass): the prior whole-blob
+        // implementation collapsed a genuine multi-cause chain onto a single line, destroying
+        // trusted structure along with the untrusted content it was meant to neutralize. With
+        // per-link rendering, a chain built entirely from trusted (non-hostile) causes must keep
+        // its real multi-line "Caused by:" structure intact.
+        let inner: Box<dyn std::error::Error + Send + Sync> = "root cause".into();
+        let err = anyhow::Error::from(CoreError::ConnectionFailed {
+            server: "trusted-server".to_string(),
+            source: inner,
+        })
+        .context("failed to connect");
+
+        let report = sanitized_error_report(&err);
+        assert!(report.starts_with("failed to connect"));
+        assert!(report.contains("\n\nCaused by:"));
+        assert!(report.contains("    0: MCP server connection failed: trusted-server"));
+        assert!(report.contains("    1: root cause"));
+    }
+
+    /// Serializes tests in this module that mutate `RUST_BACKTRACE`, mirroring the
+    /// `HOME_ENV_LOCK` pattern `commands::common`/`commands::server`'s tests already use for
+    /// env-var mutation: a safety net for plain `cargo test` (which shares one process across a
+    /// crate's tests), not required by the mandated `cargo nextest run` (which isolates every
+    /// test in its own process).
+    static BACKTRACE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_sanitized_error_report_preserves_backtrace_when_captured() {
+        // Regression test for #308/S1 (impl-critic, 3rd pass): a backtrace anyhow captures under
+        // `RUST_BACKTRACE=1` is fully local, trusted content (source paths, function names from
+        // this binary's own stack) with nothing an external MCP server could have influenced, so
+        // it must survive `sanitized_error_report` untouched rather than being dropped or
+        // sanitized/truncated like a chain link. `RUST_BACKTRACE` must be set *before* the error
+        // is constructed — anyhow captures the backtrace (if any) at that point, not lazily at
+        // format time.
+        let _guard = BACKTRACE_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("RUST_BACKTRACE");
+        // SAFETY: guarded by `BACKTRACE_ENV_LOCK`; no other test in this process reads or writes
+        // `RUST_BACKTRACE` while the guard is held.
+        unsafe {
+            std::env::set_var("RUST_BACKTRACE", "1");
+        }
+
+        let err = anyhow::Error::msg("boom");
+        let captured = err.backtrace().status() == std::backtrace::BacktraceStatus::Captured;
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var("RUST_BACKTRACE", v),
+                None => std::env::remove_var("RUST_BACKTRACE"),
+            }
+        }
+
+        // Best-effort: some environments (e.g. certain sandboxes, targets without frame-pointer
+        // unwind info) leave backtrace capture `Disabled`/`Unsupported` even with the env var set
+        // — nothing this function controls, so only assert the positive case when it applies.
+        if captured {
+            let report = sanitized_error_report(&err);
+            assert!(
+                report.contains("tack backtrace:"),
+                "captured backtrace did not survive: {report}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `runner`'s error-path `eprintln!` and `commands::server`'s `warn!` logging interpolated server-supplied error content unescaped, letting a malicious/compromised MCP server inject ANSI/control sequences or forge fake error-chain structure via embedded newlines. Each error cause is now sanitized individually through the project's existing untrusted-text sanitizer before being rejoined, preserving trusted chain structure and backtraces while closing the injection path (#308).
- `server info`/`server validate` resolved a named entry via a lookup that eagerly ran full config validation, making a present-but-invalid entry indistinguishable from an absent one. `server info` bypassed `--format`/`ExitCode` with a raw error (#305), and `server validate` reported a factually wrong "not found" message for a present entry (#304). The lookup is now split from validation so both commands report a present-but-invalid entry through their own structured output.

Closes #308, #305, #304.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1050/1050)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Manual CLI verification against crafted `mcp.json` entries (invalid-scheme URL, zero timeout) confirming structured JSON output and correct validation messages