### PR TITLE
refactor(cli): represent transport selection as a closed ServerSource enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`mcp-execution-cli`**: `introspect` and `generate` now flatten a shared `ServerFlags`
+  (private fields, `cli.rs`) instead of each declaring its own copy of the transport/timeout
+  flags. A single clap `ArgGroup` (`server_source`, over `from_config`/`server`/`http`/`sse`)
+  enforces "exactly one selector" at parse time, replacing the previous
+  `conflicts_with_all`/`required_unless_present_any` combination and the runtime
+  `TransportArgs::from_flags` check. `ServerFlags` converts into the closed `ServerSource` enum
+  (`Config { name }` / `Flags { transport, connect_timeout_secs, discover_timeout_secs }`) via
+  `TryFrom`, which also retires the domain-impossible "`from_config` set together with a
+  meaningless timeout override" state that `connect_timeout_secs`/`discover_timeout_secs` used to
+  document on both `introspect::run` and `generate::run`. `commands::introspect::run` and
+  `commands::generate::run` now take a `ServerSource` parameter instead of the old
+  `RawServerArgs` struct (#314).
+- **`mcp-execution-cli`**: `introspect <command> --http <url>` and `generate <command> --http
+  <url>` (or `--sse`) now fail to parse instead of silently discarding the positional server
+  command and using the HTTP/SSE transport — the previous behavior was an undocumented quirk of
+  `TransportArgs::from_flags` preferring `http`/`sse` over `server`, not an intentional feature.
+  Every other invocation shape (`--from-config`, positional command alone, `--http`/`--sse`
+  alone) is unchanged (#314).
+- **`mcp-execution-cli`**: `generate` gains the `-a`/`-e` short aliases for `--arg`/`--env` that
+  `introspect` already had — a side effect of both commands now flattening the same
+  `ServerFlags`, not a deliberate new feature in its own right (#314).
+
+### Removed
+
+- **`mcp-execution-cli`**: removed `commands::common::RawServerArgs` (`pub`, all-`Option`/`Vec`
+  fields with no invariant enforcement) and `TransportArgs::from_flags` (`pub`, the runtime
+  "exactly one transport" check) — both superseded by `ServerFlags`/`ServerSource` above (#314).
+
 ### Added
 
 - **`mcp-execution-codegen`**: new `pub` constant `common::typescript::MAX_SCHEMA_RECURSION_DEPTH`

--- a/crates/mcp-cli/src/cli.rs
+++ b/crates/mcp-cli/src/cli.rs
@@ -5,15 +5,16 @@
 //! - `Commands` - Available subcommands
 
 use clap::builder::{PossibleValuesParser, TypedValueParser as _};
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 use clap_complete::Shell;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use crate::actions::ServerAction;
+use crate::commands::common::{ServerSource, TransportArgs};
 use mcp_execution_core::cli::OutputFormat;
-use mcp_execution_core::{RedactedItems, RedactedUrl};
+use mcp_execution_core::{Error as CoreError, RedactedItems, RedactedUrl, sanitize_path_for_error};
 
 /// MCP Code Execution - Secure WASM-based MCP tool execution.
 ///
@@ -81,6 +82,234 @@ impl fmt::Debug for Cli {
     }
 }
 
+/// Shared server-selection, transport, and timeout flags for `introspect` and `generate`.
+///
+/// Fields are private: the only way to obtain a value of this type is via clap parsing
+/// (`#[command(flatten)]` on `Commands::Introspect`/`Commands::Generate`), which — via the
+/// `server_source` argument group below — guarantees exactly one of `--from-config`, the
+/// positional `server`, `--http`, or `--sse` is set before [`TryFrom<ServerFlags> for
+/// ServerSource`](ServerSource) ever runs. This makes the illegal states (zero or multiple
+/// selectors) unconstructible outside this module rather than merely checked at runtime.
+///
+/// # Examples
+///
+/// ```
+/// use clap::Parser;
+/// use mcp_execution_cli::cli::{Cli, Commands};
+///
+/// // The positional `server` and `--from-config`/`--http`/`--sse` are
+/// // alternative selectors accepted by the same `server_source` group.
+/// let cli = Cli::parse_from(["mcp-execution-cli", "introspect", "github-mcp-server"]);
+/// assert!(matches!(cli.command, Commands::Introspect { .. }));
+///
+/// let cli = Cli::parse_from([
+///     "mcp-execution-cli",
+///     "introspect",
+///     "--http",
+///     "https://api.example.com/mcp",
+/// ]);
+/// assert!(matches!(cli.command, Commands::Introspect { .. }));
+///
+/// // Exactly one selector is required: none set is a parse error.
+/// assert!(Cli::try_parse_from(["mcp-execution-cli", "introspect"]).is_err());
+/// ```
+#[derive(Args)]
+#[command(group(
+    ArgGroup::new("server_source")
+        .required(true)
+        .args(["from_config", "server", "http", "sse"])
+))]
+pub struct ServerFlags {
+    /// Load server configuration from ~/.claude/mcp.json by name
+    ///
+    /// When specified, all other server configuration options are ignored.
+    /// The server must be defined in ~/.claude/mcp.json with matching name.
+    ///
+    /// Example mcp.json (stdio and http entries can be mixed freely):
+    /// ```json
+    /// {
+    ///   "mcpServers": {
+    ///     "github": {
+    ///       "command": "docker",
+    ///       "args": ["run", "-i", "--rm", "..."],
+    ///       "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "..."}
+    ///     },
+    ///     "remote": {
+    ///       "type": "http",
+    ///       "url": "https://api.example.com/mcp",
+    ///       "headers": {"Authorization": "Bearer ..."}
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    #[arg(long = "from-config", conflicts_with_all = ["server", "args", "env", "cwd", "http", "sse", "connect_timeout_secs", "discover_timeout_secs"])]
+    from_config: Option<String>,
+
+    /// Server command (binary name or path)
+    ///
+    /// For stdio transport: command to execute (e.g., "docker", "npx", "github-mcp-server")
+    /// Not required when using --from-config, --http, or --sse
+    server: Option<String>,
+
+    /// Arguments to pass to the server command
+    #[arg(short, long = "arg", num_args = 1)]
+    args: Vec<String>,
+
+    /// Environment variables in KEY=VALUE format
+    #[arg(short, long = "env", num_args = 1)]
+    env: Vec<String>,
+
+    /// Working directory for the server process
+    #[arg(long)]
+    cwd: Option<String>,
+
+    /// Use HTTP transport with specified URL
+    #[arg(long, conflicts_with = "sse")]
+    http: Option<String>,
+
+    /// Use SSE transport with specified URL
+    #[arg(long, conflicts_with = "http")]
+    sse: Option<String>,
+
+    /// HTTP headers in KEY=VALUE format (for HTTP/SSE transport)
+    #[arg(long = "header", num_args = 1)]
+    headers: Vec<String>,
+
+    /// Override the connection (handshake) timeout, in seconds.
+    ///
+    /// Same field/units as `mcp.json`'s `connectTimeoutSecs`. Must be
+    /// greater than zero and at most 600 seconds (10 minutes); there is
+    /// no infinite-timeout option, since an unbounded wait would let a
+    /// hung server block this command forever.
+    ///
+    /// Conflicts with `--from-config`: to override the timeout for a
+    /// server defined in `mcp.json`, either edit its `connectTimeoutSecs`
+    /// field, or re-run this command without `--from-config` using the
+    /// server's command/args/env directly.
+    #[arg(long = "connect-timeout-secs")]
+    connect_timeout_secs: Option<u64>,
+
+    /// Override the tool discovery timeout, in seconds.
+    ///
+    /// Same field/units as `mcp.json`'s `discoverTimeoutSecs`. Same
+    /// bounds and `--from-config` conflict as `--connect-timeout-secs`.
+    #[arg(long = "discover-timeout-secs")]
+    discover_timeout_secs: Option<u64>,
+}
+
+// Hand-written to redact `server`/`env`/`http`/`sse`/`headers` — these carry
+// raw, unparsed `KEY=VALUE` secrets and URLs (which may embed credentials,
+// e.g. `https://user:token@host/mcp`) straight from argv, before
+// `TransportArgs`/`McpTransport` ever get a chance to redact them. `args` is
+// deliberately left unredacted here, matching the pre-existing
+// `Commands::Debug` invariant (see `test_commands_debug_does_not_redact_args`):
+// it is positional, not secret-shaped, and stays visible. This is an
+// intentional asymmetry with `TransportArgs::Stdio`/`McpTransport::Stdio`,
+// whose own `Debug` impls *do* wrap `args` in `RedactedItems` — a caller can
+// still smuggle a secret through `--arg` (e.g. `docker run -e TOKEN=...`
+// style), but by the time a `ServerSource`/`ServerConfig` value (the type
+// that actually flows through the app and can end up in an error's
+// `anyhow::Context`) is built from these flags, that later layer's
+// redaction applies. `ServerFlags::Debug` itself is not on that path today
+// (nothing prints a bare `Commands`/`ServerFlags` value), so this only
+// matters if a future caller adds one.
+
+impl fmt::Debug for ServerFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            from_config,
+            server,
+            args,
+            env,
+            cwd,
+            http,
+            sse,
+            headers,
+            connect_timeout_secs,
+            discover_timeout_secs,
+        } = self;
+        f.debug_struct("ServerFlags")
+            .field("from_config", from_config)
+            .field(
+                "server",
+                &server
+                    .as_deref()
+                    .map(|s| sanitize_path_for_error(Path::new(s))),
+            )
+            .field("args", args)
+            .field("env", &RedactedItems(env))
+            .field(
+                "cwd",
+                &cwd.as_deref()
+                    .map(|cwd| sanitize_path_for_error(Path::new(cwd))),
+            )
+            .field("http", &http.as_deref().map(RedactedUrl))
+            .field("sse", &sse.as_deref().map(RedactedUrl))
+            .field("headers", &RedactedItems(headers))
+            .field("connect_timeout_secs", connect_timeout_secs)
+            .field("discover_timeout_secs", discover_timeout_secs)
+            .finish()
+    }
+}
+
+/// Converts clap's parsed [`ServerFlags`] landing zone into the closed
+/// [`ServerSource`] domain enum.
+///
+/// # Errors
+///
+/// Returns [`CoreError::InvalidArgument`] if none or more than one of
+/// `from_config`/`server`/`http`/`sse` is set. Unreachable when `flags` came
+/// from real CLI parsing — the `server_source` argument group on
+/// [`ServerFlags`] already enforces exactly one — but reachable from a
+/// directly-constructed `ServerFlags` value (e.g. in tests, which can build
+/// one since they are a child module of this one).
+impl TryFrom<ServerFlags> for ServerSource {
+    type Error = CoreError;
+
+    fn try_from(flags: ServerFlags) -> Result<Self, Self::Error> {
+        let ServerFlags {
+            from_config,
+            server,
+            args,
+            env,
+            cwd,
+            http,
+            sse,
+            headers,
+            connect_timeout_secs,
+            discover_timeout_secs,
+        } = flags;
+
+        match (from_config, server, http, sse) {
+            (Some(name), None, None, None) => Ok(Self::Config { name }),
+            (None, Some(command), None, None) => Ok(Self::Flags {
+                transport: TransportArgs::Stdio {
+                    command,
+                    args,
+                    env,
+                    cwd,
+                },
+                connect_timeout_secs,
+                discover_timeout_secs,
+            }),
+            (None, None, Some(url), None) => Ok(Self::Flags {
+                transport: TransportArgs::Http { url, headers },
+                connect_timeout_secs,
+                discover_timeout_secs,
+            }),
+            (None, None, None, Some(url)) => Ok(Self::Flags {
+                transport: TransportArgs::Sse { url, headers },
+                connect_timeout_secs,
+                discover_timeout_secs,
+            }),
+            _ => Err(CoreError::InvalidArgument(
+                "exactly one of --from-config, a server command, --http, or --sse must be set"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
 /// Available CLI subcommands.
 ///
 /// # Examples
@@ -143,86 +372,13 @@ pub enum Commands {
     ///     --header "Authorization=Bearer ghp_xxx"
     /// ```
     Introspect {
-        /// Load server configuration from ~/.claude/mcp.json by name
-        ///
-        /// When specified, all other server configuration options are ignored.
-        /// The server must be defined in ~/.claude/mcp.json with matching name.
-        ///
-        /// Example mcp.json (stdio and http entries can be mixed freely):
-        /// ```json
-        /// {
-        ///   "mcpServers": {
-        ///     "github": {
-        ///       "command": "docker",
-        ///       "args": ["run", "-i", "--rm", "..."],
-        ///       "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "..."}
-        ///     },
-        ///     "remote": {
-        ///       "type": "http",
-        ///       "url": "https://api.example.com/mcp",
-        ///       "headers": {"Authorization": "Bearer ..."}
-        ///     }
-        ///   }
-        /// }
-        /// ```
-        #[arg(long = "from-config", conflicts_with_all = ["server", "args", "env", "cwd", "http", "sse", "connect_timeout_secs", "discover_timeout_secs"])]
-        from_config: Option<String>,
-
-        /// Server command (binary name or path)
-        ///
-        /// For stdio transport: command to execute (e.g., "docker", "npx", "github-mcp-server")
-        /// Not required when using --http or --sse
-        #[arg(required_unless_present_any = ["from_config", "http", "sse"])]
-        server: Option<String>,
-
-        /// Arguments to pass to the server command
-        #[arg(short, long = "arg", num_args = 1)]
-        args: Vec<String>,
-
-        /// Environment variables in KEY=VALUE format
-        #[arg(short, long = "env", num_args = 1)]
-        env: Vec<String>,
-
-        /// Working directory for the server process
-        #[arg(long)]
-        cwd: Option<String>,
-
-        /// Use HTTP transport with specified URL
-        #[arg(long, conflicts_with = "sse")]
-        http: Option<String>,
-
-        /// Use SSE transport with specified URL
-        #[arg(long, conflicts_with = "http")]
-        sse: Option<String>,
-
-        /// HTTP headers in KEY=VALUE format (for HTTP/SSE transport)
-        #[arg(long = "header", num_args = 1)]
-        headers: Vec<String>,
+        /// Server selection, transport, and timeout flags (shared with `generate`)
+        #[command(flatten)]
+        flags: ServerFlags,
 
         /// Show detailed tool schemas
         #[arg(short, long)]
         detailed: bool,
-
-        /// Override the connection (handshake) timeout, in seconds.
-        ///
-        /// Same field/units as `mcp.json`'s `connectTimeoutSecs`. Must be
-        /// greater than zero and at most 600 seconds (10 minutes); there is
-        /// no infinite-timeout option, since an unbounded wait would let a
-        /// hung server block this command forever.
-        ///
-        /// Conflicts with `--from-config`: to override the timeout for a
-        /// server defined in `mcp.json`, either edit its `connectTimeoutSecs`
-        /// field, or re-run this command without `--from-config` using the
-        /// server's command/args/env directly.
-        #[arg(long = "connect-timeout-secs")]
-        connect_timeout_secs: Option<u64>,
-
-        /// Override the tool discovery timeout, in seconds.
-        ///
-        /// Same field/units as `mcp.json`'s `discoverTimeoutSecs`. Same
-        /// bounds and `--from-config` conflict as `--connect-timeout-secs`.
-        #[arg(long = "discover-timeout-secs")]
-        discover_timeout_secs: Option<u64>,
     },
 
     /// Generate Claude Code skill file from progressive loading tools.
@@ -323,61 +479,9 @@ pub enum Commands {
     ///     --env=GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx
     /// ```
     Generate {
-        /// Load server configuration from ~/.claude/mcp.json by name
-        ///
-        /// When specified, all other server configuration options are ignored.
-        /// The server must be defined in ~/.claude/mcp.json with matching name.
-        ///
-        /// Example mcp.json (stdio and http entries can be mixed freely):
-        /// ```json
-        /// {
-        ///   "mcpServers": {
-        ///     "github": {
-        ///       "command": "docker",
-        ///       "args": ["run", "-i", "--rm", "..."],
-        ///       "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "..."}
-        ///     },
-        ///     "remote": {
-        ///       "type": "http",
-        ///       "url": "https://api.example.com/mcp",
-        ///       "headers": {"Authorization": "Bearer ..."}
-        ///     }
-        ///   }
-        /// }
-        /// ```
-        #[arg(long = "from-config", conflicts_with_all = ["server", "server_args", "server_env", "server_cwd", "http_url", "sse_url", "connect_timeout_secs", "discover_timeout_secs"])]
-        from_config: Option<String>,
-
-        /// Server command (binary name or path)
-        ///
-        /// For stdio transport: command to execute (e.g., "docker", "npx", "github-mcp-server")
-        /// Not required when using --from-config, --http, or --sse
-        #[arg(required_unless_present_any = ["from_config", "http_url", "sse_url"])]
-        server: Option<String>,
-
-        /// Arguments to pass to the server command
-        #[arg(long = "arg", num_args = 1)]
-        server_args: Vec<String>,
-
-        /// Environment variables in KEY=VALUE format
-        #[arg(long = "env", num_args = 1)]
-        server_env: Vec<String>,
-
-        /// Working directory for the server process
-        #[arg(long = "cwd")]
-        server_cwd: Option<String>,
-
-        /// Use HTTP transport with specified URL
-        #[arg(long = "http", conflicts_with = "sse_url")]
-        http_url: Option<String>,
-
-        /// Use SSE transport with specified URL
-        #[arg(long = "sse", conflicts_with = "http_url")]
-        sse_url: Option<String>,
-
-        /// HTTP headers in KEY=VALUE format (for HTTP/SSE transport)
-        #[arg(long = "header", num_args = 1)]
-        server_headers: Vec<String>,
+        /// Server selection, transport, and timeout flags (shared with `introspect`)
+        #[command(flatten)]
+        flags: ServerFlags,
 
         /// Custom server name for directory (e.g., 'github' instead of 'docker')
         /// (default: uses server command name)
@@ -392,27 +496,6 @@ pub enum Commands {
         /// Preview files that would be generated without writing to disk
         #[arg(long)]
         dry_run: bool,
-
-        /// Override the connection (handshake) timeout, in seconds.
-        ///
-        /// Same field/units as `mcp.json`'s `connectTimeoutSecs`. Must be
-        /// greater than zero and at most 600 seconds (10 minutes); there is
-        /// no infinite-timeout option, since an unbounded wait would let a
-        /// hung server block this command forever.
-        ///
-        /// Conflicts with `--from-config`: to override the timeout for a
-        /// server defined in `mcp.json`, either edit its `connectTimeoutSecs`
-        /// field, or re-run this command without `--from-config` using the
-        /// server's command/args/env directly.
-        #[arg(long = "connect-timeout-secs")]
-        connect_timeout_secs: Option<u64>,
-
-        /// Override the tool discovery timeout, in seconds.
-        ///
-        /// Same field/units as `mcp.json`'s `discoverTimeoutSecs`. Same
-        /// bounds and `--from-config` conflict as `--connect-timeout-secs`.
-        #[arg(long = "discover-timeout-secs")]
-        discover_timeout_secs: Option<u64>,
     },
 
     /// Manage MCP server connections.
@@ -458,31 +541,10 @@ pub enum Commands {
 impl fmt::Debug for Commands {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Introspect {
-                from_config,
-                server,
-                args,
-                env,
-                cwd,
-                http,
-                sse,
-                headers,
-                detailed,
-                connect_timeout_secs,
-                discover_timeout_secs,
-            } => f
+            Self::Introspect { flags, detailed } => f
                 .debug_struct("Introspect")
-                .field("from_config", from_config)
-                .field("server", server)
-                .field("args", args)
-                .field("env", &RedactedItems(env))
-                .field("cwd", cwd)
-                .field("http", &http.as_deref().map(RedactedUrl))
-                .field("sse", &sse.as_deref().map(RedactedUrl))
-                .field("headers", &RedactedItems(headers))
+                .field("flags", flags)
                 .field("detailed", detailed)
-                .field("connect_timeout_secs", connect_timeout_secs)
-                .field("discover_timeout_secs", discover_timeout_secs)
                 .finish(),
             Self::Skill {
                 server,
@@ -501,34 +563,16 @@ impl fmt::Debug for Commands {
                 .field("overwrite", overwrite)
                 .finish(),
             Self::Generate {
-                from_config,
-                server,
-                server_args,
-                server_env,
-                server_cwd,
-                http_url,
-                sse_url,
-                server_headers,
+                flags,
                 name,
                 progressive_output,
                 dry_run,
-                connect_timeout_secs,
-                discover_timeout_secs,
             } => f
                 .debug_struct("Generate")
-                .field("from_config", from_config)
-                .field("server", server)
-                .field("server_args", server_args)
-                .field("server_env", &RedactedItems(server_env))
-                .field("server_cwd", server_cwd)
-                .field("http_url", &http_url.as_deref().map(RedactedUrl))
-                .field("sse_url", &sse_url.as_deref().map(RedactedUrl))
-                .field("server_headers", &RedactedItems(server_headers))
+                .field("flags", flags)
                 .field("name", name)
                 .field("progressive_output", progressive_output)
                 .field("dry_run", dry_run)
-                .field("connect_timeout_secs", connect_timeout_secs)
-                .field("discover_timeout_secs", discover_timeout_secs)
                 .finish(),
             Self::Server { action } => f.debug_struct("Server").field("action", action).finish(),
             Self::Setup => write!(f, "Setup"),
@@ -584,16 +628,13 @@ mod tests {
             "--arg=ghcr.io/github/github-mcp-server",
             "--env=GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx",
         ]);
-        if let Commands::Introspect {
-            server, args, env, ..
-        } = cli.command
-        {
-            assert_eq!(server, Some("docker".to_string()));
+        if let Commands::Introspect { flags, .. } = cli.command {
+            assert_eq!(flags.server, Some("docker".to_string()));
             assert_eq!(
-                args,
+                flags.args,
                 vec!["run", "-i", "--rm", "ghcr.io/github/github-mcp-server"]
             );
-            assert_eq!(env, vec!["GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx"]);
+            assert_eq!(flags.env, vec!["GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxx"]);
         } else {
             panic!("Expected Introspect command");
         }
@@ -609,16 +650,13 @@ mod tests {
             "--header",
             "Authorization=Bearer token",
         ]);
-        if let Commands::Introspect {
-            server,
-            http,
-            headers,
-            ..
-        } = cli.command
-        {
-            assert_eq!(server, None);
-            assert_eq!(http, Some("https://api.githubcopilot.com/mcp/".to_string()));
-            assert_eq!(headers, vec!["Authorization=Bearer token"]);
+        if let Commands::Introspect { flags, .. } = cli.command {
+            assert_eq!(flags.server, None);
+            assert_eq!(
+                flags.http,
+                Some("https://api.githubcopilot.com/mcp/".to_string())
+            );
+            assert_eq!(flags.headers, vec!["Authorization=Bearer token"]);
         } else {
             panic!("Expected Introspect command");
         }
@@ -635,14 +673,9 @@ mod tests {
             "--discover-timeout-secs",
             "90",
         ]);
-        if let Commands::Introspect {
-            connect_timeout_secs,
-            discover_timeout_secs,
-            ..
-        } = cli.command
-        {
-            assert_eq!(connect_timeout_secs, Some(5));
-            assert_eq!(discover_timeout_secs, Some(90));
+        if let Commands::Introspect { flags, .. } = cli.command {
+            assert_eq!(flags.connect_timeout_secs, Some(5));
+            assert_eq!(flags.discover_timeout_secs, Some(90));
         } else {
             panic!("Expected Introspect command");
         }
@@ -707,14 +740,9 @@ mod tests {
             "--discover-timeout-secs",
             "90",
         ]);
-        if let Commands::Generate {
-            connect_timeout_secs,
-            discover_timeout_secs,
-            ..
-        } = cli.command
-        {
-            assert_eq!(connect_timeout_secs, Some(5));
-            assert_eq!(discover_timeout_secs, Some(90));
+        if let Commands::Generate { flags, .. } = cli.command {
+            assert_eq!(flags.connect_timeout_secs, Some(5));
+            assert_eq!(flags.discover_timeout_secs, Some(90));
         } else {
             panic!("Expected Generate command");
         }
@@ -1052,5 +1080,248 @@ mod tests {
         let debug_output = format!("{:?}", cli.command);
         assert!(!debug_output.contains(secret));
         assert!(debug_output.contains("host.example.com/mcp"));
+    }
+
+    #[test]
+    fn test_server_flags_debug_redacts_secret_shaped_fields() {
+        // Migrated from the former `RawServerArgs` regression test: `server`'s
+        // home-relative path must be tilde-sanitized, not just the URL/env/header
+        // fields already covered above.
+        let secret = "sk-live-secret";
+        let home = dirs::home_dir().expect("home directory must be resolvable in test environment");
+        let server_path = home.join("tools").join("mcp-server");
+
+        let cli = Cli::parse_from([
+            "mcp-cli",
+            "introspect",
+            &server_path.display().to_string(),
+            "--env",
+            &format!("GITHUB_TOKEN={secret}"),
+            "--connect-timeout-secs",
+            "30",
+        ]);
+
+        let debug_output = format!("{:?}", cli.command);
+        assert!(!debug_output.contains(secret));
+        assert!(!debug_output.contains(&home.display().to_string()));
+        assert!(debug_output.contains('~'));
+        assert!(debug_output.contains("connect_timeout_secs: Some(30)"));
+    }
+
+    // ── #314: `server_source` argument group makes the transport-selector
+    // exclusivity a clap-level guarantee instead of a runtime check ──
+
+    #[test]
+    fn test_cli_parsing_introspect_positional_with_http_errors() {
+        // Approved behavior change: previously the positional command was
+        // silently discarded by `TransportArgs::from_flags` in favor of
+        // `--http`. Now the `server_source` group rejects both being set.
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "introspect",
+            "docker",
+            "--http",
+            "https://api.example.com",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_positional_with_http_errors() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "generate",
+            "docker",
+            "--http",
+            "https://api.example.com",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_introspect_no_selector_errors() {
+        let result = Cli::try_parse_from(["mcp-cli", "introspect"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_no_selector_errors() {
+        let result = Cli::try_parse_from(["mcp-cli", "generate"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_introspect_http_and_sse_together_errors() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "introspect",
+            "--http",
+            "https://api.example.com",
+            "--sse",
+            "https://api.example.com/sse",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_http_and_sse_together_errors() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "generate",
+            "--http",
+            "https://api.example.com",
+            "--sse",
+            "https://api.example.com/sse",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_introspect_from_config_and_http_together_errors() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "introspect",
+            "--from-config",
+            "github",
+            "--http",
+            "https://api.example.com",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_from_config_and_http_together_errors() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "generate",
+            "--from-config",
+            "github",
+            "--http",
+            "https://api.example.com",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_server_source_try_from_server_flags_catch_all_errors() {
+        // Legal only because this test module is a child of `cli`, so it can
+        // see `ServerFlags`'s private fields. Unreachable via real CLI
+        // parsing: the `server_source` argument group already guarantees
+        // exactly one selector is set.
+        let flags = ServerFlags {
+            from_config: None,
+            server: None,
+            args: vec![],
+            env: vec![],
+            cwd: None,
+            http: None,
+            sse: None,
+            headers: vec![],
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+
+        let result = ServerSource::try_from(flags);
+        assert!(result.is_err());
+    }
+
+    // ── S1: round-trip parse -> `TryFrom<ServerFlags>` -> assert variant and
+    // payload for each of the four `Ok` arms. Without these, transposing the
+    // `Http`/`Sse` arms or the `args`/`env` fields inside `Stdio` (all
+    // same-typed) would compile and pass the rest of the suite — exactly
+    // issue #286's bug class, previously guarded by the now-deleted
+    // `test_transport_args_from_flags_{stdio,http,sse}` tests. ──
+
+    fn introspect_flags(cli: Cli) -> ServerFlags {
+        match cli.command {
+            Commands::Introspect { flags, .. } => flags,
+            other => panic!("expected Introspect command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_source_try_from_config_arm() {
+        let cli = Cli::parse_from(["mcp-cli", "introspect", "--from-config", "github"]);
+        let source = ServerSource::try_from(introspect_flags(cli)).unwrap();
+
+        assert!(matches!(source, ServerSource::Config { name } if name == "github"));
+    }
+
+    #[test]
+    fn test_server_source_try_from_stdio_arm_does_not_transpose_args_and_env() {
+        let cli = Cli::parse_from([
+            "mcp-cli",
+            "introspect",
+            "docker",
+            "--arg=run",
+            "--env=TOKEN=abc",
+            "--cwd=/tmp/work",
+        ]);
+        let source = ServerSource::try_from(introspect_flags(cli)).unwrap();
+
+        match source {
+            ServerSource::Flags {
+                transport:
+                    TransportArgs::Stdio {
+                        command,
+                        args,
+                        env,
+                        cwd,
+                    },
+                ..
+            } => {
+                assert_eq!(command, "docker");
+                assert_eq!(args, vec!["run".to_string()]);
+                assert_eq!(env, vec!["TOKEN=abc".to_string()]);
+                assert_eq!(cwd, Some("/tmp/work".to_string()));
+            }
+            other => panic!("expected Flags{{Stdio}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_source_try_from_http_arm_does_not_swap_with_sse() {
+        let cli = Cli::parse_from([
+            "mcp-cli",
+            "introspect",
+            "--http",
+            "https://api.example.com/mcp",
+            "--header=Authorization=Bearer x",
+        ]);
+        let source = ServerSource::try_from(introspect_flags(cli)).unwrap();
+
+        match source {
+            ServerSource::Flags {
+                transport: TransportArgs::Http { url, headers },
+                ..
+            } => {
+                assert_eq!(url, "https://api.example.com/mcp");
+                assert_eq!(headers, vec!["Authorization=Bearer x".to_string()]);
+            }
+            other => panic!("expected Flags{{Http}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_source_try_from_sse_arm_does_not_swap_with_http() {
+        let cli = Cli::parse_from([
+            "mcp-cli",
+            "introspect",
+            "--sse",
+            "https://api.example.com/sse",
+            "--header=X-API-Key=secret",
+        ]);
+        let source = ServerSource::try_from(introspect_flags(cli)).unwrap();
+
+        match source {
+            ServerSource::Flags {
+                transport: TransportArgs::Sse { url, headers },
+                ..
+            } => {
+                assert_eq!(url, "https://api.example.com/sse");
+                assert_eq!(headers, vec!["X-API-Key=secret".to_string()]);
+            }
+            other => panic!("expected Flags{{Sse}}, got {other:?}"),
+        }
     }
 }

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -3,7 +3,7 @@
 //! Provides shared functionality for building server configurations from CLI arguments
 //! and loading MCP server definitions from `~/.claude/mcp.json`.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use mcp_execution_core::{
     Error as CoreError, REDACTED_PLACEHOLDER, RedactedItems, RedactedMapValues, RedactedUrl,
     ServerConfig, ServerConfigBuilder, ServerId, sanitize_path_for_error,
@@ -634,9 +634,16 @@ fn parse_key_value(s: &str, kind: &str) -> Result<(String, String)> {
 /// CLI-flag mirror of [`McpTransport`], holding the raw, unvalidated
 /// `Option`/`Vec<String>` values clap hands back.
 ///
-/// [`TransportArgs::from_flags`] is the single place that enforces "exactly
-/// one transport selected". `TryFrom<TransportArgs> for McpTransport` does
-/// the `KEY=VALUE` parsing for environment variables and headers.
+/// Every variant is a legal state by construction — there is no all-`None`
+/// or "both http and sse" shape to represent, unlike the flat flag surface
+/// this type is built from. In the real CLI path, values come from
+/// [`TryFrom<ServerFlags> for ServerSource`](crate::cli::ServerFlags), the
+/// single place "exactly one transport selected" is enforced (backed by
+/// clap's `server_source` argument group at parse time); since this type and
+/// its fields are `pub`, a direct caller can also construct one by hand
+/// (e.g. as a library), which is exactly why every variant already being
+/// well-formed matters. `TryFrom<TransportArgs> for McpTransport` does the
+/// `KEY=VALUE` parsing for environment variables and headers.
 ///
 /// # Examples
 ///
@@ -732,67 +739,6 @@ impl fmt::Debug for TransportArgs {
     }
 }
 
-impl TransportArgs {
-    /// Builds a [`TransportArgs`] from the CLI's flat `--http`/`--sse`/positional
-    /// flag surface, enforcing that exactly one transport was selected.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if both `http` and `sse` are set, or if none of
-    /// `server`, `http`, or `sse` is set. Clap's `conflicts_with` /
-    /// `required_unless_present_any` already prevent both cases when parsing
-    /// real CLI input; this is the safety net for callers that build
-    /// `TransportArgs` directly (e.g. as a library).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_cli::commands::common::TransportArgs;
-    ///
-    /// let transport = TransportArgs::from_flags(
-    ///     Some("github-mcp-server".to_string()),
-    ///     vec!["stdio".to_string()],
-    ///     vec![],
-    ///     None,
-    ///     None,
-    ///     None,
-    ///     vec![],
-    /// )
-    /// .unwrap();
-    /// assert!(matches!(transport, TransportArgs::Stdio { .. }));
-    ///
-    /// let err = TransportArgs::from_flags(None, vec![], vec![], None, None, None, vec![]);
-    /// assert!(err.is_err());
-    /// ```
-    #[allow(clippy::too_many_arguments)] // mirrors the CLI's flat argument surface; grouping would add an abstraction for no behavioral benefit
-    pub fn from_flags(
-        server: Option<String>,
-        args: Vec<String>,
-        env: Vec<String>,
-        cwd: Option<String>,
-        http: Option<String>,
-        sse: Option<String>,
-        headers: Vec<String>,
-    ) -> Result<Self> {
-        match (http, sse) {
-            (Some(_), Some(_)) => bail!("cannot use both --http and --sse transports"),
-            (Some(url), None) => Ok(Self::Http { url, headers }),
-            (None, Some(url)) => Ok(Self::Sse { url, headers }),
-            (None, None) => {
-                let command = server.context(
-                    "server command is required for stdio transport (or use --http/--sse)",
-                )?;
-                Ok(Self::Stdio {
-                    command,
-                    args,
-                    env,
-                    cwd,
-                })
-            }
-        }
-    }
-}
-
 impl TryFrom<TransportArgs> for McpTransport {
     type Error = anyhow::Error;
 
@@ -837,8 +783,8 @@ impl TryFrom<TransportArgs> for McpTransport {
 ///
 /// # Arguments
 ///
-/// * `transport` - The selected transport and its raw CLI flags; build with
-///   [`TransportArgs::from_flags`].
+/// * `transport` - The selected transport and its raw CLI flags, from a
+///   [`ServerSource::Flags`] arm.
 /// * `connect_timeout_secs` - Connection (handshake) timeout override, in
 ///   seconds. Same semantics as `mcp.json`'s `connectTimeoutSecs`: must be
 ///   greater than zero and at most 600 seconds, enforced by
@@ -878,90 +824,77 @@ pub(crate) fn build_server_config(
     Ok((server_id, builder.build()?))
 }
 
-/// Raw, same-typed server transport/timeout arguments as accepted from the CLI.
+/// Fully-resolved "how do I reach this server" selection for `introspect` and
+/// `generate`.
 ///
-/// Bundles the fields shared by `introspect` and `generate` (config-file
-/// selector, transport flags, and timeout overrides) into a single named
-/// struct so callers can't accidentally transpose two `Option<String>` or
-/// `Vec<String>` fields (e.g. `http`/`sse`) by passing them in the wrong
-/// positional order — see issue #286.
+/// The output of [`TryFrom<ServerFlags> for
+/// ServerSource`](crate::cli::ServerFlags), converted from clap's parsed
+/// argv once the `server_source` argument group has already guaranteed
+/// exactly one selector was set. Unlike the former `RawServerArgs` landing
+/// zone, every value of this type is a legal state: `--from-config` and the
+/// timeout overrides are folded into the same enum because they belong to
+/// the same exclusivity group (a `from_config` selection can never carry a
+/// meaningless `connect_timeout_secs`/`discover_timeout_secs` override, since
+/// those live on the `Flags` arm only).
 ///
 /// # Examples
 ///
 /// ```
-/// use mcp_execution_cli::commands::common::RawServerArgs;
+/// use mcp_execution_cli::commands::common::{ServerSource, TransportArgs};
 ///
-/// let raw = RawServerArgs {
-///     from_config: None,
-///     server: Some("github-mcp-server".to_string()),
-///     args: vec!["stdio".to_string()],
-///     env: vec![],
-///     cwd: None,
-///     http: None,
-///     sse: None,
-///     headers: vec![],
+/// let source = ServerSource::Flags {
+///     transport: TransportArgs::Stdio {
+///         command: "github-mcp-server".to_string(),
+///         args: vec!["stdio".to_string()],
+///         env: vec![],
+///         cwd: None,
+///     },
 ///     connect_timeout_secs: None,
 ///     discover_timeout_secs: None,
 /// };
 ///
-/// assert_eq!(raw.server.as_deref(), Some("github-mcp-server"));
+/// assert!(matches!(source, ServerSource::Flags { .. }));
 /// ```
-#[derive(Default)]
-pub struct RawServerArgs {
-    /// Load server config from `~/.claude/mcp.json` by name.
-    pub from_config: Option<String>,
-    /// Server command (binary name or path), `None` for HTTP/SSE.
-    pub server: Option<String>,
-    /// Arguments to pass to the server command.
-    pub args: Vec<String>,
-    /// Environment variables in `KEY=VALUE` format.
-    pub env: Vec<String>,
-    /// Working directory for the server process.
-    pub cwd: Option<String>,
-    /// HTTP transport URL.
-    pub http: Option<String>,
-    /// SSE transport URL.
-    pub sse: Option<String>,
-    /// HTTP headers in `KEY=VALUE` format.
-    pub headers: Vec<String>,
-    /// Connection (handshake) timeout override, in seconds.
-    pub connect_timeout_secs: Option<u64>,
-    /// Tool discovery timeout override, in seconds.
-    pub discover_timeout_secs: Option<u64>,
+///
+/// Debug output redacts via [`TransportArgs`]'s own redacting `Debug` impl:
+///
+/// ```
+/// use mcp_execution_cli::commands::common::{ServerSource, TransportArgs};
+///
+/// let source = ServerSource::Flags {
+///     transport: TransportArgs::Http {
+///         url: "https://api.example.com/mcp".to_string(),
+///         headers: vec!["Authorization=Bearer sk-secret".to_string()],
+///     },
+///     connect_timeout_secs: None,
+///     discover_timeout_secs: None,
+/// };
+///
+/// let debug_output = format!("{source:?}");
+/// assert!(!debug_output.contains("sk-secret"));
+/// ```
+#[derive(Debug, Clone)]
+pub enum ServerSource {
+    /// Load server configuration from `~/.claude/mcp.json` by name.
+    Config {
+        /// Server name as defined under `mcpServers` in `mcp.json`.
+        name: String,
+    },
+    /// Build server configuration directly from CLI transport flags.
+    Flags {
+        /// Selected transport and its raw CLI flags.
+        transport: TransportArgs,
+        /// Connection (handshake) timeout override, in seconds.
+        connect_timeout_secs: Option<u64>,
+        /// Tool discovery timeout override, in seconds.
+        discover_timeout_secs: Option<u64>,
+    },
 }
 
-impl fmt::Debug for RawServerArgs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RawServerArgs")
-            .field("from_config", &self.from_config)
-            .field(
-                "server",
-                &self
-                    .server
-                    .as_deref()
-                    .map(|s| sanitize_path_for_error(Path::new(s))),
-            )
-            .field("args", &RedactedItems(&self.args))
-            .field("env", &RedactedItems(&self.env))
-            .field(
-                "cwd",
-                &self
-                    .cwd
-                    .as_deref()
-                    .map(|cwd| sanitize_path_for_error(Path::new(cwd))),
-            )
-            .field("http", &self.http.as_deref().map(RedactedUrl))
-            .field("sse", &self.sse.as_deref().map(RedactedUrl))
-            .field("headers", &RedactedItems(&self.headers))
-            .field("connect_timeout_secs", &self.connect_timeout_secs)
-            .field("discover_timeout_secs", &self.discover_timeout_secs)
-            .finish()
-    }
-}
-
-/// Resolves a server's [`ServerId`] and [`ServerConfig`], either from
-/// `~/.claude/mcp.json` (when `raw.from_config` is set) or from CLI transport
-/// flags.
+/// Resolves a server's [`ServerId`] and [`ServerConfig`] from an
+/// already-validated [`ServerSource`], either loading `~/.claude/mcp.json`
+/// (`ServerSource::Config`) or building directly from CLI transport flags
+/// (`ServerSource::Flags`).
 ///
 /// The single place `generate` and `introspect` share for this "config file
 /// vs. CLI flags" branch, since both commands accept the identical flag
@@ -969,32 +902,20 @@ impl fmt::Debug for RawServerArgs {
 ///
 /// # Errors
 ///
-/// Returns an error if `raw.from_config` is set and the named server is
-/// missing from the config file or the file is malformed, or if the CLI
-/// transport flags fail [`TransportArgs::from_flags`] validation or the
-/// resulting [`ServerConfig`] fails security validation.
-pub(crate) fn resolve_server_config(raw: RawServerArgs) -> Result<(ServerId, ServerConfig)> {
-    if let Some(config_name) = raw.from_config {
-        debug!(
-            "Loading server configuration from ~/.claude/mcp.json: {}",
-            config_name
-        );
-        load_server_from_config(&config_name)
-    } else {
-        let transport = TransportArgs::from_flags(
-            raw.server,
-            raw.args,
-            raw.env,
-            raw.cwd,
-            raw.http,
-            raw.sse,
-            raw.headers,
-        )?;
-        build_server_config(
+/// Returns an error if `source` is `Config` and the named server is missing
+/// from the config file or the file is malformed, or if `source` is `Flags`
+/// and the resulting [`ServerConfig`] fails security validation.
+pub(crate) fn resolve_server_config(source: ServerSource) -> Result<(ServerId, ServerConfig)> {
+    match source {
+        ServerSource::Config { name } => {
+            debug!("Loading server configuration from ~/.claude/mcp.json: {name}");
+            load_server_from_config(&name)
+        }
+        ServerSource::Flags {
             transport,
-            raw.connect_timeout_secs,
-            raw.discover_timeout_secs,
-        )
+            connect_timeout_secs,
+            discover_timeout_secs,
+        } => build_server_config(transport, connect_timeout_secs, discover_timeout_secs),
     }
 }
 
@@ -1510,6 +1431,28 @@ mod tests {
     }
 
     #[test]
+    fn test_server_source_debug_redacts_via_transport() {
+        // `ServerSource` derives `Debug`, so it must inherit the redaction
+        // through `TransportArgs`'s custom impl rather than needing its own —
+        // same pattern as `McpServerEntry` inheriting from `McpTransport`.
+        let secret_body = "sk-verySECRETtoken1234567890";
+        let secret = format!("Bearer {secret_body}");
+        let source = ServerSource::Flags {
+            transport: TransportArgs::Http {
+                url: "https://api.example.com/mcp".to_string(),
+                headers: vec![format!("Authorization={secret}")],
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+
+        let debug_output = format!("{source:?}");
+        assert!(!debug_output.contains(&secret));
+        assert!(!debug_output.contains(secret_body));
+        assert!(debug_output.contains("<redacted>"));
+    }
+
+    #[test]
     fn test_transport_args_debug_redacts_headers_and_env() {
         // Regression test for #229/S1: `TransportArgs` is the CLI-flag
         // mirror of `McpTransport` and holds raw, unparsed `KEY=VALUE`
@@ -1633,37 +1576,6 @@ mod tests {
         assert!(debug_output.contains("GITHUB_TOKEN"));
         assert!(debug_output.contains("someUnknownSecret"));
         assert!(debug_output.contains("node"));
-    }
-
-    #[test]
-    fn test_raw_server_args_debug_redacts_secret_shaped_fields() {
-        let secret = "sk-live-secret";
-        let home = dirs::home_dir().expect("home directory must be resolvable in test environment");
-        let server_path = home.join("tools").join("mcp-server");
-
-        let raw = RawServerArgs {
-            from_config: None,
-            server: Some(server_path.display().to_string()),
-            args: vec!["--api-key".to_string(), secret.to_string()],
-            env: vec![format!("GITHUB_TOKEN={secret}")],
-            cwd: None,
-            http: Some(format!(
-                "https://user:{secret}@api.example.com/mcp?token={secret}"
-            )),
-            sse: None,
-            headers: vec![format!("Authorization=Bearer {secret}")],
-            connect_timeout_secs: Some(30),
-            discover_timeout_secs: None,
-        };
-
-        let debug_output = format!("{raw:?}");
-        assert!(!debug_output.contains(secret));
-        // The server path's username component must be scrubbed, same as
-        // McpTransport::Stdio.command and TransportArgs::Stdio.command.
-        assert!(!debug_output.contains(&home.display().to_string()));
-        assert!(debug_output.contains('~'));
-        assert!(debug_output.contains("api.example.com/mcp"));
-        assert!(debug_output.contains("connect_timeout_secs: Some(30)"));
     }
 
     #[test]
@@ -2121,75 +2033,6 @@ mod tests {
             config.mcp_servers.is_empty(),
             "missing mcpServers key must produce empty map, not error"
         );
-    }
-
-    // ── TransportArgs::from_flags ──
-
-    #[test]
-    fn test_transport_args_from_flags_stdio() {
-        let transport = TransportArgs::from_flags(
-            Some("server".to_string()),
-            vec![],
-            vec![],
-            None,
-            None,
-            None,
-            vec![],
-        )
-        .unwrap();
-        assert!(matches!(transport, TransportArgs::Stdio { .. }));
-    }
-
-    #[test]
-    fn test_transport_args_from_flags_http() {
-        let transport = TransportArgs::from_flags(
-            None,
-            vec![],
-            vec![],
-            None,
-            Some("https://example.com".to_string()),
-            None,
-            vec![],
-        )
-        .unwrap();
-        assert!(matches!(transport, TransportArgs::Http { .. }));
-    }
-
-    #[test]
-    fn test_transport_args_from_flags_sse() {
-        let transport = TransportArgs::from_flags(
-            None,
-            vec![],
-            vec![],
-            None,
-            None,
-            Some("https://example.com/sse".to_string()),
-            vec![],
-        )
-        .unwrap();
-        assert!(matches!(transport, TransportArgs::Sse { .. }));
-    }
-
-    #[test]
-    fn test_transport_args_from_flags_none_set_errors() {
-        // Regression test: this used to be an `.expect()` panic in
-        // `build_server_config`'s stdio branch.
-        let result = TransportArgs::from_flags(None, vec![], vec![], None, None, None, vec![]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_transport_args_from_flags_both_http_and_sse_errors() {
-        let result = TransportArgs::from_flags(
-            None,
-            vec![],
-            vec![],
-            None,
-            Some("https://example.com".to_string()),
-            Some("https://example.com/sse".to_string()),
-            vec![],
-        );
-        assert!(result.is_err());
     }
 
     // ── derive_server_id_from_url (review S1: raw-URL server ids are unsafe) ──

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -6,7 +6,7 @@
 //! 2. Generates TypeScript files for progressive loading (one file per tool)
 //! 3. Saves files to `~/.claude/servers/{server-id}/` directory
 
-use super::common::{RawServerArgs, derive_server_id_from_path_or_name, resolve_server_config};
+use super::common::{ServerSource, derive_server_id_from_path_or_name, resolve_server_config};
 use crate::formatters::escape_display;
 use anyhow::{Context, Result};
 use mcp_execution_codegen::GeneratedCode;
@@ -90,11 +90,11 @@ fn format_size(bytes: usize) -> String {
 ///
 /// # Arguments
 ///
-/// * `raw` - Server config-file selector, transport flags, and timeout
-///   overrides. `connect_timeout_secs` is ignored when `raw.from_config` is
-///   set (the `mcp.json` entry's `connectTimeoutSecs` applies instead); both
-///   timeout overrides share `mcp.json`'s bounds (greater than zero, at most
-///   600 seconds).
+/// * `source` - Resolved server-selection source: either a `~/.claude/mcp.json`
+///   name or CLI transport flags with timeout overrides. Timeout overrides
+///   only exist on the `Flags` arm — a `Config` source always uses the
+///   `mcp.json` entry's own `connectTimeoutSecs`/`discoverTimeoutSecs`, so
+///   there is no "ignored override" state to document.
 /// * `name` - Custom server name for directory (default: `server_id`)
 /// * `output_dir` - Custom output directory (default: ~/.claude/servers/)
 /// * `dry_run` - When true, preview files without writing to disk
@@ -110,19 +110,20 @@ fn format_size(bytes: usize) -> String {
 /// - Code generation fails
 /// - File export fails (skipped in dry-run mode)
 pub async fn run(
-    raw: RawServerArgs,
+    source: ServerSource,
     name: Option<String>,
     output_dir: Option<PathBuf>,
     dry_run: bool,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
-    // Captured before `raw` is consumed below: an id resolved from
+    // Captured before `source` is consumed below: an id resolved from
     // `--from-config` without a `--name` override is the one case
     // `resolve_server_dir_name` isn't a redundant backstop for (see its doc
     // comment) — `--name` always overrides `server_info.id`, so if it was
     // given the id came from its own, already-validated value instead.
-    let id_from_unvalidated_config_key = raw.from_config.is_some() && name.is_none();
-    let (server_id, server_config) = resolve_server_config(raw)?;
+    let id_from_unvalidated_config_key =
+        matches!(source, ServerSource::Config { .. }) && name.is_none();
+    let (server_id, server_config) = resolve_server_config(source)?;
 
     let server_info = discover_server_info(server_id, &server_config, name.as_deref()).await?;
 
@@ -442,6 +443,7 @@ fn format_success(result: &GenerationResult, output_format: OutputFormat) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::common::TransportArgs;
     use mcp_execution_core::ServerId;
     use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
     use serde_json::json;
@@ -735,12 +737,17 @@ mod tests {
     async fn test_run_zero_connect_timeout_override_rejected_by_validation() {
         // A zero override must surface the same connect_timeout validation
         // error as the mcp.json path, not just a generic connection failure.
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server-timeout-test".to_string()),
+        let source = ServerSource::Flags {
+            transport: TransportArgs::Stdio {
+                command: "nonexistent-server-timeout-test".to_string(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            },
             connect_timeout_secs: Some(0),
-            ..Default::default()
+            discover_timeout_secs: None,
         };
-        let result = run(raw, None, None, false, OutputFormat::Json).await;
+        let result = run(source, None, None, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -758,13 +765,17 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_valid_timeout_overrides_reaches_connection_attempt() {
         // Valid overrides must not be rejected before the connection attempt.
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server-timeout-test-2".to_string()),
+        let source = ServerSource::Flags {
+            transport: TransportArgs::Stdio {
+                command: "nonexistent-server-timeout-test-2".to_string(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            },
             connect_timeout_secs: Some(5),
             discover_timeout_secs: Some(90),
-            ..Default::default()
         };
-        let result = run(raw, None, None, false, OutputFormat::Json).await;
+        let result = run(source, None, None, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -2,7 +2,7 @@
 //!
 //! Connects to an MCP server and displays its capabilities, tools, and metadata.
 
-use super::common::{RawServerArgs, resolve_server_config};
+use super::common::{ServerSource, resolve_server_config};
 use anyhow::{Context, Result};
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use mcp_execution_introspector::{Introspector, ServerInfo, ToolInfo};
@@ -126,11 +126,11 @@ pub struct ToolDisplay {
 ///
 /// # Arguments
 ///
-/// * `raw` - Server config-file selector, transport flags, and timeout
-///   overrides. `connect_timeout_secs` is ignored when `raw.from_config` is
-///   set (the `mcp.json` entry's `connectTimeoutSecs` applies instead); both
-///   timeout overrides share `mcp.json`'s bounds (greater than zero, at most
-///   600 seconds).
+/// * `source` - Resolved server-selection source: either a `~/.claude/mcp.json`
+///   name or CLI transport flags with timeout overrides. Timeout overrides
+///   only exist on the `Flags` arm — a `Config` source always uses the
+///   `mcp.json` entry's own `connectTimeoutSecs`/`discoverTimeoutSecs`, so
+///   there is no "ignored override" state to document.
 /// * `detailed` - Whether to show detailed tool schemas
 /// * `output_format` - Output format (json, text, pretty)
 ///
@@ -145,22 +145,20 @@ pub struct ToolDisplay {
 /// # Examples
 ///
 /// ```no_run
-/// use mcp_execution_cli::commands::common::RawServerArgs;
+/// use mcp_execution_cli::commands::common::{ServerSource, TransportArgs};
 /// use mcp_execution_cli::commands::introspect;
 /// use mcp_execution_core::cli::OutputFormat;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// // Simple server
 /// let exit_code = introspect::run(
-///     RawServerArgs {
-///         from_config: None,
-///         server: Some("github-mcp-server".to_string()),
-///         args: vec!["stdio".to_string()],
-///         env: vec![],
-///         cwd: None,
-///         http: None,
-///         sse: None,
-///         headers: vec![],
+///     ServerSource::Flags {
+///         transport: TransportArgs::Stdio {
+///             command: "github-mcp-server".to_string(),
+///             args: vec!["stdio".to_string()],
+///             env: vec![],
+///             cwd: None,
+///         },
 ///         connect_timeout_secs: None,
 ///         discover_timeout_secs: None,
 ///     },
@@ -170,15 +168,11 @@ pub struct ToolDisplay {
 ///
 /// // HTTP transport with a shorter connect timeout
 /// let exit_code = introspect::run(
-///     RawServerArgs {
-///         from_config: None,
-///         server: None,
-///         args: vec![],
-///         env: vec![],
-///         cwd: None,
-///         http: Some("https://api.githubcopilot.com/mcp/".to_string()),
-///         sse: None,
-///         headers: vec!["Authorization=Bearer token".to_string()],
+///     ServerSource::Flags {
+///         transport: TransportArgs::Http {
+///             url: "https://api.githubcopilot.com/mcp/".to_string(),
+///             headers: vec!["Authorization=Bearer token".to_string()],
+///         },
 ///         connect_timeout_secs: Some(5),
 ///         discover_timeout_secs: None,
 ///     },
@@ -189,12 +183,12 @@ pub struct ToolDisplay {
 /// # }
 /// ```
 pub async fn run(
-    raw: RawServerArgs,
+    source: ServerSource,
     detailed: bool,
     output_format: OutputFormat,
 ) -> Result<ExitCode> {
     // Build server config: either from mcp.json or from CLI arguments
-    let (server_id, config) = resolve_server_config(raw)?;
+    let (server_id, config) = resolve_server_config(source)?;
 
     info!("Introspecting server: {}", server_id);
     info!("Transport: {:?}", config.transport());
@@ -311,9 +305,51 @@ fn build_tool_metadata(tool_info: &ToolInfo, detailed: bool) -> ToolDisplay {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::common::TransportArgs;
     use mcp_execution_core::{ServerId, ToolName};
     use mcp_execution_introspector::ServerCapabilities;
     use serde_json::json;
+
+    fn stdio_source(command: &str) -> ServerSource {
+        ServerSource::Flags {
+            transport: TransportArgs::Stdio {
+                command: command.to_string(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        }
+    }
+
+    fn http_source(url: &str, headers: Vec<&str>) -> ServerSource {
+        ServerSource::Flags {
+            transport: TransportArgs::Http {
+                url: url.to_string(),
+                headers: headers.into_iter().map(String::from).collect(),
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        }
+    }
+
+    fn sse_source(url: &str, headers: Vec<&str>) -> ServerSource {
+        ServerSource::Flags {
+            transport: TransportArgs::Sse {
+                url: url.to_string(),
+                headers: headers.into_iter().map(String::from).collect(),
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        }
+    }
+
+    fn config_source(name: &str) -> ServerSource {
+        ServerSource::Config {
+            name: name.to_string(),
+        }
+    }
 
     #[test]
     fn test_build_result_basic() {
@@ -533,11 +569,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_server_connection_failure() {
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server-xyz".to_string()),
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let source = stdio_source("nonexistent-server-xyz");
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -634,11 +667,8 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_text_format() {
         // Test that Text format output works correctly (compact JSON)
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server".to_string()),
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Text).await;
+        let source = stdio_source("nonexistent-server");
+        let result = run(source, false, OutputFormat::Text).await;
 
         // Connection should fail but format handling should not panic
         assert!(result.is_err());
@@ -647,11 +677,8 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_pretty_format() {
         // Test that Pretty format output works correctly (colorized)
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server".to_string()),
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Pretty).await;
+        let source = stdio_source("nonexistent-server");
+        let result = run(source, false, OutputFormat::Pretty).await;
 
         // Connection should fail but format handling should not panic
         assert!(result.is_err());
@@ -660,11 +687,8 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_detailed_mode() {
         // Test that detailed mode doesn't cause crashes even with connection failure
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server".to_string()),
-            ..Default::default()
-        };
-        let result = run(raw, true, OutputFormat::Json).await; // detailed mode
+        let source = stdio_source("nonexistent-server");
+        let result = run(source, true, OutputFormat::Json).await; // detailed mode
 
         assert!(result.is_err());
     }
@@ -674,12 +698,11 @@ mod tests {
     /// deterministic without a live server.
     #[tokio::test]
     async fn test_run_http_transport() {
-        let raw = RawServerArgs {
-            http: Some("https://localhost:99999/invalid".to_string()),
-            headers: vec!["Authorization=Bearer test".to_string()],
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let source = http_source(
+            "https://localhost:99999/invalid",
+            vec!["Authorization=Bearer test"],
+        );
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -706,12 +729,8 @@ mod tests {
     /// See `test_run_http_transport` — same deterministic-failure rationale.
     #[tokio::test]
     async fn test_run_sse_transport() {
-        let raw = RawServerArgs {
-            sse: Some("https://localhost:99999/sse".to_string()),
-            headers: vec!["X-API-Key=test-key".to_string()],
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let source = sse_source("https://localhost:99999/sse", vec!["X-API-Key=test-key"]);
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -735,11 +754,8 @@ mod tests {
     async fn test_run_all_output_formats() {
         // Test all output formats don't cause panics
         for format in [OutputFormat::Json, OutputFormat::Text, OutputFormat::Pretty] {
-            let raw = RawServerArgs {
-                server: Some("nonexistent".to_string()),
-                ..Default::default()
-            };
-            let result = run(raw, false, format).await;
+            let source = stdio_source("nonexistent");
+            let result = run(source, false, format).await;
 
             assert!(result.is_err());
         }
@@ -749,11 +765,8 @@ mod tests {
     async fn test_run_detailed_with_all_formats() {
         // Test detailed mode with all output formats
         for format in [OutputFormat::Json, OutputFormat::Text, OutputFormat::Pretty] {
-            let raw = RawServerArgs {
-                server: Some("nonexistent".to_string()),
-                ..Default::default()
-            };
-            let result = run(raw, true, format).await; // detailed
+            let source = stdio_source("nonexistent");
+            let result = run(source, true, format).await; // detailed
 
             assert!(result.is_err());
         }
@@ -955,11 +968,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_from_config_not_found() {
-        let raw = RawServerArgs {
-            from_config: Some("nonexistent-server-xyz".to_string()),
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let source = config_source("nonexistent-server-xyz");
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -974,13 +984,10 @@ mod tests {
     #[tokio::test]
     async fn test_run_from_config_takes_priority() {
         // When from_config is Some, it should be used for config loading
-        // (server arg should be None due to clap conflicts, but we test the logic)
-        let raw = RawServerArgs {
-            from_config: Some("test-server".to_string()),
-            server: None, // server is None when from_config is used
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Json).await;
+        // (server arg is unrepresentable alongside it — enforced by
+        // `ServerSource` being a closed enum rather than a runtime check).
+        let source = config_source("test-server");
+        let result = run(source, false, OutputFormat::Json).await;
 
         // Should fail because config doesn't exist, not because of server
         assert!(result.is_err());
@@ -995,11 +1002,8 @@ mod tests {
     #[tokio::test]
     async fn test_run_manual_mode_backward_compatible() {
         // Existing behavior: from_config = None, use server arg
-        let raw = RawServerArgs {
-            server: Some("test-server-direct".to_string()),
-            ..Default::default()
-        };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let source = stdio_source("test-server-direct");
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -1014,12 +1018,17 @@ mod tests {
     async fn test_run_zero_connect_timeout_override_rejected_by_validation() {
         // A zero override must surface the same connect_timeout validation
         // error as the mcp.json path, not just a generic connection failure.
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server-timeout-test".to_string()),
+        let source = ServerSource::Flags {
+            transport: TransportArgs::Stdio {
+                command: "nonexistent-server-timeout-test".to_string(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            },
             connect_timeout_secs: Some(0),
-            ..Default::default()
+            discover_timeout_secs: None,
         };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -1037,13 +1046,17 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_valid_timeout_overrides_reaches_connection_attempt() {
         // Valid overrides must not be rejected before the connection attempt.
-        let raw = RawServerArgs {
-            server: Some("nonexistent-server-timeout-test-2".to_string()),
+        let source = ServerSource::Flags {
+            transport: TransportArgs::Stdio {
+                command: "nonexistent-server-timeout-test-2".to_string(),
+                args: vec![],
+                env: vec![],
+                cwd: None,
+            },
             connect_timeout_secs: Some(5),
             discover_timeout_secs: Some(90),
-            ..Default::default()
         };
-        let result = run(raw, false, OutputFormat::Json).await;
+        let result = run(source, false, OutputFormat::Json).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 
 use crate::cli::Commands;
 use crate::commands;
-use crate::commands::common::RawServerArgs;
+use crate::commands::common::ServerSource;
 use crate::formatters::escape_error_text;
 
 /// Initializes logging infrastructure.
@@ -103,32 +103,9 @@ pub async fn execute_command(command: Commands, output_format: OutputFormat) -> 
 /// Returns whatever error the dispatched command handler produces.
 async fn dispatch(command: Commands, output_format: OutputFormat) -> Result<ExitCode> {
     match command {
-        Commands::Introspect {
-            from_config,
-            server,
-            args,
-            env,
-            cwd,
-            http,
-            sse,
-            headers,
-            detailed,
-            connect_timeout_secs,
-            discover_timeout_secs,
-        } => {
-            let raw = RawServerArgs {
-                from_config,
-                server,
-                args,
-                env,
-                cwd,
-                http,
-                sse,
-                headers,
-                connect_timeout_secs,
-                discover_timeout_secs,
-            };
-            commands::introspect::run(raw, detailed, output_format).await
+        Commands::Introspect { flags, detailed } => {
+            let source = ServerSource::try_from(flags)?;
+            commands::introspect::run(source, detailed, output_format).await
         }
         Commands::Skill {
             server,
@@ -150,33 +127,13 @@ async fn dispatch(command: Commands, output_format: OutputFormat) -> Result<Exit
             .await
         }
         Commands::Generate {
-            from_config,
-            server,
-            server_args,
-            server_env,
-            server_cwd,
-            http_url,
-            sse_url,
-            server_headers,
+            flags,
             name,
             progressive_output,
             dry_run,
-            connect_timeout_secs,
-            discover_timeout_secs,
         } => {
-            let raw = RawServerArgs {
-                from_config,
-                server,
-                args: server_args,
-                env: server_env,
-                cwd: server_cwd,
-                http: http_url,
-                sse: sse_url,
-                headers: server_headers,
-                connect_timeout_secs,
-                discover_timeout_secs,
-            };
-            commands::generate::run(raw, name, progressive_output, dry_run, output_format).await
+            let source = ServerSource::try_from(flags)?;
+            commands::generate::run(source, name, progressive_output, dry_run, output_format).await
         }
         Commands::Server { action } => commands::server::run(action, output_format).await,
         Commands::Setup => commands::setup::run(output_format).await,
@@ -524,23 +481,17 @@ mod tests {
         // falling back to anyhow's default exit-code-1 handling. Asserting
         // the exact `SERVER_ERROR` value (not just `!is_success()`) so a
         // regression to the generic `ExitCode::ERROR` fallback is caught.
-        let result = execute_command(
-            Commands::Introspect {
-                from_config: None,
-                server: Some("nonexistent-server-for-exit-code-test".to_string()),
-                args: vec![],
-                env: vec![],
-                cwd: None,
-                http: None,
-                sse: None,
-                headers: vec![],
-                detailed: false,
-                connect_timeout_secs: None,
-                discover_timeout_secs: None,
-            },
-            OutputFormat::Json,
-        )
-        .await;
+        //
+        // Built via real clap parsing (rather than a `Commands::Introspect`
+        // literal): `ServerFlags`'s fields are private outside `cli.rs` by
+        // design, so this is the only way an external module can produce one.
+        use clap::Parser as _;
+        let cli = crate::cli::Cli::parse_from([
+            "mcp-execution-cli",
+            "introspect",
+            "nonexistent-server-for-exit-code-test",
+        ]);
+        let result = execute_command(cli.command, OutputFormat::Json).await;
 
         let exit_code = result.expect("execute_command must not propagate Err");
         assert_eq!(exit_code, ExitCode::SERVER_ERROR);

--- a/specs/SRS-mcp-execution-2026-07-27.md
+++ b/specs/SRS-mcp-execution-2026-07-27.md
@@ -775,7 +775,7 @@ identifying keys, while leaving `Serialize` unredacted for that same type.
 - *Acceptance criteria*:
   1. `ServerConfig`, `ServerConfigBuilder`, and every CLI-facing type
      capable of carrying a secret (`Cli`/`Commands`, `McpTransport`,
-     `RawMcpServerEntry`, `TransportArgs`, `RawServerArgs`) hand-write
+     `RawMcpServerEntry`, `TransportArgs`, `ServerFlags`) hand-write
      `Debug` using `RedactedItems`/`RedactedMapValues`/`RedactedUrl`/
      `sanitize_path_for_error`.
   2. Regression tests assert a specific secret substring never appears in

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -40,7 +40,7 @@ manage/validate server configuration and the local runtime environment.
 | Subcommand | Purpose | Key flags |
 |---|---|---|
 | `introspect` | Connect + display server capabilities/tools | `--from-config`, `server` (positional), `--arg`/`-a`, `--env`/`-e`, `--cwd`, `--http`/`--sse`, `--header`, `--detailed`/`-d`, `--connect-timeout-secs`, `--discover-timeout-secs` |
-| `generate` | Introspect + emit progressive-loading TypeScript to `~/.claude/servers/{id}/` | same transport flags as `introspect` (long-form: `--arg`, `--env`, `--cwd`, `--http`, `--sse`, `--header`), plus `--name`, `--progressive-output`, `--dry-run` |
+| `generate` | Introspect + emit progressive-loading TypeScript to `~/.claude/servers/{id}/` | identical transport flags as `introspect` (`--arg`/`-a`, `--env`/`-e`, `--cwd`, `--http`/`--sse`, `--header` — both commands flatten the same `ServerFlags`, so the `-a`/`-e` short aliases apply here too), plus `--name`, `--progressive-output`, `--dry-run` |
 | `skill` | Render SKILL.md directly from a generated server's tools (no LLM) | `-s/--server`, `--servers-dir`, `-o/--output`, `--skill-name`, `--hint` (repeatable), `--overwrite` |
 | `server` | Manage `~/.claude/mcp.json` entries | subcommand: `list`, `info <server>`, `validate <command>` |
 | `setup` | Validate the local runtime (Node.js version, executable bits, config presence) | none |
@@ -49,11 +49,19 @@ manage/validate server configuration and the local runtime environment.
 Global flags on `Cli` (apply to every subcommand): `-v/--verbose` (DEBUG log
 level), `--format {json,text,pretty}` (default `pretty`, case-insensitive).
 
-`--from-config`/transport flags are **mutually exclusive** at the clap
-level (`conflicts_with_all`), and `server`/`http_url`/`sse_url` collectively
-satisfy `required_unless_present_any` — i.e. exactly one of "load from
-config" or "pick a transport" must be chosen, enforced before any command
-handler runs.
+`introspect`/`generate` flatten a shared `ServerFlags` (`#[derive(Args)]`,
+private fields, `cli.rs`) holding `from_config`/`server`/`args`/`env`/`cwd`/
+`http`/`sse`/`headers`/`connect_timeout_secs`/`discover_timeout_secs`.
+Exclusivity is a single clap `ArgGroup` named `server_source`
+(`required(true)`, default `multiple(false)`) over
+`[from_config, server, http, sse]` — i.e. exactly one of "load from config"
+or "pick a transport" must be chosen, enforced before any command handler
+runs. `from_config` additionally `conflicts_with_all` the non-selector args
+(`args`/`env`/`cwd`/`headers`/the two timeout overrides). `ServerFlags`
+converts into the closed `ServerSource` domain enum via `TryFrom` (see
+below) once parsing has run — its private fields make the "no selector" /
+"multiple selectors" states unconstructible from outside `cli.rs`, not just
+runtime-checked.
 
 ## 3. `common.rs` — Shared Server-Resolution Machinery
 
@@ -61,19 +69,28 @@ This module is the single place `introspect` and `generate` (which accept
 an identical flag surface) resolve "how do I reach this server":
 
 ```rust
-pub struct RawServerArgs { from_config, server, args, env, cwd, http, sse, headers, connect_timeout_secs, discover_timeout_secs }
-pub(crate) fn resolve_server_config(raw: RawServerArgs) -> Result<(ServerId, ServerConfig)>;
+pub enum ServerSource {
+    Config { name: String },
+    Flags { transport: TransportArgs, connect_timeout_secs: Option<u64>, discover_timeout_secs: Option<u64> },
+}
+pub(crate) fn resolve_server_config(source: ServerSource) -> Result<(ServerId, ServerConfig)>;
 ```
-`RawServerArgs` exists specifically to prevent transposing two
-same-typed fields (e.g. `http`/`sse`, both `Option<String>`) by positional
-argument order (issue #286's fix) — named fields instead.
+`ServerSource` is the output of `TryFrom<ServerFlags> for ServerSource`
+(`cli.rs`, needs `ServerFlags`'s private fields). Every value of this type
+is a legal state: `--from-config` and the timeout overrides are folded into
+the same enum because they share one exclusivity group, which also means a
+`Config` source can never carry a meaningless timeout override — unlike the
+former `RawServerArgs` landing zone (`pub` fields, all-`Option`/`Vec`
+shape), where that combination was constructible but silently ignored.
+Named fields (rather than positional parameters) still prevent transposing
+two same-typed fields (e.g. `http`/`sse`, both `Option<String>`) — issue
+#286's original fix, preserved here.
 
 ```rust
 pub struct McpConfig { pub mcp_servers: HashMap<String, McpServerEntry> }
 pub struct McpServerEntry { pub transport: McpTransport, pub connect_timeout_secs, pub discover_timeout_secs }
 pub enum McpTransport { Stdio{command,args,env,cwd}, Http{url,headers}, Sse{url,headers} }
-pub enum TransportArgs { Stdio{...}, Http{...}, Sse{...} } // raw, unparsed CLI-flag mirror of McpTransport
-impl TransportArgs { pub fn from_flags(...) -> Result<Self>; } // enforces "exactly one transport" as a safety net for direct callers
+pub enum TransportArgs { Stdio{...}, Http{...}, Sse{...} } // raw, unparsed CLI-flag mirror of McpTransport; every variant is a legal state by construction (no all-`None`/"both http and sse" shape exists). `pub` with `pub` fields, so directly constructible by any caller; the real CLI path only ever produces one via `TryFrom<ServerFlags>`, which enforces "exactly one transport" at the ServerFlags -> ServerSource boundary
 ```
 
 `McpServerEntry`'s `Deserialize` is **hand-written** (via a
@@ -113,7 +130,7 @@ whole string, or the "key" half, may itself be the secret.
 ## 4. Debug-Redaction Discipline
 
 Every CLI-facing type that can carry a secret (`Cli`/`Commands` themselves,
-`McpTransport`, `RawMcpServerEntry`, `TransportArgs`, `RawServerArgs`) hand-
+`ServerFlags`, `McpTransport`, `RawMcpServerEntry`, `TransportArgs`) hand-
 writes `Debug` rather than deriving it, applying `mcp-core`'s
 `RedactedItems`/`RedactedMapValues`/`RedactedUrl`/`sanitize_path_for_error`
 consistently — because `runner::report_and_classify` prints
@@ -159,7 +176,7 @@ classifies as `SERVER_ERROR`, not the generic fallback:
 
 ## 6. `introspect` Command (`commands/introspect.rs`)
 
-`run(raw: RawServerArgs, detailed: bool, output_format: OutputFormat) -> Result<ExitCode>`.
+`run(source: ServerSource, detailed: bool, output_format: OutputFormat) -> Result<ExitCode>`.
 Resolves config via `resolve_server_config`, runs
 `Introspector::discover_server` once, formats an `IntrospectionResult`
 (`ServerMetadata` + `Vec<ToolDisplay>`, schemas included only when
@@ -168,7 +185,7 @@ command.
 
 ## 7. `generate` Command (`commands/generate.rs`)
 
-`run(raw, name: Option<String>, output_dir: Option<PathBuf>, dry_run: bool, output_format) -> Result<ExitCode>`:
+`run(source: ServerSource, name: Option<String>, output_dir: Option<PathBuf>, dry_run: bool, output_format) -> Result<ExitCode>`:
 
 1. `resolve_server_config` → `discover_server_info` (introspects; applies
    `--name` override to `ServerInfo.id` if given, so generated
@@ -281,8 +298,8 @@ itself.
   `mcp-files::FilesBuilder`, `mcp-skill::{scan_tools_directory,
   build_skill_context, render_skill_md, validate_server_id,
   MAX_SERVER_ID_LENGTH}`.
-- Shares the exact `RawServerArgs`/`resolve_server_config` code path
-  between `introspect` and `generate` — any transport-resolution fix
+- Shares the exact `ServerFlags`/`ServerSource`/`resolve_server_config` code
+  path between `introspect` and `generate` — any transport-resolution fix
   applies to both simultaneously by construction.
 
 ## 15. Edge Cases & Notable Behaviors


### PR DESCRIPTION
## Summary
- Replaces `Commands::Introspect`/`Generate`'s four independent `Option<String>` transport-selecting flags with `ServerFlags`, a private-field clap `Args` type carrying a named `ArgGroup` that enforces "exactly one selector" at parse time.
- `ServerFlags` converts via `TryFrom` into a closed `ServerSource` enum (`Config { name }` / `Flags { transport, connect_timeout_secs, discover_timeout_secs }`), so illegal combinations (both `--http`/`--sse`, or none) can no longer be constructed by any direct caller — only clap-parsed input reaches `introspect::run`/`generate::run`.
- Removes `commands::common::RawServerArgs` and `TransportArgs::from_flags` (both previously `pub`), the runtime-only backstop this replaces.
- Updates `specs/cli/spec.md` and `specs/SRS-mcp-execution-2026-07-27.md` in the same change, per the project's spec-workflow rule.

## Breaking changes
- `introspect <cmd> --http URL` / `generate <cmd> --http URL` (or `--sse`) now fail to parse instead of silently discarding the positional server command and preferring the transport flag — a latent-bug fix, not an intentional prior feature.
- `generate` gains the `-a`/`-e` short aliases for `--arg`/`--env` that `introspect` already had, as a side effect of both commands now flattening the same `ServerFlags`.
- All other invocation syntax (`--from-config`, `--http`, `--sse`, `--server`, timeouts) is unchanged.

See `CHANGELOG.md` `[Unreleased]` for full details.

Closes #314

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1076 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New tests added covering: the `ArgGroup` exclusivity for both commands, the `TryFrom<ServerFlags>` catch-all arm, and round-trip parse -> `TryFrom` -> variant+payload assertions for all four legal arms (guards against a transposed `args`/`env` or swapped `Http`/`Sse` arm slipping through untested)