### PR TITLE
refactor(files,skill)!: close FilesResourceKind and ParsedToolFile server_id gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   separately-threaded `server_id` parameter, so the map key can no longer drift from the value's
   `id` field even though both were already sourced from the same identifier in practice. No
   public API change (#317).
+- **`mcp-execution-skill`**: `parser::ParsedToolFile`'s `impl From<ToolMetadata>` (which set
+  `server_id: String::new()` as a placeholder, patched in afterward by `scan_tools_directory`)
+  replaced by a private `parsed_tool_file_from_metadata(meta, server_id)` function that takes
+  `server_id` directly, so a `ParsedToolFile` with the wrong (or empty-sentinel) server id can no
+  longer be constructed via that conversion path (see the `### Breaking` entry below for the
+  compatibility impact). `ParsedToolFile`'s own fields and `scan_tools_directory`'s output are
+  unchanged (#342).
+- **`mcp-execution-files`**: `FilesError::ResourceLimitExceeded.resource` changed from a
+  free-form `String` to the new closed `pub enum types::FilesResourceKind` (`ExportFileCount`,
+  `ExportTotalSize`), re-exported at the crate root, closing the gap `mcp-execution-core`'s
+  `ResourceKind` (#317) intentionally left open (see the `### Breaking` entry below for the
+  compatibility impact). Kept as a local enum rather than added as variants to
+  `mcp-core::ResourceKind`: that enum already has semantically adjacent variants
+  (`GeneratedOutputSize`/`GeneratedFileCount`, the closest neighbors to
+  `ExportTotalSize`/`ExportFileCount`), but `mcp-files` has no direct dependency on
+  `mcp-execution-core` (only a transitive one via `mcp-execution-codegen`), so sharing that enum
+  would mean adding a new direct dependency on `mcp-core` for a single error variant — a local
+  enum avoids that coupling. `FilesResourceKind`'s `Display` reproduces the same wording
+  `check_export_bounds` built by hand (`"export file count"` / `"export total size"`), so the
+  error message is unchanged in substance. The only in-tree construction sites
+  (`mcp-files::filesystem::check_export_bounds`) and match/test sites (`mcp-cli::runner`)
+  updated (#343).
 
 ### Removed
 
@@ -305,6 +327,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variant list and rationale). Source-breaking for any downstream consumer that constructs
   `Error::ResourceLimitExceeded { resource: ... }` with a string literal, or pattern-matches/reads
   `.resource` expecting a `String` (#317).
+- **`mcp-execution-files`**: `FilesError::ResourceLimitExceeded.resource` changed from `String`
+  to the new closed `pub enum FilesResourceKind` (see the `### Changed` entry above for the full
+  variant list and rationale). Source-breaking for any downstream consumer that constructs
+  `FilesError::ResourceLimitExceeded { resource: ... }` with a string literal, or
+  pattern-matches/reads `.resource` expecting a `String` (#343).
+- **`mcp-execution-skill`**: `impl From<mcp_execution_core::metadata::ToolMetadata> for
+  ParsedToolFile` removed (see the `### Changed` entry above for the replacement). Both types are
+  publicly re-exported, so this is source-breaking for any downstream consumer that relied on
+  `ToolMetadata::into::<ParsedToolFile>()`/`ParsedToolFile::from(tool_metadata)`; `ParsedToolFile`
+  itself is unaffected and still constructible via its (unchanged) public fields (#342).
 - **`mcp-execution-core`**: `metadata::ServerMetadata.server_id` changed from `String` to
   `ServerId`, and `metadata::ToolMetadata.name` changed from `String` to `ToolName` (see the
   `### Changed` entry above for the wire-format-compatibility note). Source-breaking for any

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -341,6 +341,7 @@ mod tests {
     use super::*;
     use mcp_execution_core::ResourceKind;
     use mcp_execution_core::ServerId;
+    use mcp_execution_files::FilesResourceKind;
 
     fn wrap(core_error: CoreError) -> anyhow::Error {
         anyhow::Error::new(core_error)
@@ -382,7 +383,7 @@ mod tests {
     #[test]
     fn test_classify_exit_code_files_error_resource_limit_exceeded() {
         let files_error = FilesError::ResourceLimitExceeded {
-            resource: "export file count".to_string(),
+            resource: FilesResourceKind::ExportFileCount,
             actual: 3000,
             limit: 2000,
         };

--- a/crates/mcp-files/src/builder.rs
+++ b/crates/mcp-files/src/builder.rs
@@ -448,6 +448,7 @@ fn write_file_atomic(base_path: &Path, vfs_path: &str, content: &str) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::FilesResourceKind;
     use mcp_execution_codegen::GeneratedFile;
     use tempfile::TempDir;
 
@@ -883,10 +884,16 @@ mod tests {
         let target = temp_dir.path().join("out");
         let result = builder.build_and_export(&target);
 
-        assert!(matches!(
-            result,
-            Err(FilesError::ResourceLimitExceeded { .. })
-        ));
+        assert!(
+            matches!(
+                result,
+                Err(FilesError::ResourceLimitExceeded {
+                    resource: FilesResourceKind::ExportFileCount,
+                    ..
+                })
+            ),
+            "expected ResourceLimitExceeded{{resource: ExportFileCount}}, got: {result:?}"
+        );
         // Rejected before any per-group publish ran, so the target directory
         // (which build_and_export would otherwise create unconditionally)
         // must never have been created.

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -60,7 +60,7 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-use crate::types::{FileEntry, FilePath, FilesError, Result};
+use crate::types::{FileEntry, FilePath, FilesError, FilesResourceKind, Result};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
@@ -713,7 +713,7 @@ impl FileSystem {
     pub(crate) fn check_export_bounds(&self) -> Result<()> {
         if self.file_count() > MAX_EXPORT_FILES {
             return Err(FilesError::ResourceLimitExceeded {
-                resource: "export file count".to_string(),
+                resource: FilesResourceKind::ExportFileCount,
                 actual: self.file_count(),
                 limit: MAX_EXPORT_FILES,
             });
@@ -722,7 +722,7 @@ impl FileSystem {
         let total_bytes: usize = self.files().map(|(_, file)| file.size()).sum();
         if total_bytes > MAX_EXPORT_BYTES {
             return Err(FilesError::ResourceLimitExceeded {
-                resource: "export total size".to_string(),
+                resource: FilesResourceKind::ExportTotalSize,
                 actual: total_bytes,
                 limit: MAX_EXPORT_BYTES,
             });
@@ -1954,8 +1954,16 @@ mod tests {
 
         let result = vfs.export_to_filesystem(temp.path());
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_resource_limit_exceeded());
+        assert!(
+            matches!(
+                result,
+                Err(FilesError::ResourceLimitExceeded {
+                    resource: FilesResourceKind::ExportFileCount,
+                    ..
+                })
+            ),
+            "expected ResourceLimitExceeded{{resource: ExportFileCount}}, got: {result:?}"
+        );
     }
 
     #[test]
@@ -1980,8 +1988,16 @@ mod tests {
 
         let result = vfs.export_to_filesystem(temp.path());
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_resource_limit_exceeded());
+        assert!(
+            matches!(
+                result,
+                Err(FilesError::ResourceLimitExceeded {
+                    resource: FilesResourceKind::ExportTotalSize,
+                    ..
+                })
+            ),
+            "expected ResourceLimitExceeded{{resource: ExportTotalSize}}, got: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/mcp-files/src/lib.rs
+++ b/crates/mcp-files/src/lib.rs
@@ -86,4 +86,4 @@ pub mod types;
 // Re-export main types
 pub use builder::FilesBuilder;
 pub use filesystem::{ExportOptions, FileSystem};
-pub use types::{FileEntry, FilePath, FilesError, Result};
+pub use types::{FileEntry, FilePath, FilesError, FilesResourceKind, Result};

--- a/crates/mcp-files/src/types.rs
+++ b/crates/mcp-files/src/types.rs
@@ -19,6 +19,50 @@ use std::fmt;
 use std::path::Path;
 use thiserror::Error;
 
+/// Identifies which bounded resource a [`FilesError::ResourceLimitExceeded`] rejection concerns.
+///
+/// Closes the free-form `resource: String` field this replaced (issue #343) into a fixed set of
+/// variants, so a call site can no longer report a resource category via an arbitrary,
+/// typo-prone string. This mirrors `mcp-core`'s
+/// [`ResourceKind`](https://docs.rs/mcp-execution-core/latest/mcp_execution_core/enum.ResourceKind.html)
+/// closed-enum pattern (issue #317) but is kept local to this crate rather than added as variants
+/// there: `mcp-core`'s enum already has semantically adjacent variants (`GeneratedOutputSize`/
+/// `GeneratedFileCount`, the closest neighbors to `ExportTotalSize`/`ExportFileCount`), but this
+/// crate has no direct dependency on `mcp-execution-core` — only a transitive one via
+/// `mcp-execution-codegen` — so sharing that enum would mean adding a new direct dependency on
+/// `mcp-core` for a single error variant. A local enum avoids that coupling.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_files::FilesResourceKind;
+///
+/// assert_eq!(
+///     FilesResourceKind::ExportFileCount.to_string(),
+///     "export file count"
+/// );
+/// assert_eq!(
+///     FilesResourceKind::ExportTotalSize.to_string(),
+///     "export total size"
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilesResourceKind {
+    /// Number of files a single export batch would write.
+    ExportFileCount,
+    /// Combined byte size of every file's content in a single export batch.
+    ExportTotalSize,
+}
+
+impl fmt::Display for FilesResourceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExportFileCount => f.write_str("export file count"),
+            Self::ExportTotalSize => f.write_str("export total size"),
+        }
+    }
+}
+
 /// Errors that can occur during VFS operations.
 ///
 /// All error variants include contextual information for diagnostics.
@@ -84,8 +128,8 @@ pub enum FilesError {
     /// limit (denial-of-service protection, CWE-400).
     #[error("export exceeds resource limit for {resource}: {actual} exceeds limit of {limit}")]
     ResourceLimitExceeded {
-        /// Human-readable name of the bounded resource (e.g. "export file count").
-        resource: String,
+        /// Which bounded resource was exceeded.
+        resource: FilesResourceKind,
         /// The actual observed size/count that triggered the rejection.
         actual: usize,
         /// The configured maximum allowed for this resource.
@@ -112,10 +156,10 @@ impl FilesError {
     /// # Examples
     ///
     /// ```
-    /// use mcp_execution_files::FilesError;
+    /// use mcp_execution_files::{FilesError, FilesResourceKind};
     ///
     /// let error = FilesError::ResourceLimitExceeded {
-    ///     resource: "export file count".to_string(),
+    ///     resource: FilesResourceKind::ExportFileCount,
     ///     actual: 3000,
     ///     limit: 2000,
     /// };
@@ -419,6 +463,32 @@ pub type Result<T> = std::result::Result<T, FilesError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_resource_limit_exceeded_display_export_file_count() {
+        let err = FilesError::ResourceLimitExceeded {
+            resource: FilesResourceKind::ExportFileCount,
+            actual: 3000,
+            limit: 2000,
+        };
+        assert_eq!(
+            err.to_string(),
+            "export exceeds resource limit for export file count: 3000 exceeds limit of 2000"
+        );
+    }
+
+    #[test]
+    fn test_resource_limit_exceeded_display_export_total_size() {
+        let err = FilesError::ResourceLimitExceeded {
+            resource: FilesResourceKind::ExportTotalSize,
+            actual: 5_000_000,
+            limit: 4_000_000,
+        };
+        assert_eq!(
+            err.to_string(),
+            "export exceeds resource limit for export total size: 5000000 exceeds limit of 4000000"
+        );
+    }
 
     #[test]
     fn test_vfs_path_new_valid() {

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -196,17 +196,27 @@ impl From<mcp_execution_core::metadata::ParameterMetadata> for ParsedParameter {
     }
 }
 
-impl From<mcp_execution_core::metadata::ToolMetadata> for ParsedToolFile {
-    fn from(meta: mcp_execution_core::metadata::ToolMetadata) -> Self {
-        Self {
-            name: meta.name.into_inner(),
-            typescript_name: meta.typescript_name,
-            server_id: String::new(),
-            category: meta.category,
-            keywords: meta.keywords,
-            description: meta.description,
-            parameters: meta.parameters.into_iter().map(Into::into).collect(),
-        }
+/// Builds a [`ParsedToolFile`] from a sidecar tool entry and the server ID it belongs to.
+///
+/// A plain function rather than a `From<ToolMetadata>` impl: `ToolMetadata` carries no
+/// `server_id` of its own (it lives once on the enclosing [`ServerMetadata`]), so a `From` impl
+/// could only ever produce a `ParsedToolFile` with a placeholder `server_id` that every caller
+/// then had to patch in after construction — a representable-but-wrong intermediate state.
+/// Taking `server_id` as a parameter removes that sentinel from this construction path;
+/// `ParsedToolFile`'s fields remain public, so callers that build one directly (e.g. test
+/// fixtures) are unaffected and can still set an arbitrary `server_id` themselves.
+fn parsed_tool_file_from_metadata(
+    meta: mcp_execution_core::metadata::ToolMetadata,
+    server_id: &str,
+) -> ParsedToolFile {
+    ParsedToolFile {
+        name: meta.name.into_inner(),
+        typescript_name: meta.typescript_name,
+        server_id: server_id.to_string(),
+        category: meta.category,
+        keywords: meta.keywords,
+        description: meta.description,
+        parameters: meta.parameters.into_iter().map(Into::into).collect(),
     }
 }
 
@@ -319,11 +329,7 @@ pub async fn scan_tools_directory(dir: &Path) -> Result<ScanResult, ScanError> {
     let mut tools: Vec<ParsedToolFile> = meta
         .tools
         .into_iter()
-        .map(|tool| {
-            let mut parsed: ParsedToolFile = tool.into();
-            parsed.server_id.clone_from(&server_id);
-            parsed
-        })
+        .map(|tool| parsed_tool_file_from_metadata(tool, &server_id))
         .collect();
 
     // Sort by name for consistent ordering

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -112,8 +112,11 @@ pub enum ResourceKind {
 free-form `resource: String` (issue #317): each variant's `Display` reproduces the same
 human-readable wording call sites used to build by hand (e.g. `ToolCount` renders `"tool count
 for server '{id}'"`), so `Error::ResourceLimitExceeded`'s own message is unchanged in substance.
-Covers `mcp-core` only — `mcp-files::FilesError::ResourceLimitExceeded` still uses a free-form
-`resource: String` (tracked separately as issue #343).
+Covers `mcp-core` only. `mcp-files::FilesError::ResourceLimitExceeded` closed its own free-form
+`resource: String` separately (issue #343) with a local `FilesResourceKind` enum rather than
+adding variants here: `mcp-files` has no direct dependency on `mcp-core` (only a transitive one
+via `mcp-execution-codegen`), so sharing this enum would mean adding a new direct dependency on
+`mcp-core` for a single error variant — see [[../files/spec#7. Error Conditions]].
 Each variant has an `is_*` predicate (`is_connection_error`,
 `is_security_error`, `is_timeout`, `is_validation_error`,
 `is_script_generation_error`, `is_resource_limit_exceeded`). No predicate

--- a/specs/files/spec.md
+++ b/specs/files/spec.md
@@ -38,7 +38,7 @@ such that:
 // crate root
 pub use builder::FilesBuilder;
 pub use filesystem::{ExportOptions, FileSystem};
-pub use types::{FileEntry, FilePath, FilesError, Result};
+pub use types::{FileEntry, FilePath, FilesError, FilesResourceKind, Result};
 
 pub struct FilePath(String); // validated: absolute ('/'-prefixed), no "..", no empty/"." components, Unix-style on all platforms
 impl FilePath {
@@ -211,9 +211,26 @@ pub enum FilesError {
     PathNotAbsolute { path },
     InvalidPathComponent { path },
     IoError { path, source: std::io::Error },
-    ResourceLimitExceeded { resource, actual, limit }, // is_resource_limit_exceeded()
+    ResourceLimitExceeded { resource: FilesResourceKind, actual, limit }, // is_resource_limit_exceeded()
+    PathEscapesBase { path, base },
+}
+
+pub enum FilesResourceKind {
+    ExportFileCount,
+    ExportTotalSize,
 }
 ```
+`FilesResourceKind` (`types::FilesResourceKind`, re-exported at crate root) closes what was a
+free-form `resource: String` (issue #343), mirroring `mcp-core::ResourceKind`'s closed-enum
+pattern (issue #317, [[../core/spec#`Error` / `Result<T>` (`src/error.rs`)]]) without adding
+variants to that enum: `mcp-core`'s `ResourceKind` already has semantically adjacent variants
+(`GeneratedOutputSize`/`GeneratedFileCount`, the closest neighbors to
+`ExportTotalSize`/`ExportFileCount`), but this crate has no direct dependency on
+`mcp-execution-core` (only a transitive one via `mcp-execution-codegen`), so sharing that enum
+would mean adding a new direct dependency on `mcp-core` for a single error variant — a local enum
+avoids that coupling. Each variant's `Display` reproduces the same wording `check_export_bounds`
+used to build by hand (`"export file count"` / `"export total size"`), so
+`FilesError::ResourceLimitExceeded`'s message is unchanged in substance.
 
 ## 8. Cross-Crate Contracts
 


### PR DESCRIPTION
## Summary
- Close `mcp-files::FilesError::ResourceLimitExceeded`'s free-form `resource: String` into a
  closed `FilesResourceKind` enum (`ExportFileCount`, `ExportTotalSize`), kept local to
  `mcp-files` since the crate has no direct dependency on `mcp-execution-core` (#343).
- Replace `parser::ParsedToolFile`'s `impl From<ToolMetadata>` (placeholder empty `server_id`
  patched in by the caller) with a private `parsed_tool_file_from_metadata(meta, server_id)`
  function that takes `server_id` directly (#342).

## Breaking Changes
- `FilesError::ResourceLimitExceeded.resource`: `String` -> `FilesResourceKind`.
- `impl From<ToolMetadata> for ParsedToolFile` removed; `ParsedToolFile` itself unaffected.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1092/1092)
- [x] `cargo test --doc --all-features --workspace`
- [x] rustdoc gate (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`)

Closes #342, closes #343.