### PR TITLE
Rename skill's ServerIdError and close stdio test coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fields with no invariant enforcement) and `TransportArgs::from_flags` (`pub`, the runtime
   "exactly one transport" check) — both superseded by `ServerFlags`/`ServerSource` above (#314).
 
+### Testing
+
+- **`mcp-execution-introspector`**: added stdio-path coverage for two `connect_and_list_tools`
+  error branches previously only exercised via HTTP fixtures. `tests/stdio_connect_failure_test.rs`
+  spawns a new `fixture-immediate-exit-server` binary — a process that spawns successfully but
+  exits immediately, closing stdout before answering the `initialize` handshake — to prove the
+  non-timeout `Error::ConnectionFailed` mapping fires over stdio (the existing
+  `test_discover_server_nonexistent_command` only covers process *spawn* failure, before
+  `connect_and_list_tools` ever runs). `tests/tool_count_bound_test.rs` gained
+  `test_discover_server_stdio_bails_early_once_accumulated_tool_count_exceeds_max`, using a new
+  `fixture-paginated-stdio-server` binary that never signals pagination completion, mirroring the
+  existing HTTP-only `PaginatedFixtureHandler` test to prove `list_tools_bounded`'s
+  `MAX_TOOL_COUNT` early-bailout also fires over the stdio transport (#332).
+
 ### Added
 
 - **`mcp-execution-codegen`**: new `pub` constant `common::typescript::MAX_SCHEMA_RECURSION_DEPTH`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mcp-execution-skill`**: renamed the `pub enum ServerIdError` (returned by
+  `validate_server_id`) to `SkillServerIdError` to remove a name collision with the unrelated
+  `mcp_execution_core::ServerIdError` enum in the same workspace, which was a rename hazard for
+  glob imports and auto-import. Pure rename — variants (`Empty`, `TooLong`, `InvalidCharacters`)
+  and validation behavior are unchanged (#329).
 - **`mcp-execution-cli`**: `introspect` and `generate` now flatten a shared `ServerFlags`
   (private fields, `cli.rs`) instead of each declaring its own copy of the transport/timeout
   flags. A single clap `ArgGroup` (`server_source`, over `from_config`/`server`/`http`/`sse`)

--- a/crates/mcp-introspector/Cargo.toml
+++ b/crates/mcp-introspector/Cargo.toml
@@ -24,6 +24,28 @@ test = false
 doc = false
 required-features = ["test-fixtures"]
 
+[[bin]]
+# Test fixture spawned by tests/stdio_connect_failure_test.rs: a process that
+# spawns successfully but exits immediately without behaving as an MCP
+# server. Not part of the public crate API; only built with `--features
+# test-fixtures` (implied by `--all-features`, which is how CI runs tests).
+name = "fixture-immediate-exit-server"
+path = "tests/fixtures/immediate_exit_server.rs"
+test = false
+doc = false
+required-features = ["test-fixtures"]
+
+[[bin]]
+# Test fixture spawned by tests/tool_count_bound_test.rs: an MCP server over
+# stdio that never signals pagination completion. Not part of the public
+# crate API; only built with `--features test-fixtures` (implied by
+# `--all-features`, which is how CI runs tests).
+name = "fixture-paginated-stdio-server"
+path = "tests/fixtures/paginated_stdio_server.rs"
+test = false
+doc = false
+required-features = ["test-fixtures"]
+
 [features]
 # Enables the server-side rmcp features needed by the slow-server (stdio) and
 # HTTP fixture servers used in tests, without pulling them into the default

--- a/crates/mcp-introspector/tests/fixtures/immediate_exit_server.rs
+++ b/crates/mcp-introspector/tests/fixtures/immediate_exit_server.rs
@@ -1,0 +1,14 @@
+//! Test fixture: an executable that spawns successfully but exits immediately
+//! without ever behaving as an MCP server, closing its stdout pipe before
+//! answering the `initialize` handshake.
+//!
+//! Used by `tests/stdio_connect_failure_test.rs` (issue #332) to exercise
+//! `connect_and_list_tools`'s non-timeout `Error::ConnectionFailed` mapping via
+//! the stdio path: `test_discover_server_nonexistent_command` in
+//! `tests/integration_test.rs` fails during process *spawn* itself (the
+//! command does not resolve on `PATH`), so it never reaches
+//! `connect_and_list_tools`. This fixture is a real, spawnable executable, so
+//! the failure instead surfaces once the client tries to read the handshake
+//! response from the (immediately closed) stdout pipe.
+
+const fn main() {}

--- a/crates/mcp-introspector/tests/fixtures/paginated_stdio_server.rs
+++ b/crates/mcp-introspector/tests/fixtures/paginated_stdio_server.rs
@@ -1,0 +1,61 @@
+//! Test fixture: an MCP server over stdio whose `tools/list` handler serves
+//! tools [`PAGE_SIZE`] at a time and never signals completion (every page
+//! carries a `next_cursor`).
+//!
+//! Mirrors `PaginatedFixtureHandler` in `tests/tool_count_bound_test.rs`
+//! (issue #198 S4), which proves `list_tools_bounded`'s early-bailout works
+//! against a real `rmcp` transport over Streamable HTTP. This fixture closes
+//! the same coverage gap for the stdio path (issue #332): without it,
+//! `map_list_tools_bounded_error`'s `Error::ResourceLimitExceeded` mapping was
+//! only ever exercised via HTTP.
+
+use rmcp::model::{ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool};
+use rmcp::service::RequestContext;
+use rmcp::transport::stdio;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, ServiceExt};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Number of tools served per `list_tools` page. Deliberately smaller than
+/// `MAX_TOOL_COUNT` so a single discovery run spans multiple pages.
+const PAGE_SIZE: usize = 300;
+
+#[derive(Default)]
+struct PaginatedServer {
+    /// Number of `list_tools` calls served so far; incremented on every call.
+    call_count: AtomicUsize,
+}
+
+impl ServerHandler for PaginatedServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let page_index = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let start = page_index * PAGE_SIZE;
+
+        let tools = (0..PAGE_SIZE)
+            .map(|i| Tool::new(format!("tool{}", start + i), "d", serde_json::Map::new()))
+            .collect();
+
+        Ok(ListToolsResult {
+            meta: None,
+            next_cursor: Some("more".to_string()),
+            tools,
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let service = PaginatedServer::default()
+        .serve(stdio())
+        .await
+        .expect("fixture server failed to start");
+
+    let _ = service.waiting().await;
+}

--- a/crates/mcp-introspector/tests/stdio_connect_failure_test.rs
+++ b/crates/mcp-introspector/tests/stdio_connect_failure_test.rs
@@ -1,0 +1,63 @@
+//! Integration test proving `connect_and_list_tools`'s non-timeout
+//! `Error::ConnectionFailed` mapping fires via the stdio path (issue #332).
+//!
+//! `discover_via_http`'s analogous branch is covered by
+//! `test_discover_server_http_reserved_header_collision_is_legible` in
+//! `tests/http_transport_test.rs`. On the stdio side,
+//! `test_discover_server_nonexistent_command` in `tests/integration_test.rs`
+//! only covers process *spawn* failure (the command never resolves on
+//! `PATH`), which fails before `connect_and_list_tools` runs at all. This
+//! test spawns a real, resolvable executable that exits immediately, closing
+//! its stdout pipe before ever answering the `initialize` handshake, so the
+//! failure instead surfaces from the handshake read itself — exercising the
+//! `connect` future's `Err` arm inside `connect_and_list_tools`.
+//!
+//! Requires the `test-fixtures` feature (implied by `--all-features`, which
+//! is how CI and the project's preferred `cargo nextest` invocation run
+//! tests) so that `fixture-immediate-exit-server` is built.
+
+#![cfg(feature = "test-fixtures")]
+
+use mcp_execution_core::{Error, ServerConfig, ServerId};
+use mcp_execution_introspector::Introspector;
+use std::time::Duration;
+
+/// Absolute path to the `fixture-immediate-exit-server` binary built
+/// alongside this test target.
+const FIXTURE_BIN: &str = env!("CARGO_BIN_EXE_fixture-immediate-exit-server");
+
+#[tokio::test]
+async fn test_discover_server_stdio_handshake_failure_is_connection_failed_not_timeout() {
+    let mut introspector = Introspector::new();
+    let server_id = ServerId::new("stdio-immediate-exit").unwrap();
+
+    let config = ServerConfig::builder()
+        .command(FIXTURE_BIN.to_string())
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    let result = introspector.discover_server(server_id, &config).await;
+
+    match result {
+        Err(Error::ConnectionFailed { server, source }) => {
+            assert_eq!(server, "stdio-immediate-exit");
+            // Pins the failure to the handshake step inside `connect_and_list_tools`
+            // (`lib.rs:991`), not to `spawn_introspection_child`'s spawn-failure or
+            // pipe-capture `ConnectionFailed` sites (`lib.rs:628`/`646`/`650`) —
+            // neither of which ever mentions "initialize". The fixture exits so
+            // fast there's a genuine race between two legitimate outcomes at the
+            // *same* intended site: the client's `initialize` write can fail first
+            // (`"... Broken pipe ..., when send initialize request"`) or its read of
+            // the response can fail first (`ServiceError::ConnectionClosed("initialize
+            // response")`) — both are correct, so the check must accept either.
+            let msg = source.to_string().to_ascii_lowercase();
+            assert!(
+                msg.contains("initialize"),
+                "expected a handshake-failure error mentioning \"initialize\" (either the \
+                 request write or the response read), got: {msg}"
+            );
+        }
+        other => panic!("expected Error::ConnectionFailed, got {other:?}"),
+    }
+}

--- a/crates/mcp-introspector/tests/tool_count_bound_test.rs
+++ b/crates/mcp-introspector/tests/tool_count_bound_test.rs
@@ -14,7 +14,7 @@
 #![cfg(feature = "test-fixtures")]
 
 use axum::Router;
-use mcp_execution_core::{ServerConfig, ServerId};
+use mcp_execution_core::{Error, ServerConfig, ServerId};
 use mcp_execution_introspector::{Introspector, MAX_TOOL_COUNT};
 use rmcp::model::{
     Implementation, InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
@@ -199,4 +199,65 @@ async fn test_discover_server_accepts_exactly_max_tool_count_across_pages() {
 
     let expected_pages = MAX_TOOL_COUNT.div_ceil(PAGE_SIZE);
     assert_eq!(call_count.load(Ordering::SeqCst), expected_pages);
+}
+
+/// Absolute path to the `fixture-paginated-stdio-server` binary built
+/// alongside this test target. Unlike [`PaginatedFixtureHandler`] above (HTTP
+/// only, issue #226's rationale for why HTTP has no response-size bound), the
+/// stdio path reads through `bounded_response_stream`, but pagination
+/// early-bailout happens in `list_tools_bounded` before that bound is ever
+/// relevant — this fixture proves the same early-bailout logic used by the
+/// HTTP tests above also fires via stdio, closing the coverage gap noted in
+/// issue #332.
+const STDIO_FIXTURE_BIN: &str = env!("CARGO_BIN_EXE_fixture-paginated-stdio-server");
+
+/// Stdio counterpart to
+/// `test_discover_server_bails_early_once_accumulated_tool_count_exceeds_max`:
+/// the fixture never signals pagination completion, so if
+/// `list_tools_bounded` did not bail out mid-pagination over the stdio
+/// transport, this test would hang until `discover_timeout` fires instead of
+/// failing fast with `Error::ResourceLimitExceeded`.
+#[tokio::test]
+async fn test_discover_server_stdio_bails_early_once_accumulated_tool_count_exceeds_max() {
+    let mut introspector = Introspector::new();
+    let config = ServerConfig::builder()
+        .command(STDIO_FIXTURE_BIN.to_string())
+        .connect_timeout(Duration::from_secs(5))
+        .discover_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    let result = introspector
+        .discover_server(
+            ServerId::new("paginated-stdio-fixture-over").unwrap(),
+            &config,
+        )
+        .await;
+
+    let err = result.expect_err(
+        "discover_server must reject once accumulated tool count exceeds MAX_TOOL_COUNT",
+    );
+
+    // Smallest page count `k` such that `k * PAGE_SIZE > MAX_TOOL_COUNT` (see the HTTP sibling
+    // test's identical calculation above) — the fixture's `PAGE_SIZE` matches this file's.
+    let expected_pages = MAX_TOOL_COUNT / PAGE_SIZE + 1;
+    let expected_actual = expected_pages * PAGE_SIZE;
+    match err {
+        Error::ResourceLimitExceeded {
+            resource,
+            actual,
+            limit,
+        } => {
+            assert!(
+                resource.contains("tool count"),
+                "expected a tool-count resource limit, got resource={resource:?}"
+            );
+            assert_eq!(
+                actual, expected_actual,
+                "must bail on the page that first pushes the running total over MAX_TOOL_COUNT"
+            );
+            assert_eq!(limit, MAX_TOOL_COUNT);
+        }
+        other => panic!("expected Error::ResourceLimitExceeded, got {other:?}"),
+    }
 }

--- a/crates/mcp-skill/src/lib.rs
+++ b/crates/mcp-skill/src/lib.rs
@@ -39,6 +39,6 @@ pub use parser::{
 pub use template::{TemplateError, render_generation_prompt, render_skill_md};
 pub use types::{
     GenerateSkillParams, GenerateSkillResult, MAX_SERVER_ID_LENGTH, SaveSkillParams,
-    SaveSkillResult, ServerIdError, SkillCategory, SkillMetadata, SkillTool, ToolExample,
+    SaveSkillResult, SkillCategory, SkillMetadata, SkillServerIdError, SkillTool, ToolExample,
     validate_server_id,
 };

--- a/crates/mcp-skill/src/types.rs
+++ b/crates/mcp-skill/src/types.rs
@@ -239,7 +239,7 @@ pub struct SkillMetadata {
 
 /// Errors returned by [`validate_server_id`].
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum ServerIdError {
+pub enum SkillServerIdError {
     /// `server_id` was empty.
     ///
     /// An empty `server_id` would collapse a per-server confinement
@@ -277,7 +277,7 @@ pub enum ServerIdError {
 ///
 /// # Errors
 ///
-/// Returns [`ServerIdError`] if:
+/// Returns [`SkillServerIdError`] if:
 /// - Empty
 /// - Length exceeds 64 characters
 /// - Contains characters other than lowercase letters, digits, and hyphens
@@ -299,17 +299,17 @@ pub enum ServerIdError {
 /// assert!(validate_server_id("GitHub").is_err()); // uppercase
 /// assert!(validate_server_id("my_server").is_err()); // underscore
 /// ```
-pub fn validate_server_id(server_id: &str) -> Result<(), ServerIdError> {
+pub fn validate_server_id(server_id: &str) -> Result<(), SkillServerIdError> {
     // Check emptiness (the character-class check below is vacuously true for
     // an empty string, and an empty server_id would collapse a per-server
     // confinement directory back to its shared parent)
     if server_id.is_empty() {
-        return Err(ServerIdError::Empty);
+        return Err(SkillServerIdError::Empty);
     }
 
     // Check length
     if server_id.len() > MAX_SERVER_ID_LENGTH {
-        return Err(ServerIdError::TooLong {
+        return Err(SkillServerIdError::TooLong {
             len: server_id.len(),
             limit: MAX_SERVER_ID_LENGTH,
         });
@@ -320,7 +320,7 @@ pub fn validate_server_id(server_id: &str) -> Result<(), ServerIdError> {
         .chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
     {
-        return Err(ServerIdError::InvalidCharacters);
+        return Err(SkillServerIdError::InvalidCharacters);
     }
 
     Ok(())
@@ -370,25 +370,25 @@ mod tests {
     #[test]
     fn test_validate_server_id_empty() {
         let result = validate_server_id("");
-        assert_eq!(result, Err(ServerIdError::Empty));
+        assert_eq!(result, Err(SkillServerIdError::Empty));
     }
 
     #[test]
     fn test_validate_server_id_uppercase() {
         let result = validate_server_id("GitHub");
-        assert_eq!(result, Err(ServerIdError::InvalidCharacters));
+        assert_eq!(result, Err(SkillServerIdError::InvalidCharacters));
     }
 
     #[test]
     fn test_validate_server_id_underscore() {
         let result = validate_server_id("my_server");
-        assert_eq!(result, Err(ServerIdError::InvalidCharacters));
+        assert_eq!(result, Err(SkillServerIdError::InvalidCharacters));
     }
 
     #[test]
     fn test_validate_server_id_special_chars() {
         let result = validate_server_id("my@server");
-        assert_eq!(result, Err(ServerIdError::InvalidCharacters));
+        assert_eq!(result, Err(SkillServerIdError::InvalidCharacters));
     }
 
     #[test]
@@ -397,7 +397,7 @@ mod tests {
         let result = validate_server_id(&long_id);
         assert_eq!(
             result,
-            Err(ServerIdError::TooLong {
+            Err(SkillServerIdError::TooLong {
                 len: 65,
                 limit: MAX_SERVER_ID_LENGTH
             })

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -52,11 +52,11 @@ pub use parser::{MAX_FILE_SIZE, MAX_FRONTMATTER_SIZE, MAX_TOOL_FILES,
     extract_skill_metadata, scan_tools_directory};
 pub use template::{TemplateError, render_generation_prompt, render_skill_md};
 pub use types::{GenerateSkillParams, GenerateSkillResult, MAX_SERVER_ID_LENGTH,
-    SaveSkillParams, SaveSkillResult, ServerIdError, SkillCategory, SkillMetadata,
+    SaveSkillParams, SaveSkillResult, SkillCategory, SkillMetadata, SkillServerIdError,
     SkillTool, ToolExample, validate_server_id};
 
 pub const MAX_SERVER_ID_LENGTH: usize = 64;
-pub fn validate_server_id(server_id: &str) -> Result<(), ServerIdError>;
+pub fn validate_server_id(server_id: &str) -> Result<(), SkillServerIdError>;
 // Rules: non-empty, <= 64 bytes, only [a-z0-9-]
 
 pub const MAX_TOOL_FILES: usize = 500;
@@ -197,7 +197,7 @@ reach):
 `InvalidPath`, `ServerIdIsSymlink`, `Escape`, `NotADirectory`, `NotAFile`,
 `CreateDir`, `Io`.
 
-`ServerIdError`: `Empty`, `TooLong { len, limit }`, `InvalidCharacters`.
+`SkillServerIdError`: `Empty`, `TooLong { len, limit }`, `InvalidCharacters`.
 
 ## 10. Cross-Crate Contracts
 


### PR DESCRIPTION
## Summary

Two independent P3 issues, bundled in one PR since both are small and non-breaking-in-scope hardening work:

- Rename `mcp_execution_skill::ServerIdError` to `SkillServerIdError` to resolve a name collision with the unrelated `mcp_execution_core::ServerIdError` in the same workspace (closes #329). Pure rename — variants and validation semantics are unchanged, but it is source-breaking for any downstream consumer referencing the old name.
- Add stdio-path test coverage for two branches of `connect_and_list_tools` (shared by `discover_via_stdio`/`discover_via_http`) that were previously only reachable via HTTP fixtures: the non-timeout `ConnectionFailed` mapping, and the `MAX_TOOL_COUNT` pagination bail-out (closes #332).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1080/1080 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New stdio tests independently verified (via `cargo llvm-cov` line-hit tracing) to hit the exact intended branches, not superficial passes
- [x] A rare (~1/300) race in the connect-failure test's error-message assertion was found in review and fixed; the fixed assertion was stress-tested with 1000+ direct binary runs across two independent runs with zero failures