### PR TITLE
refactor(cli,files)!: type-safety cluster for export panics, output validation, and server status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call sites now distinguish `io::ErrorKind::NotFound` — which still reports the existing
   `DirectoryNotFound`/`MissingMetadata` variants — from any other I/O error, which now propagates
   the real cause via `ScanError::Io` instead of being discarded (#302).
+- **`mcp-execution-files`**: `FileSystem::vfs_to_disk_path`'s defense-in-depth path-traversal
+  check used `assert!`, panicking the whole process if a VFS path ever reached it still
+  containing `..` — turning a validation regression elsewhere into a process-killing DoS instead
+  of a recoverable error. It now returns `Result<PathBuf, FilesError>`, surfacing
+  `FilesError::InvalidPathComponent` instead; `collect_directories`, `write_files`, and
+  `export_to_filesystem_parallel` (its three call sites) now propagate the error via `?` (#318).
+- **`mcp-execution-cli`**: `server list`/`server info`/`server validate`'s `ServerEntry.status`
+  and `ServerInfo.status` fields were `pub status: String`, discarding the closed two-variant
+  `ServerStatus` enum already used internally to compute them — nothing in the type system
+  prevented a future call site from writing an arbitrary string into a field meant to only ever
+  be `"available"`/`"unavailable"`. Both fields are now `pub status: ServerStatus` (see the
+  `### Breaking` entry below for the compatibility impact); `#[derive(Serialize)]` with
+  `#[serde(rename_all = "lowercase")]` keeps JSON/pretty output unchanged (#318).
 
 ### Documentation
 
@@ -176,6 +189,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added justification comments to 3 undocumented `#[allow(...)]` clippy attributes explaining the tradeoff for each (#186).
 - Documented that `ServerConfig`'s `Serialize` output is a separate code path from its redacting `Debug` impl and is not covered by that guarantee — serialized output must never be logged or printed directly (#247).
 - Documented `tsconfig.json` leaf-configuration behavior in `mcp-codegen` crate docs and README: generated `tsconfig.json` is not intended to be `extends`-ed (silent `noEmit` inheritance), is regenerated on every `generate` run, and the generated package should be executed or type-checked as a separate process rather than merged into the consumer's own TypeScript compilation (#258).
+- **`mcp-execution-cli`**: reviewed `skill`'s `--output` path validation
+  (`validate_output_path`/`has_path_traversal`) against its sibling
+  `mcp_execution_skill::output_path::relative_target`, which additionally rejects absolute paths.
+  Confirmed the CLI's component-based traversal check was already correct as-is and does not need
+  to match the sibling: `--output` is an operator-supplied CLI flag (same trust level as the
+  invoking user), while `relative_target` confines the MCP-server-exposed `save_skill` tool
+  against an agent/LLM-supplied argument — different trust boundaries, so identical confinement
+  isn't actually appropriate here. No functional change; a doc comment now records this rationale
+  on `validate_output_path` (#318).
 
 ### Breaking
 
@@ -377,6 +399,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deserialization; `mcp-cli`'s `mcp.json` format is a distinct schema
   (`McpServerEntry`/`McpTransport`, with its own hand-written `Deserialize` and an optional
   `"type"` key inferred from `command`/`url` when absent) and is unaffected by this change.
+
+- **`mcp-execution-cli`**: `generate`'s `--name` override now rejects a value outside
+  `[a-z0-9-]` outright via `validate_server_id` instead of silently slugifying it into a
+  best-effort directory name (see the `### Fixed` entry above, #311). A caller that previously
+  relied on `--name` being auto-slugified (e.g. passing `My Server!`) now gets a hard error
+  instead of a generated `my-server` directory; existing callers already passing a valid
+  `[a-z0-9-]` id are unaffected.
+
+- **`mcp-execution-cli`**: `commands::server::ServerEntry.status` and `ServerInfo.status` changed
+  from `pub status: String` to `pub status: ServerStatus`, a new `pub`, closed, two-variant enum
+  (`Available`/`Unavailable`) replacing the previously untyped string (see the `### Fixed` entry
+  above, #318). Source-breaking for any downstream consumer of this crate as a library that
+  constructs `ServerEntry`/`ServerInfo` directly or pattern-matches/compares `.status` as a
+  `String`. `ServerStatus` derives `Serialize` with `#[serde(rename_all = "lowercase")]`, so CLI
+  JSON/pretty output is unchanged.
 
 ### Security
 

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -35,7 +35,7 @@ const LIST_AVAILABILITY_TIMEOUT: Duration = Duration::from_secs(3);
 /// Status of a configured server.
 ///
 /// The precise check behind this depends on the call site: `server list`
-/// uses [`transport_available`] (PATH lookup for stdio; URL well-formedness
+/// uses `transport_available` (PATH lookup for stdio; URL well-formedness
 /// plus a bounded MCP introspection attempt for http/sse — see
 /// `LIST_AVAILABILITY_TIMEOUT`). `server info`/`server validate` instead
 /// reflect whether a full MCP introspection handshake succeeded, waiting out
@@ -57,8 +57,24 @@ const LIST_AVAILABILITY_TIMEOUT: Duration = Duration::from_secs(3);
 /// a PATH lookup while `info`/`validate` perform a full handshake, so the
 /// two can disagree about more than timing (pre-existing behavior, unrelated
 /// to #280's http/sse scope).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ServerStatus {
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_cli::commands::server::ServerStatus;
+///
+/// assert_eq!(
+///     serde_json::to_string(&ServerStatus::Available).unwrap(),
+///     "\"available\""
+/// );
+/// assert_eq!(
+///     serde_json::to_string(&ServerStatus::Unavailable).unwrap(),
+///     "\"unavailable\""
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServerStatus {
     /// `list`: command in PATH / URL well-formed and reachable. `info`:
     /// introspection succeeded.
     Available,
@@ -67,26 +83,17 @@ enum ServerStatus {
     Unavailable,
 }
 
-impl ServerStatus {
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Available => "available",
-            Self::Unavailable => "unavailable",
-        }
-    }
-}
-
 /// Represents a configured server entry for output.
 ///
 /// # Examples
 ///
 /// ```
-/// use mcp_execution_cli::commands::server::ServerEntry;
+/// use mcp_execution_cli::commands::server::{ServerEntry, ServerStatus};
 ///
 /// let entry = ServerEntry {
 ///     id: "github".to_string(),
 ///     command: "github-mcp-server".to_string(),
-///     status: "available".to_string(),
+///     status: ServerStatus::Available,
 /// };
 ///
 /// assert_eq!(entry.id, "github");
@@ -97,14 +104,13 @@ pub struct ServerEntry {
     pub id: String,
     /// Command used to start the server.
     pub command: String,
-    /// Current server status (`"available"` or `"unavailable"`). For stdio,
-    /// a PATH lookup. For http/sse, a well-formedness pre-check followed by
-    /// the same MCP introspection handshake `server info`/`server validate`
-    /// use — but bounded to `LIST_AVAILABILITY_TIMEOUT` rather than the
-    /// entry's full configured timeout, so this is a time-bounded,
-    /// best-effort signal. Run `server validate <name>` for an authoritative
-    /// answer on one specific server.
-    pub status: String,
+    /// Current server status. For stdio, a PATH lookup. For http/sse, a
+    /// well-formedness pre-check followed by the same MCP introspection
+    /// handshake `server info`/`server validate` use — but bounded to
+    /// `LIST_AVAILABILITY_TIMEOUT` rather than the entry's full configured
+    /// timeout, so this is a time-bounded, best-effort signal. Run `server
+    /// validate <name>` for an authoritative answer on one specific server.
+    pub status: ServerStatus,
 }
 
 /// List of configured servers.
@@ -112,14 +118,14 @@ pub struct ServerEntry {
 /// # Examples
 ///
 /// ```
-/// use mcp_execution_cli::commands::server::{ServerEntry, ServerList};
+/// use mcp_execution_cli::commands::server::{ServerEntry, ServerList, ServerStatus};
 ///
 /// let list = ServerList {
 ///     servers: vec![
 ///         ServerEntry {
 ///             id: "github".to_string(),
 ///             command: "github-mcp-server".to_string(),
-///             status: "available".to_string(),
+///             status: ServerStatus::Available,
 ///         }
 ///     ],
 /// };
@@ -137,14 +143,14 @@ pub struct ServerList {
 /// # Examples
 ///
 /// ```
-/// use mcp_execution_cli::commands::server::{ServerInfo, ToolSummary};
+/// use mcp_execution_cli::commands::server::{ServerInfo, ServerStatus, ToolSummary};
 ///
 /// let info = ServerInfo {
 ///     id: "github".to_string(),
 ///     name: "GitHub MCP".to_string(),
 ///     version: "1.0.0".to_string(),
 ///     command: "github-mcp-server".to_string(),
-///     status: "available".to_string(),
+///     status: ServerStatus::Available,
 ///     tools: vec![],
 ///     capabilities: vec!["tools".to_string()],
 /// };
@@ -162,7 +168,7 @@ pub struct ServerInfo {
     /// Command used to start the server.
     pub command: String,
     /// Current server status.
-    pub status: String,
+    pub status: ServerStatus,
     /// Available tools.
     pub tools: Vec<ToolSummary>,
     /// Server capabilities.
@@ -302,7 +308,7 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
         ServerEntry {
             id: name,
             command,
-            status: status.as_str().to_string(),
+            status,
         }
     });
     let entries = futures_util::future::join_all(checks).await;
@@ -376,7 +382,7 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
                 name: introspected.name,
                 version: introspected.version,
                 command,
-                status: ServerStatus::Available.as_str().to_string(),
+                status: ServerStatus::Available,
                 tools,
                 capabilities,
             };
@@ -413,7 +419,7 @@ fn unavailable_server_info(server: String, command: String) -> ServerInfo {
         name: server,
         version: "unknown".to_string(),
         command,
-        status: ServerStatus::Unavailable.as_str().to_string(),
+        status: ServerStatus::Unavailable,
         tools: Vec::new(),
         capabilities: Vec::new(),
     }
@@ -631,9 +637,15 @@ mod tests {
     use std::collections::HashMap;
 
     #[test]
-    fn test_server_status_as_str() {
-        assert_eq!(ServerStatus::Available.as_str(), "available");
-        assert_eq!(ServerStatus::Unavailable.as_str(), "unavailable");
+    fn test_server_status_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&ServerStatus::Available).unwrap(),
+            "\"available\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerStatus::Unavailable).unwrap(),
+            "\"unavailable\""
+        );
     }
 
     #[test]
@@ -831,7 +843,7 @@ mod tests {
         let entry = ServerEntry {
             id: "test".to_string(),
             command: "test-cmd".to_string(),
-            status: "available".to_string(),
+            status: ServerStatus::Available,
         };
 
         let json = serde_json::to_string(&entry).unwrap();
@@ -846,7 +858,7 @@ mod tests {
             servers: vec![ServerEntry {
                 id: "test".to_string(),
                 command: "test-cmd".to_string(),
-                status: "available".to_string(),
+                status: ServerStatus::Available,
             }],
         };
 
@@ -862,7 +874,7 @@ mod tests {
             name: "Test Server".to_string(),
             version: "1.0.0".to_string(),
             command: "test-cmd".to_string(),
-            status: "available".to_string(),
+            status: ServerStatus::Available,
             tools: vec![ToolSummary {
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
@@ -1158,7 +1170,7 @@ mod tests {
         // this crate's `println!`-only output (see `with_home_pointed_at` test comments).
         let info = unavailable_server_info("http-malformed".to_string(), "curl".to_string());
 
-        assert_eq!(info.status, ServerStatus::Unavailable.as_str());
+        assert_eq!(info.status, ServerStatus::Unavailable);
         assert_eq!(info.id, "http-malformed");
         assert_eq!(info.name, "http-malformed");
         assert!(info.tools.is_empty());

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -393,6 +393,13 @@ fn validate_path_security(path: &Path, base: &Path) -> Result<PathBuf> {
 
 /// Validate output path for path traversal attacks.
 ///
+/// This only rejects traversal escapes (`..`), not absolute paths — callers must ensure `path`
+/// originates from a trusted source (e.g. an interactive CLI operator's own flag), not
+/// agent/LLM-supplied input. This is a narrower contract than
+/// `mcp_execution_skill::output_path::relative_target`, which additionally rejects absolute
+/// paths because it confines the MCP-server-exposed `save_skill` tool, reachable from
+/// agent/LLM-supplied arguments.
+///
 /// # Arguments
 ///
 /// * `path` - Output path to validate

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -580,7 +580,7 @@ impl FileSystem {
                 })?;
 
         // Phase 1: Collect all unique directories
-        let dirs = self.collect_directories(&canonical_staging);
+        let dirs = self.collect_directories(&canonical_staging)?;
 
         // Phase 2: Create all directories in one pass
         Self::create_directories(&dirs)?;
@@ -687,7 +687,7 @@ impl FileSystem {
         self.files().collect::<Vec<_>>().par_iter().try_for_each(
             |(vfs_path, file)| -> Result<()> {
                 let staging_disk_path =
-                    Self::vfs_to_disk_path(vfs_path.as_str(), &canonical_staging);
+                    Self::vfs_to_disk_path(vfs_path.as_str(), &canonical_staging)?;
                 write_file_atomic(&staging_disk_path, file.content(), options.atomic)
             },
         )?;
@@ -734,11 +734,11 @@ impl FileSystem {
     /// Collects all unique directory paths needed for export.
     ///
     /// This is done in a single pass to minimize allocations.
-    fn collect_directories(&self, base: &Path) -> HashSet<PathBuf> {
+    fn collect_directories(&self, base: &Path) -> Result<HashSet<PathBuf>> {
         let mut dirs = HashSet::new();
 
         for (vfs_path, _) in self.files() {
-            let disk_path = Self::vfs_to_disk_path(vfs_path.as_str(), base);
+            let disk_path = Self::vfs_to_disk_path(vfs_path.as_str(), base)?;
 
             // Add all parent directories
             if let Some(parent) = disk_path.parent() {
@@ -754,7 +754,7 @@ impl FileSystem {
             }
         }
 
-        dirs
+        Ok(dirs)
     }
 
     /// Creates all directories in one pass.
@@ -772,7 +772,7 @@ impl FileSystem {
     /// Writes all files into the staging directory ahead of publishing.
     fn write_files(&self, staging_base: &Path, options: &ExportOptions) -> Result<()> {
         for (vfs_path, file) in self.files() {
-            let staging_disk_path = Self::vfs_to_disk_path(vfs_path.as_str(), staging_base);
+            let staging_disk_path = Self::vfs_to_disk_path(vfs_path.as_str(), staging_base)?;
             write_file_atomic(&staging_disk_path, file.content(), options.atomic)?;
         }
         Ok(())
@@ -1016,20 +1016,21 @@ impl FileSystem {
     ///
     /// Strips leading '/' and joins with base path.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if path contains `..` (path traversal attempt).
-    /// This is defense-in-depth since `FilePath::new()` also validates.
-    fn vfs_to_disk_path(vfs_path: &str, base: &Path) -> PathBuf {
+    /// Returns `FilesError::InvalidPathComponent` if `vfs_path` contains `..` (path traversal
+    /// attempt). This is defense-in-depth since `FilePath::new()` also validates.
+    fn vfs_to_disk_path(vfs_path: &str, base: &Path) -> Result<PathBuf> {
         // Strip leading '/' from VFS path
         let relative = vfs_path.strip_prefix('/').unwrap_or(vfs_path);
 
         // Defense-in-depth: reject path traversal attempts
         // Primary validation is in FilePath::new(), this is a safety net
-        assert!(
-            !relative.contains(".."),
-            "SECURITY: Path traversal attempt detected in VFS path: {vfs_path}"
-        );
+        if relative.contains("..") {
+            return Err(FilesError::InvalidPathComponent {
+                path: vfs_path.to_string(),
+            });
+        }
 
         // Convert forward slashes to platform-specific separators
         let relative_path = if cfg!(target_os = "windows") {
@@ -1038,7 +1039,7 @@ impl FileSystem {
             PathBuf::from(relative)
         };
 
-        base.join(relative_path)
+        Ok(base.join(relative_path))
     }
 }
 
@@ -1215,6 +1216,24 @@ mod tests {
         let vfs = FileSystem::new();
         let result = vfs.read_file("/missing.ts");
         assert!(matches!(result, Err(FilesError::FileNotFound { .. })));
+    }
+
+    #[test]
+    fn test_vfs_to_disk_path_rejects_parent_dir_component() {
+        // Defense-in-depth: FilePath::new already rejects `..` at construction time, so this
+        // exercises vfs_to_disk_path's own safety net directly, bypassing that primary
+        // validation — it must return an error instead of panicking (#318).
+        let result = FileSystem::vfs_to_disk_path("/../etc/passwd", Path::new("/base"));
+        assert!(matches!(
+            result,
+            Err(FilesError::InvalidPathComponent { .. })
+        ));
+    }
+
+    #[test]
+    fn test_vfs_to_disk_path_accepts_valid_path() {
+        let result = FileSystem::vfs_to_disk_path("/foo/bar.ts", Path::new("/base")).unwrap();
+        assert_eq!(result, Path::new("/base/foo/bar.ts"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three independent, low-risk type-safety/robustness fixes from issue #318, plus a CHANGELOG breaking-change note from issue #323:

- `FileSystem::vfs_to_disk_path`'s defense-in-depth path-traversal check now returns `Result<PathBuf, FilesError>` instead of `assert!`-panicking the whole export process on a validation regression. Its three call sites propagate the error via `?`.
- `mcp-cli skill --output`'s path validation was reviewed against its sibling `mcp_execution_skill::output_path::relative_target`, which additionally rejects absolute paths. **No functional change was made here** — `--output` is an operator-supplied CLI flag (same trust level as the invoking user), while `relative_target` confines the MCP-server-exposed `save_skill` tool against agent/LLM-supplied arguments; identical confinement isn't appropriate given the different trust boundaries. This is documented in a new doc comment and in the CHANGELOG (moved to `### Documentation`, not `### Fixed`, since nothing was fixed).
- `ServerEntry.status`/`ServerInfo.status` changed from `pub status: String` to `pub status: ServerStatus`, an existing closed two-variant enum now made `pub` with a `Serialize` derive (`#[serde(rename_all = "lowercase")]`) — CLI JSON/pretty output is unchanged, but this is **source-breaking** for any downstream consumer of `mcp-execution-cli` as a library.
- CHANGELOG breaking-change note added for #323 (`generate --name` now rejects invalid values instead of silently slugifying them).

Closes #318
Closes #323

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1069 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`