### PR TITLE
security(deny): close unsound-advisory gap for transitive unsafe deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`deny.toml`**: `[advisories]` now sets `unsound = "all"`, closing the gap where cargo-deny's
+  default (`"workspace"`) silently drops RUSTSEC "unsound" advisories against transitive
+  dependencies such as `unsafe-libyaml-norway` (reached via `mcp-skill -> serde_norway ->
+  unsafe-libyaml-norway`, the workspace's only YAML parser and its largest unsafe-code
+  footprint). `yanked = "deny"` turns a yanked-crate warning into a hard CI failure. Both checks
+  are RUSTSEC/registry-driven — they catch an advisory or yank once filed, not before (#293).
+
 ### Changed
 
 - **`mcp-execution-skill`**: renamed the `pub enum ServerIdError` (returned by

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -33,6 +33,9 @@ pub const MAX_FILE_SIZE: u64 = 1024 * 1024;
 /// latency. A real `name`/`description` frontmatter is a few hundred bytes at
 /// most, so 8KB is already generous while keeping [`extract_skill_metadata`]
 /// cheap enough to run synchronously on `save_skill`'s request-handling task.
+///
+/// This cap is the project-wide contract for any YAML entry point, not a local
+/// detail of this one — see the project constitution's security section.
 pub const MAX_FRONTMATTER_SIZE: usize = 8 * 1024;
 
 // Locates the raw YAML block between a SKILL.md's `---` delimiters. The

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,24 @@
 
 [advisories]
 
-# Ignore specific advisories if needed (add RUSTSEC IDs here)
+# The workspace's only YAML parser reaches libyaml through
+# mcp-skill -> serde_norway -> unsafe-libyaml-norway (depth 2) -- by far the
+# largest unsafe-code footprint in the tree. cargo-deny's `unsound` field
+# (RUSTSEC "unsound" advisories, i.e. memory-safety unsoundness in unsafe
+# code) defaults to "workspace" and so silently drops advisories against
+# transitive dependencies like this one; `unsound = "all"` is the setting
+# that actually closes that gap. `unmaintained` already defaults to "all"
+# upstream, so restating it below is explicit policy, not a behavior change.
+# `yanked` defaults to "warn"; `yanked = "deny"` turns a yank into a hard CI
+# failure. Note all three checks are RUSTSEC/registry-driven: they only fire
+# once an advisory or yank record exists, they do not bound risk proactively.
+unmaintained = "all"
+unsound = "all"
+yanked = "deny"
+
+# Ignore specific advisories if needed (add RUSTSEC IDs here). A yanked
+# version can be allowed temporarily via "a-crate@x.y.z" or
+# { crate = "a-crate@x.y.z", reason = "..." }.
 ignore = []
 
 [licenses]

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -52,7 +52,8 @@ related:
   hand-written sanitizers instead.
 - Schema/validation: `schemars` for JSON-Schema-derived MCP tool parameter
   schemas; `serde`/`serde_json` for wire types; `serde_norway` for YAML
-  (SKILL.md frontmatter) — never `serde_yaml`/`serde_yml`.
+  (SKILL.md frontmatter) — never `serde_yaml`/`serde_yml`. See §V's YAML
+  parse-time bound for the pre-parse cap this parser requires.
 - Error handling: `thiserror` in every library crate; `anyhow` only in
   `mcp-execution-cli`.
 - CLI: `clap` (derive API) + `clap_complete`.
@@ -109,6 +110,16 @@ and issue-number references dedicated to it.
   layer below it rather than choosing an independent number, specifically so
   that data which already cleared a lower layer's bound can never be
   rejected by a higher layer for merely being "as large as already allowed."
+- **YAML parse-time bound (a deliberate exception to the rule above)**:
+  `MAX_FRONTMATTER_SIZE` (`crates/mcp-skill/src/parser.rs`) caps the
+  extracted `SKILL.md` frontmatter block at 8 KiB *before* handing it to
+  `serde_norway`. Unlike the resource-exhaustion bounds above, this cap is
+  intentionally independent of the enclosing `SKILL.md` size limit rather
+  than derived from it: libyaml-based parsers are not linear-time on
+  pathologically nested input, so a much larger document-size bound would
+  not itself bound parse latency. Any future YAML parse entry point must
+  apply this same kind of independent, pre-parse cap to the exact slice it
+  hands to its parser.
 - **Prompt-injection / Markdown-injection defense**: any text that
   originates from an introspected (untrusted) MCP server and is later shown
   to an LLM or embedded in a document (tool names, descriptions, keywords,

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -153,10 +153,16 @@ regex capture that an earlier version used). The extracted block is
 size-capped at `MAX_FRONTMATTER_SIZE` (8 KiB) **before** parsing, since
 `serde_norway` (like other libyaml-based parsers) is not linear-time on
 pathologically nested input — bounding only the overall `SKILL.md` size
-would not bound parse latency. `name`/`description` are required and
-treated as invalid if absent, `null`/`~`, or blank-after-trim. A
-`serde_norway` deserialization error's line number is corrected to be
-file-relative (the block starts one line after the file's opening `---`).
+would not bound parse latency. This pre-parse cap is the project-wide
+contract for YAML input, not a local detail of this function: any future
+YAML parse entry point applies its own cap to the slice it passes to
+`serde_norway`, rather than inheriting a bound from an enclosing
+document-size limit (see [[../constitution#V. Security]]).
+
+`name`/`description` are required and treated as invalid if absent,
+`null`/`~`, or blank-after-trim. A `serde_norway` deserialization error's
+line number is corrected to be file-relative (the block starts one line
+after the file's opening `---`).
 
 ## 8. `resolve_skill_output_path` — Path Confinement
 


### PR DESCRIPTION
## Summary

- cargo-deny's `unsound` field defaults to `"workspace"`, which silently excludes RUSTSEC "unsound" advisories against transitive dependencies. `unsafe-libyaml-norway` (reached via `mcp-skill -> serde_norway -> unsafe-libyaml-norway`, the workspace's only YAML parser and by far its largest unsafe-code footprint) sits exactly in that blind spot. `deny.toml` now sets `unsound = "all"` and `yanked = "deny"`.
- Documents the `MAX_FRONTMATTER_SIZE` pre-parse byte-cap pattern (`crates/mcp-skill/src/parser.rs`) as a project-wide contract in `specs/constitution.md` (§V Security) and `specs/skill/spec.md`, so any future YAML parse entry point applies the same bound instead of assuming it by default.
- No parser change, no dependency bump, no runtime logic change — this is a hardening/discoverability fix per the issue's own remediation section.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1078 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo deny --all-features check advisories licenses bans sources` (cargo-deny 0.20.2, matching CI's `cargo-deny-action@v2` pin)

Fixes #293