### PR TITLE
ci: restore fail-fast gating on downstream jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    if: always() && needs.changes.outputs.run-checks == 'true'
+    if: needs.changes.outputs.run-checks == 'true' && needs.check.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -185,7 +185,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # For uploading artifacts
-    if: always() && needs.changes.outputs.run-checks == 'true'
+    if: needs.changes.outputs.run-checks == 'true' && needs.check.result == 'success'
     steps:
       - uses: actions/checkout@v7
 
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-    if: always() && needs.changes.outputs.run-checks == 'true'
+    if: needs.changes.outputs.run-checks == 'true' && needs.check.result == 'success'
     steps:
       - uses: actions/checkout@v7
 
@@ -273,7 +273,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-    if: always() && needs.changes.outputs.run-checks == 'true'
+    if: needs.changes.outputs.run-checks == 'true' && needs.check.result == 'success'
     steps:
       - uses: actions/checkout@v7
 
@@ -296,7 +296,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-    if: always() && needs.changes.outputs.run-checks == 'true'
+    if: needs.changes.outputs.run-checks == 'true' && needs.test.result == 'success'
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary
- `test`, `coverage`, `msrv`, `benchmark` (each depending on `check`) now require `needs.check.result == 'success'` in addition to the docs-only-change filter
- `release` (depending on `test`, not `check` directly) now requires `needs.test.result == 'success'`
- `check`/`security` (depend only on `changes`) and `ci-success` (manual aggregator) are unchanged

Previously these jobs used `if: always() && needs.changes.outputs.run-checks == 'true'`, which bypassed the default GitHub Actions behavior of skipping a job when one of its `needs` fails. On a non-docs-only change with a failing `check` job (fmt/clippy), the full cross-platform test matrix, coverage run, MSRV check, and benchmark build ran to completion instead of being skipped, contradicting the workflow's own "fail fast" documentation.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1067 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `fy lint .github/workflows/ci.yml` (0 errors, pre-existing style warnings only)
- [x] Verified `needs:` graph for every changed job matches the new `if:` condition
- [x] Verified `ci-success`'s aggregation still correctly reflects `check` failures

Fixes #330