### PR TITLE
refactor(codegen): eliminate domain-impossible states in ToolContext/BridgeContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `build_server_config`'s example scenario remains covered by the existing
   `test_build_server_config_stdio` unit test (#266).
 
+- **`mcp-execution-codegen`**: `ToolContext::short_description` changed from `Option<String>` to
+  `String`. The only constructor (`ProgressiveGenerator::create_tool_context`) always populated
+  it — falling back to the tool's own description when no categorization short description was
+  available — so `None` was a state the type could represent but the pipeline could never
+  actually produce; the field now reflects that guarantee structurally instead of leaving every
+  consumer to re-check an `Option` that was never `None` in practice. `ToolCategorization::keywords`
+  changed from a comma-joined `String` to `Vec<String>`, removing the ad hoc
+  `split(',').map(str::trim)` re-parsing this forced on its one real consumer
+  (`create_tool_metadata`'s `_meta.json` sidecar keywords); JSDoc rendering (the `.ts` header
+  comment, `index.ts`'s tool listing) now joins the vector with `", "` at the point it needs a
+  display string, via a new `render_keywords_for_jsdoc` helper. `mcp-execution-server`'s
+  `generate_with_categorization`, which converts the wire-format `CategorizedTool::keywords`
+  (still a comma-separated `String` — that shape is part of the tool's MCP-facing JSON schema)
+  into a `ToolCategorization`, now does the comma-splitting exactly once, at that boundary,
+  instead of the old duplicated re-parse further downstream (#316).
+
+- **`mcp-execution-codegen`**: `BridgeContext`'s `forbidden_chars`/`forbidden_env_names`/
+  `forbidden_env_prefix` fields are now private, with read-only `forbidden_chars()`/
+  `forbidden_env_names()`/`forbidden_env_prefix()` accessors. Previously being `pub` let
+  `BridgeContext { forbidden_chars: vec![], .. }` compile and silently bypass the hand-written
+  `Default` impl's invariant that these lists are never empty — an empty `forbidden_chars` would
+  render a bridge whose `validateCommandString` accepts every shell metacharacter, fail-open on
+  exactly the check it exists to enforce. `BridgeContext::default()` is now the only way to
+  construct a valid instance. `Deserialize` is no longer derived: nothing in this codebase
+  deserializes a `BridgeContext` from external input, and templates only ever render it via
+  `Serialize` (#315).
+
 ### Security
 
 - **`mcp-cli`**: `generate`'s `Text`/`Pretty` output (both the success summary and the dry-run
@@ -446,6 +473,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   impls, closing the last unredacted path by which a raw, unparsed URL argument — which can
   embed credentials, e.g. `https://user:token@host/mcp` — reached CLI debug/log output before
   `TransportArgs`/`McpTransport` ever get a chance to redact it (#251).
+
+- **`mcp-execution-codegen`**: `sanitize_jsdoc` replaced `*/` and normalized `\r`/`\n`/U+2028/
+  U+2029 but let every other C0 control character (in particular ESC `\x1b`) through unmodified.
+  This project's documented workflow for reading a generated tool is `cat
+  ~/.claude/servers/<id>/<tool>.ts`, so a malicious MCP server could embed an ANSI escape
+  sequence in a tool description or categorization field and have it replayed verbatim to a
+  user's terminal. `sanitize_jsdoc` now neutralizes control characters (C0, DEL, and C1 —
+  everything `char::is_control` reports — plus U+2028/U+2029) by delegating to the shared
+  `mcp_execution_core::untrusted::sanitize_untrusted_text`, which *replaces* each with a space
+  rather than deleting it, and does so *before* escaping `*/` rather than after: an initial
+  version of this fix escaped `*/` first and only then stripped control characters, which meant
+  a control character sitting directly between `*` and `/` survived the escape untouched and
+  then collapsed into a live, unescaped `*/` once removed — reopening the JSDoc comment and
+  making the remaining tool description live TypeScript. Neutralizing first (and replacing with
+  a space instead of deleting) closes that gap and also stops adjacent words from being glued
+  together (e.g. `"tab\tseparated"` no longer becomes `"tabseparated"`) (#300).
+- **`mcp-execution-introspector`**: `build_tool_info`'s `tracing::trace!("Found tool: {name}")`
+  interpolated an MCP server's raw, unvalidated tool name directly into the log message text
+  before any of this function's own length validation ran. The trace call now runs after the
+  tool-name length check and sanitizes the name through the same shared
+  `mcp_execution_core::untrusted::sanitize_untrusted_text` used above before logging it as a
+  structured field, so a malicious tool name's control characters (e.g. an ANSI escape
+  sequence) cannot reach an operator's terminal via `RUST_LOG=trace` regardless of how the
+  installed `tracing` subscriber renders structured fields (#300).
 
 ### Testing
 

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -314,7 +314,7 @@ impl<'a> ProgressiveGenerator<'a> {
     /// let mut categorizations = HashMap::new();
     /// categorizations.insert("create_issue".to_string(), ToolCategorization {
     ///     category: "issues".to_string(),
-    ///     keywords: "create,issue,new,bug".to_string(),
+    ///     keywords: vec!["create".to_string(), "issue".to_string(), "new".to_string(), "bug".to_string()],
     ///     short_description: "Create a new issue".to_string(),
     /// });
     ///
@@ -502,10 +502,10 @@ impl<'a> ProgressiveGenerator<'a> {
         let description = sanitize_jsdoc(&tool.description, 256);
         // Falls back to the tool's own description when no LLM categorization is
         // available, so the header JSDoc always emits `@description` (issue #94).
-        let short_description = Some(categorization.map_or_else(
+        let short_description = categorization.map_or_else(
             || description.clone(),
             |c| sanitize_jsdoc(&c.short_description, 256),
-        ));
+        );
 
         Ok(ToolContext {
             server_id: sanitize_jsdoc(server_id, 256),
@@ -517,7 +517,7 @@ impl<'a> ProgressiveGenerator<'a> {
             input_schema: sanitize_schema_jsdoc_descriptions(tool.input_schema.clone()),
             properties,
             category: categorization.map(|c| sanitize_jsdoc(&c.category, 128)),
-            keywords: categorization.map(|c| sanitize_jsdoc(&c.keywords, 256)),
+            keywords: categorization.map(|c| render_keywords_for_jsdoc(&c.keywords)),
             short_description,
         })
     }
@@ -544,7 +544,7 @@ impl<'a> ProgressiveGenerator<'a> {
                     typescript_name: typescript_names.get(idx).cloned().unwrap_or_default(),
                     description: sanitize_jsdoc(&tool.description, 256),
                     category: cat.map(|c| sanitize_jsdoc(&c.category, 128)),
-                    keywords: cat.map(|c| sanitize_jsdoc(&c.keywords, 256)),
+                    keywords: cat.map(|c| render_keywords_for_jsdoc(&c.keywords)),
                     short_description: cat.map(|c| sanitize_jsdoc(&c.short_description, 256)),
                 }
             })
@@ -734,14 +734,7 @@ impl<'a> ProgressiveGenerator<'a> {
 
         let description = (!tool.description.is_empty()).then(|| tool.description.clone());
         let category = categorization.map(|c| c.category.clone());
-        let keywords = categorization.map_or_else(Vec::new, |c| {
-            c.keywords
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string)
-                .collect()
-        });
+        let keywords = categorization.map_or_else(Vec::new, |c| c.keywords.clone());
 
         Ok(ToolMetadata {
             name: tool.name.as_str().to_string(),
@@ -867,20 +860,33 @@ fn add_tracked(
 
 /// Sanitizes a server-controlled string for safe interpolation into JSDoc block comments.
 ///
-/// Prevents JSDoc comment terminator injection by replacing `*/` sequences,
-/// stripping newlines (including U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR,
-/// which ECMAScript treats as line terminators and which therefore also terminate a `//`
-/// line comment even though they aren't ASCII `\r`/`\n`), and truncating to a safe maximum
-/// length.
+/// Neutralizes control characters (C0, DEL, C1 — everything `char::is_control` reports —
+/// plus U+2028 LINE SEPARATOR/U+2029 PARAGRAPH SEPARATOR, which ECMAScript treats as line
+/// terminators even though they aren't in the control-character category) by delegating to
+/// the shared [`mcp_execution_core::untrusted::sanitize_untrusted_text`], which *replaces*
+/// each with a space rather than deleting it — deleting would glue adjacent words together
+/// (`"tab\tseparated"` -> `"tabseparated"`) and, more importantly, would let a control
+/// character sitting between `*` and `/` collapse into a live JSDoc comment terminator once
+/// removed. This neutralization runs *before* the `*/` escape step for exactly that reason:
+/// escaping first would see no `*/` match (the control character still separates them), then
+/// deleting/collapsing that character afterward would reopen the comment. Truncation to
+/// `max_len` runs last, after escaping, so a `*/` straddling the truncation boundary is
+/// already widened to `*\/` and cannot be split back into a bare `*/` by the cut.
 fn sanitize_jsdoc(s: &str, max_len: usize) -> String {
-    let sanitized = s
-        .replace("*/", "*\\/")
-        .replace(['\r', '\n', '\u{2028}', '\u{2029}'], " ");
+    let neutralized = mcp_execution_core::untrusted::sanitize_untrusted_text(s, usize::MAX);
+    let sanitized = neutralized.replace("*/", "*\\/");
     if sanitized.chars().count() > max_len {
         sanitized.chars().take(max_len).collect()
     } else {
         sanitized
     }
+}
+
+/// Joins `ToolCategorization::keywords` into the comma-separated form JSDoc rendering displays
+/// (`@keywords foo, bar, baz`), sanitizing the joined text the same way any other JSDoc-embedded
+/// value is sanitized.
+fn render_keywords_for_jsdoc(keywords: &[String]) -> String {
+    sanitize_jsdoc(&keywords.join(", "), 256)
 }
 
 /// Escapes a string for safe embedding inside a single-quoted TypeScript string literal.
@@ -1290,7 +1296,7 @@ mod tests {
             "create_issue".to_string(),
             ToolCategorization {
                 category: "issues".to_string(),
-                keywords: "create, issue , new".to_string(),
+                keywords: vec!["create".to_string(), "issue".to_string(), "new".to_string()],
                 short_description: "Create a new issue".to_string(),
             },
         );
@@ -1420,7 +1426,11 @@ mod tests {
 
         let categorization = ToolCategorization {
             category: "messaging".to_string(),
-            keywords: "send,message,chat".to_string(),
+            keywords: vec![
+                "send".to_string(),
+                "message".to_string(),
+                "chat".to_string(),
+            ],
             short_description: "Send a message".to_string(),
         };
         let context = generator
@@ -1441,11 +1451,8 @@ mod tests {
         assert_eq!(context.properties.len(), 1);
         assert_eq!(context.properties[0].name, "text");
         assert_eq!(context.category, Some("messaging".to_string()));
-        assert_eq!(context.keywords, Some("send,message,chat".to_string()));
-        assert_eq!(
-            context.short_description,
-            Some("Send a message".to_string())
-        );
+        assert_eq!(context.keywords, Some("send, message, chat".to_string()));
+        assert_eq!(context.short_description, "Send a message".to_string());
     }
 
     #[test]
@@ -1561,7 +1568,7 @@ mod tests {
 
         assert_eq!(
             context.short_description,
-            Some("Format document with language-specific rules".to_string())
+            "Format document with language-specific rules".to_string()
         );
 
         // The header JSDoc must emit @description even without LLM categorization.
@@ -2060,7 +2067,7 @@ mod tests {
             "create_issue".to_string(),
             ToolCategorization {
                 category: "issues\u{2028}export const pwned = 1;".to_string(),
-                keywords: String::new(),
+                keywords: vec![],
                 short_description: "Create a new issue".to_string(),
             },
         );
@@ -2098,6 +2105,45 @@ mod tests {
     #[test]
     fn test_sanitize_jsdoc_passthrough() {
         assert_eq!(sanitize_jsdoc("Normal string", 256), "Normal string");
+    }
+
+    #[test]
+    fn test_sanitize_jsdoc_strips_ansi_escape_sequence() {
+        // Issue #300: this project's documented workflow is `cat` on the generated `.ts`
+        // file, so a raw ESC (`\x1b`)-led ANSI escape sequence in a tool description must
+        // not survive into the JSDoc comment verbatim. The control character becomes a
+        // space (not deleted), so adjacent text is not glued together.
+        let payload = "Innocuous \x1b[31mred text\x1b[0m looking description";
+        let sanitized = sanitize_jsdoc(payload, 256);
+        assert!(!sanitized.contains('\x1b'));
+        assert_eq!(sanitized, "Innocuous  [31mred text [0m looking description");
+    }
+
+    #[test]
+    fn test_sanitize_jsdoc_replaces_other_c0_control_characters_with_space() {
+        assert_eq!(sanitize_jsdoc("a\u{0}b\u{7}c\u{7f}d", 256), "a b c d");
+    }
+
+    /// Critic C1 regression: a control character sitting directly between `*` and `/`
+    /// must not survive as a live JSDoc comment terminator. The old (buggy) order
+    /// escaped `*/` before neutralizing control characters, so `*\u{0}/` had no `*/`
+    /// substring at escape time, then the control character was deleted, reconstituting
+    /// a bare `*/` that closed the comment early and let the trailing text become live
+    /// top-level TypeScript.
+    #[test]
+    fn test_sanitize_jsdoc_control_char_between_star_slash_cannot_reopen_comment() {
+        for ctrl in ['\u{0}', '\u{7f}', '\u{1b}'] {
+            let payload = format!("safe *{ctrl}/ export const pwned = 1; //");
+            let sanitized = sanitize_jsdoc(&payload, 256);
+            assert!(
+                !sanitized.contains("*/"),
+                "control char {ctrl:?} must not let a bare `*/` reappear: {sanitized:?}"
+            );
+            assert!(
+                sanitized.contains("* /"),
+                "the control char should be neutralized to a space, not deleted: {sanitized:?}"
+            );
+        }
     }
 
     #[test]
@@ -2776,7 +2822,7 @@ mod tests {
             "create_issue".to_string(),
             ToolCategorization {
                 category: "issues */ injected\nnext".to_string(),
-                keywords: "create,*/ injected\nnext".to_string(),
+                keywords: vec!["create,*/ injected\nnext".to_string()],
                 short_description: "Create */ injected\nnext".to_string(),
             },
         );

--- a/crates/mcp-codegen/src/progressive/types.rs
+++ b/crates/mcp-codegen/src/progressive/types.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 ///     properties: vec![],
 ///     category: Some("issues".to_string()),
 ///     keywords: Some("create,issue,new,bug".to_string()),
-///     short_description: Some("Create a new issue".to_string()),
+///     short_description: "Create a new issue".to_string(),
 /// };
 ///
 /// assert_eq!(context.server_id, "github");
@@ -55,8 +55,10 @@ pub struct ToolContext {
     pub category: Option<String>,
     /// Optional keywords for discovery via grep/search
     pub keywords: Option<String>,
-    /// Optional short description for header comment
-    pub short_description: Option<String>,
+    /// Short description for header comment. Always populated: `ProgressiveGenerator`'s only
+    /// constructor falls back to `description` when no categorization short description is
+    /// available, so `None` is not a state this type can represent.
+    pub short_description: String,
 }
 
 /// Information about a single parameter property.
@@ -169,7 +171,7 @@ pub struct ToolSummary {
 ///
 /// let cat = ToolCategorization {
 ///     category: "issues".to_string(),
-///     keywords: "create,issue,new,bug".to_string(),
+///     keywords: vec!["create".to_string(), "issue".to_string(), "new".to_string(), "bug".to_string()],
 ///     short_description: "Create a new issue in a repository".to_string(),
 /// };
 ///
@@ -179,8 +181,8 @@ pub struct ToolSummary {
 pub struct ToolCategorization {
     /// Category for tool grouping
     pub category: String,
-    /// Comma-separated keywords for discovery
-    pub keywords: String,
+    /// Keywords for discovery via grep/search
+    pub keywords: Vec<String>,
     /// Concise description for header comment
     pub short_description: String,
 }
@@ -229,25 +231,82 @@ pub struct CategoryInfo {
 /// check this exists to enforce), so `Default` is hand-written to make "always populated" a
 /// property of the type rather than a convention callers must remember to uphold.
 ///
+/// The three fields are private with read-only accessors for the same reason: `pub` fields
+/// would let `BridgeContext { forbidden_chars: vec![], .. }` bypass the invariant entirely and
+/// still compile, silently reintroducing the fail-open state `Default` exists to prevent.
+/// `Deserialize` is intentionally not derived — nothing in this codebase deserializes a
+/// `BridgeContext` from external input, and doing so would need to re-validate non-emptiness
+/// rather than trust the wire data.
+///
 /// # Examples
 ///
 /// ```
 /// use mcp_execution_codegen::progressive::BridgeContext;
 ///
 /// let context = BridgeContext::default();
-/// assert!(!context.forbidden_chars.is_empty());
-/// assert!(context.forbidden_chars.contains(&";".to_string()));
-/// assert!(!context.forbidden_env_prefix.is_empty());
+/// assert!(!context.forbidden_chars().is_empty());
+/// assert!(context.forbidden_chars().contains(&";".to_string()));
+/// assert!(!context.forbidden_env_prefix().is_empty());
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// The shared `forbidden_` prefix mirrors the three distinct `mcp_execution_core` accessors
+// (`forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix`) these fields are populated
+// from; dropping it would obscure that correspondence for no clarity gain.
+#[allow(clippy::struct_field_names)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BridgeContext {
     /// Shell metacharacters forbidden in a command or argument string, each pre-escaped for
     /// safe embedding inside a single-quoted TypeScript string literal.
-    pub forbidden_chars: Vec<String>,
+    forbidden_chars: Vec<String>,
     /// Forbidden environment variable names (exact match).
-    pub forbidden_env_names: Vec<String>,
+    forbidden_env_names: Vec<String>,
     /// Environment-variable-name prefix rejected regardless of exact match (e.g. `DYLD_`).
-    pub forbidden_env_prefix: String,
+    forbidden_env_prefix: String,
+}
+
+impl BridgeContext {
+    /// Shell metacharacters forbidden in a command or argument string, each pre-escaped for
+    /// safe embedding inside a single-quoted TypeScript string literal. Never empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_codegen::progressive::BridgeContext;
+    ///
+    /// assert!(!BridgeContext::default().forbidden_chars().is_empty());
+    /// ```
+    #[must_use]
+    pub fn forbidden_chars(&self) -> &[String] {
+        &self.forbidden_chars
+    }
+
+    /// Forbidden environment variable names (exact match). Never empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_codegen::progressive::BridgeContext;
+    ///
+    /// assert!(!BridgeContext::default().forbidden_env_names().is_empty());
+    /// ```
+    #[must_use]
+    pub fn forbidden_env_names(&self) -> &[String] {
+        &self.forbidden_env_names
+    }
+
+    /// Environment-variable-name prefix rejected regardless of exact match (e.g. `DYLD_`).
+    /// Never empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_codegen::progressive::BridgeContext;
+    ///
+    /// assert!(!BridgeContext::default().forbidden_env_prefix().is_empty());
+    /// ```
+    #[must_use]
+    pub fn forbidden_env_prefix(&self) -> &str {
+        &self.forbidden_env_prefix
+    }
 }
 
 impl Default for BridgeContext {
@@ -290,7 +349,7 @@ mod tests {
             properties: vec![],
             category: Some("issues".to_string()),
             keywords: Some("create,issue,new".to_string()),
-            short_description: Some("Create a new issue".to_string()),
+            short_description: "Create a new issue".to_string(),
         };
 
         assert_eq!(context.server_id, "github");
@@ -352,8 +411,8 @@ mod tests {
         // #221 critique S2: `Default` must never render a fail-open (empty) forbidden-char
         // list, since an empty `FORBIDDEN_CHARS` in the rendered bridge would make
         // `validateCommandString` accept every shell metacharacter.
-        assert!(!context.forbidden_chars.is_empty());
-        assert!(!context.forbidden_env_names.is_empty());
-        assert!(!context.forbidden_env_prefix.is_empty());
+        assert!(!context.forbidden_chars().is_empty());
+        assert!(!context.forbidden_env_names().is_empty());
+        assert!(!context.forbidden_env_prefix().is_empty());
     }
 }

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -1176,7 +1176,6 @@ fn build_server_info(
 /// schema exceeds [`MAX_SCHEMA_SIZE_BYTES`].
 fn build_tool_info(tool: rmcp::model::Tool) -> Result<ToolInfo> {
     let name = tool.name.to_string();
-    tracing::trace!("Found tool: {name}");
 
     if name.len() > MAX_TOOL_NAME_LEN {
         return Err(Error::ResourceLimitExceeded {
@@ -1185,6 +1184,20 @@ fn build_tool_info(tool: rmcp::model::Tool) -> Result<ToolInfo> {
             limit: MAX_TOOL_NAME_LEN,
         });
     }
+
+    // Logged only after the length check above, and through the shared untrusted-metadata
+    // sanitizer (control characters replaced with a space) rather than the raw MCP-supplied
+    // name: this project's `fmt::layer()` subscriber (`mcp-execution-server`'s `main.rs`)
+    // renders trace fields verbatim, so an unsanitized name would let a malicious server plant
+    // an ANSI escape sequence (or similar) directly on the operator's terminal under
+    // `RUST_LOG=trace`.
+    tracing::trace!(
+        tool.name = %mcp_execution_core::untrusted::sanitize_untrusted_text(
+            &name,
+            mcp_execution_core::untrusted::MAX_UNTRUSTED_FIELD_LEN,
+        ),
+        "Found tool"
+    );
 
     let description = tool.description.unwrap_or_default().to_string();
     if description.len() > MAX_TOOL_DESCRIPTION_LEN {

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -1381,7 +1381,7 @@ fn generate_with_categorization(
                 tool_name.clone(),
                 ToolCategorization {
                     category: cat_tool.category.clone(),
-                    keywords: cat_tool.keywords.clone(),
+                    keywords: parse_keywords(&cat_tool.keywords),
                     short_description: cat_tool.short_description.clone(),
                 },
             )
@@ -1389,6 +1389,17 @@ fn generate_with_categorization(
         .collect();
 
     generator.generate_with_categories(server_info, &categorizations)
+}
+
+/// Splits `CategorizedTool::keywords`' comma-separated wire format into the individual
+/// keywords `ToolCategorization` expects, trimming whitespace and dropping empty entries
+/// (e.g. from a trailing comma or repeated separators).
+fn parse_keywords(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 #[cfg(test)]
@@ -1696,6 +1707,24 @@ mod tests {
 
         let result = generate_with_categorization(&generator, &server_info, &categorization);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_keywords_trims_whitespace_and_drops_empty_entries() {
+        assert_eq!(
+            parse_keywords("create, issue , new,,important"),
+            vec![
+                "create".to_string(),
+                "issue".to_string(),
+                "new".to_string(),
+                "important".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_keywords_empty_string_yields_empty_vec() {
+        assert!(parse_keywords("").is_empty());
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- `ToolContext::short_description` changes from `Option<String>` to `String` — its only constructor always populated it, so the type permitted a `None` state the pipeline never actually produced.
- `ToolCategorization::keywords` changes from a comma-joined `String` to `Vec<String>`, removing an ad hoc `split(',').trim()` re-parse at its one real consumer and allowing keywords that contain commas; JSDoc rendering now joins the vector only at the point a display string is needed.
- `BridgeContext`'s `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix` fields are now private with read-only accessors, so its hand-written `Default` (which exists to guarantee these lists are never empty — an empty `forbidden_chars` would make the generated bridge's shell-metacharacter guard fail open) can no longer be bypassed via direct struct construction.
- `sanitize_jsdoc` now reuses the project's shared untrusted-text sanitizer for control-character neutralization instead of a narrower ad hoc replacement list (this also closes a JSDoc `*/`-breakout regression caught during review — see Test plan), and the introspector sanitizes tool names before they reach its trace-level log.

Closes #316, #315, #300.

## Breaking changes

- `ToolContext::short_description`: `Option<String>` -> `String`
- `ToolCategorization::keywords`: `String` (comma-joined) -> `Vec<String>`
- `BridgeContext`'s three fields are private now; use the new accessor methods

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1041/1041)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Added regression test for a control-character-mediated JSDoc comment-breakout (`*` + control char + `/`) found and fixed during implementation