### PR TITLE
fix(cli): redact secrets in introspect --verbose transport log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`mcp-execution-cli`**: `introspect --verbose` no longer logs the raw HTTP/SSE header values or
+  stdio environment variable values from the resolved `ServerConfig` at INFO level. The log line
+  previously formatted `config.transport()` (`&Transport`, plain derived `Debug`) directly; it now
+  formats `config` (`ServerConfig`), whose existing hand-written `Debug` impl already redacts
+  header/env values, args, and URL userinfo/query. `mcp_execution_core::Transport` itself still
+  derives a plain `Debug` and remains unredacted if formatted directly elsewhere — tracked
+  separately (#336, #345).
 - **`deny.toml`**: `[advisories]` now sets `unsound = "all"`, closing the gap where cargo-deny's
   default (`"workspace"`) silently drops RUSTSEC "unsound" advisories against transitive
   dependencies such as `unsafe-libyaml-norway` (reached via `mcp-skill -> serde_norway ->

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -191,7 +191,7 @@ pub async fn run(
     let (server_id, config) = resolve_server_config(source)?;
 
     info!("Introspecting server: {}", server_id);
-    info!("Transport: {:?}", config.transport());
+    info!("Server config: {config:?}");
     info!("Detailed: {}", detailed);
     info!("Output format: {}", output_format);
 
@@ -306,7 +306,7 @@ fn build_tool_metadata(tool_info: &ToolInfo, detailed: bool) -> ToolDisplay {
 mod tests {
     use super::*;
     use crate::commands::common::TransportArgs;
-    use mcp_execution_core::{ServerId, ToolName};
+    use mcp_execution_core::{REDACTED_PLACEHOLDER, ServerId, ToolName};
     use mcp_execution_introspector::ServerCapabilities;
     use serde_json::json;
 
@@ -1041,6 +1041,110 @@ mod tests {
             chain_msg.contains("greater than zero"),
             "expected connect_timeout validation error in the error chain, got: {chain_msg}"
         );
+    }
+
+    /// Captures the formatted `message` text of every tracing event observed while
+    /// installed as the default subscriber, so a test can assert on what an `info!`
+    /// call actually emitted instead of re-deriving it via a bare `format!` call.
+    ///
+    /// Minimal by design (mirrors the `WarnCounter`/`CorrelationLayer` precedents in
+    /// `mcp-introspector`/`mcp-server`'s test suites): no span bookkeeping beyond
+    /// what `tracing::Subscriber` requires, since these tests only need event text.
+    #[derive(Clone, Default)]
+    struct MessageCapture(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+    impl MessageCapture {
+        fn joined(&self) -> String {
+            self.0.lock().unwrap().join("\n")
+        }
+    }
+
+    impl tracing::Subscriber for MessageCapture {
+        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+        fn event(&self, event: &tracing::Event<'_>) {
+            struct MessageVisitor(Option<String>);
+            impl tracing::field::Visit for MessageVisitor {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        self.0 = Some(format!("{value:?}"));
+                    }
+                }
+            }
+
+            let mut visitor = MessageVisitor(None);
+            event.record(&mut visitor);
+            if let Some(message) = visitor.0 {
+                self.0.lock().unwrap().push(message);
+            }
+        }
+
+        fn enter(&self, _span: &tracing::span::Id) {}
+
+        fn exit(&self, _span: &tracing::span::Id) {}
+    }
+
+    /// Regression test for #336: drives the real CLI-args -> `resolve_server_config`
+    /// -> `run` path (not a bare `ServerConfig::builder()` + `format!` call) with an
+    /// HTTP header carrying a secret, and captures the actual tracing output the
+    /// `--verbose` log line emits. The server connection still fails (no real
+    /// server listening), but the log line fires before that attempt, so the
+    /// capture reflects exactly what a `--verbose` run would print to stderr.
+    #[tokio::test]
+    async fn test_run_verbose_log_redacts_http_header_secret() {
+        let secret_body = "sk-verySECRETtoken1234567890";
+        let header = format!("Authorization=Bearer {secret_body}");
+        let capture = MessageCapture::default();
+        let _guard = tracing::subscriber::set_default(capture.clone());
+
+        let source = http_source("https://localhost:99999/invalid", vec![&header]);
+        let _ = run(source, false, OutputFormat::Json).await;
+
+        let logged = capture.joined();
+        assert!(logged.contains("Authorization"));
+        assert!(logged.contains(REDACTED_PLACEHOLDER));
+        assert!(!logged.contains(secret_body));
+    }
+
+    /// Regression test for #336, stdio transport variant: env var values (e.g.
+    /// `GITHUB_TOKEN`) must not leak into the same log line either, exercised
+    /// through the same CLI-args -> `run` path as the HTTP case above.
+    #[tokio::test]
+    async fn test_run_verbose_log_redacts_stdio_env_secret() {
+        let secret_body = "ghp_verySECRETtoken1234567890abcdef";
+        let capture = MessageCapture::default();
+        let _guard = tracing::subscriber::set_default(capture.clone());
+
+        let source = ServerSource::Flags {
+            transport: TransportArgs::Stdio {
+                command: "nonexistent-server-336".to_string(),
+                args: vec![],
+                env: vec![format!("GITHUB_TOKEN={secret_body}")],
+                cwd: None,
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+        let _ = run(source, false, OutputFormat::Json).await;
+
+        let logged = capture.joined();
+        assert!(logged.contains("GITHUB_TOKEN"));
+        assert!(logged.contains(REDACTED_PLACEHOLDER));
+        assert!(!logged.contains(secret_body));
     }
 
     #[tokio::test]

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -140,6 +140,19 @@ tests assert specific secret substrings (e.g. `sk-verySECRETtoken...`)
 never appear in `format!("{:?}", cli.command)` for `--env`/`--header`/
 `--http`/`--sse` inputs.
 
+This discipline extends to `tracing` log lines, not just the error path:
+`commands::introspect::run` logs the resolved `ServerConfig` under
+`--verbose` (INFO level) by formatting `config` itself
+(`mcp_execution_core::ServerConfig`, whose own hand-written `Debug` impl
+applies the same redaction) rather than `config.transport()`
+(`&mcp_execution_core::Transport`). `Transport` is `mcp-core`'s one
+secret-bearing type that still derives a plain `Debug` — formatting it
+directly, here or anywhere else, reproduces the leak this log line was
+fixed for (#336; tracked for a structural fix, redacting `Debug` on
+`Transport` itself, in #345). Any new log line touching a `ServerConfig`
+must format the `ServerConfig`/`TransportArgs`/`McpTransport` wrapper, never
+`Transport` directly.
+
 ## 5. `runner.rs` — Dispatch and Exit-Code Classification
 
 ```rust


### PR DESCRIPTION
## Summary
- `introspect`'s `--verbose` transport log line formatted the resolved `Transport` value directly with `{:?}` (plain derived `Debug`), printing HTTP/SSE header values and stdio env var values in cleartext to stderr at INFO level on every verbose invocation.
- The fix logs the `ServerConfig` itself instead of `config.transport()`, reusing its existing hand-written redacting `Debug` impl rather than introducing a second redaction path.
- Added two regression tests that drive the real `ServerSource::Flags` -> `resolve_server_config` -> `run()` path with secret-shaped HTTP headers and stdio env vars, capturing actual `tracing` output via a minimal test-only `Subscriber` and asserting the raw secret never appears.

## Scope notes
- `Transport` itself still derives a plain `Debug` and remains unredacted if formatted directly anywhere else — tracked separately in #345 (deliberately out of scope for this fix; larger structural change).
- `server validate`/`server info` also print raw command args/URLs unconditionally (not verbose-gated) — tracked separately in #346 (different severity/scope; deliberately not touched here).

Closes #336

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1090 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests verified to fail on manual revert of the fix line