### PR TITLE
fix(core,cli): close secret-redaction gaps in Transport Debug and server output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`mcp-execution-core`**: `Transport` now has its own hand-written `Debug` impl, redacting
+  `args`/`env`/`headers`/`url` the same way as `ServerConfig`'s existing impl, instead of
+  deriving a plain `Debug` that echoed every secret verbatim. This closes the gap noted below
+  (#336, #345): `Transport` was the only secret-bearing type in the workspace without its own
+  redacting `Debug` impl, so formatting a bare `&Transport` (e.g. from `ServerConfig::transport()`)
+  still leaked header/env values, args, and URL userinfo/query even after `introspect --verbose`
+  was fixed to format `ServerConfig` instead.
+- **`mcp-execution-cli`**: `server list`/`server info`/`server validate` no longer print a stdio
+  entry's raw `args` or an http/sse entry's raw `url` verbatim in their unconditional (non-verbose)
+  output. `build_command_string` now redacts both: an argument is replaced wholesale with the
+  `REDACTED_PLACEHOLDER` constant, rendered as a space-joined shell-shaped string rather than
+  `RedactedItems`'s `Debug`-list syntax (which would otherwise land as literal `Debug` output
+  inside `--format json`'s `command` field); a URL has its userinfo/query stripped via
+  `RedactedUrl` while keeping scheme/host/path readable. `command` itself is routed through
+  `sanitize_path_for_error`, the same home-directory/username scrub `ServerConfig`/`McpTransport`/
+  `Transport` already apply to it — not a secret, but an absolute path leaks the OS username.
+  `validate_command`'s "URL is not well-formed" precheck message (reached before
+  `build_command_string` even runs) is also redacted via the same `RedactedUrl` helper, closing a
+  gap where a malformed-but-still-credentialed URL leaked through that message even though the
+  `command` field next to it was already redacted (#346).
 - **`mcp-execution-cli`**: `introspect --verbose` no longer logs the raw HTTP/SSE header values or
   stdio environment variable values from the resolved `ServerConfig` at INFO level. The log line
   previously formatted `config.transport()` (`&Transport`, plain derived `Debug`) directly; it now
   formats `config` (`ServerConfig`), whose existing hand-written `Debug` impl already redacts
-  header/env values, args, and URL userinfo/query. `mcp_execution_core::Transport` itself still
-  derives a plain `Debug` and remains unredacted if formatted directly elsewhere — tracked
-  separately (#336, #345).
+  header/env values, args, and URL userinfo/query (#336).
 - **`deny.toml`**: `[advisories]` now sets `unsound = "all"`, closing the gap where cargo-deny's
   default (`"workspace"`) silently drops RUSTSEC "unsound" advisories against transitive
   dependencies such as `unsafe-libyaml-norway` (reached via `mcp-skill -> serde_norway ->

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -12,8 +12,10 @@ use anyhow::{Context, Result};
 use mcp_execution_core::ServerConfig;
 use mcp_execution_core::ServerId;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
+use mcp_execution_core::{REDACTED_PLACEHOLDER, RedactedUrl, sanitize_path_for_error};
 use mcp_execution_introspector::Introspector;
 use serde::Serialize;
+use std::path::Path;
 use std::time::Duration;
 use tracing::{info, warn};
 use url::Url;
@@ -459,10 +461,9 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
             ..
         } => (!check_command_exists(bin_command))
             .then(|| format!("Command '{bin_command}' not found in PATH")),
-        McpTransport::Http { url, .. } | McpTransport::Sse { url, .. } => (!url_well_formed(url))
-            .then(|| {
-                format!("URL '{url}' is not well-formed (expected http:// or https:// with a host)")
-            }),
+        McpTransport::Http { url, .. } | McpTransport::Sse { url, .. } => {
+            (!url_well_formed(url)).then(|| url_precheck_message(url))
+        }
     };
 
     if let Some(message) = precheck_failure {
@@ -541,18 +542,54 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
 /// Builds a displayable command string from a server entry.
 ///
 /// Stdio entries render as `command args…`; http/sse entries render as the
-/// endpoint URL.
+/// endpoint URL. This feeds `server list`/`server info`/`server validate`
+/// output, which is printed unconditionally (not gated behind `--verbose`),
+/// so every field is redacted the same way `ServerConfig`'s own `Debug` impl
+/// redacts them (#346): `command` is routed through
+/// [`sanitize_path_for_error`] (home directory/username scrub — not a
+/// secret, but an absolute path leaks the OS username); `args` are replaced
+/// wholesale with [`REDACTED_PLACEHOLDER`] since an argument routinely holds
+/// an entire secret (e.g. `--api-key sk-...`) with no key/value half worth
+/// preserving; `url` is redacted via [`RedactedUrl`], which strips userinfo
+/// credentials and any query string while keeping scheme/host/path
+/// readable. Unlike `ServerConfig`'s `Debug` impl, `args` render as a
+/// space-joined, shell-shaped string (`REDACTED_PLACEHOLDER` per entry)
+/// rather than [`mcp_execution_core::RedactedItems`]'s `Debug`-list syntax
+/// (`["<redacted>", ...]`) — this string lands verbatim in `--format json`
+/// output, where embedding Rust `Debug` syntax inside a JSON string would be
+/// needlessly awkward for machine consumers.
 fn build_command_string(entry: &McpServerEntry) -> String {
     match &entry.transport {
         McpTransport::Stdio { command, args, .. } => {
+            let command = sanitize_path_for_error(Path::new(command));
             if args.is_empty() {
-                command.clone()
+                command
             } else {
-                format!("{} {}", command, args.join(" "))
+                let redacted_args = vec![REDACTED_PLACEHOLDER; args.len()].join(" ");
+                format!("{command} {redacted_args}")
             }
         }
-        McpTransport::Http { url, .. } | McpTransport::Sse { url, .. } => url.clone(),
+        McpTransport::Http { url, .. } | McpTransport::Sse { url, .. } => {
+            format!("{:?}", RedactedUrl(url))
+        }
     }
+}
+
+/// Builds the "URL is not well-formed" precheck failure message used by
+/// [`validate_command`], redacting `url` via [`RedactedUrl`] so a malformed URL that still
+/// carries userinfo credentials (e.g. a mistyped port on an otherwise valid
+/// `https://user:pass@host` URL) never leaks them into `server validate`'s unconditional
+/// `ValidationResult::message` output (#346 S1: this precheck message was the one call site the
+/// original fix missed — it sits above `build_command_string`, not inside it).
+///
+/// Extracted into its own function so the redaction can be unit-tested directly, since this
+/// crate has no harness to capture the `println!`-only command output (see the `#[cfg(test)]`
+/// module's other notes on that limitation).
+fn url_precheck_message(url: &str) -> String {
+    format!(
+        "URL '{:?}' is not well-formed (expected http:// or https:// with a host)",
+        RedactedUrl(url)
+    )
 }
 
 /// Returns `true` if the given command binary is available in PATH.
@@ -663,6 +700,10 @@ mod tests {
         assert_eq!(build_command_string(&entry), "node");
     }
 
+    /// #346 — args are redacted wholesale (mirroring `ServerConfig`'s `Debug` impl), since an
+    /// argument can itself be an entire secret with no key/value split to preserve half of.
+    /// Asserts the exact rendering (not just secret absence, per critic M3: a `retain`-style
+    /// bug that silently dropped args instead of redacting them would otherwise still pass).
     #[test]
     fn test_build_command_string_with_args() {
         let entry = McpServerEntry {
@@ -675,9 +716,62 @@ mod tests {
             connect_timeout_secs: None,
             discover_timeout_secs: None,
         };
+        let command = build_command_string(&entry);
         assert_eq!(
-            build_command_string(&entry),
-            "node /path/to/server.js --verbose"
+            command,
+            format!("node {REDACTED_PLACEHOLDER} {REDACTED_PLACEHOLDER}")
+        );
+        assert!(!command.contains("/path/to/server.js"));
+        assert!(!command.contains("--verbose"));
+    }
+
+    /// #346 regression: a stdio arg carrying an entire secret (e.g. `--api-key sk-...`) must
+    /// never appear in `server list`/`server info`/`server validate` output, which is printed
+    /// unconditionally. Counts placeholders (critic M3) rather than only asserting the secret's
+    /// absence, so silently dropping args instead of redacting them would fail this test too.
+    #[test]
+    fn test_build_command_string_redacts_secret_arg() {
+        let secret = "sk-live-secret-arg-value";
+        let entry = McpServerEntry {
+            transport: McpTransport::Stdio {
+                command: "docker".to_string(),
+                args: vec!["--api-key".to_string(), secret.to_string()],
+                env: HashMap::default(),
+                cwd: None,
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+        let command = build_command_string(&entry);
+        assert!(command.starts_with("docker "));
+        assert!(!command.contains(secret));
+        assert_eq!(command.matches(REDACTED_PLACEHOLDER).count(), 2);
+    }
+
+    /// #346 M2: `command` routes through the same [`sanitize_path_for_error`] scrub
+    /// `ServerConfig`/`McpTransport`/`Transport` all apply, so an absolute stdio command path
+    /// under the home directory doesn't leak the OS username into unconditional output.
+    #[test]
+    fn test_build_command_string_sanitizes_command_home_path() {
+        let home = dirs::home_dir().expect("home dir available in this environment");
+        let entry = McpServerEntry {
+            transport: McpTransport::Stdio {
+                command: home.join("bin/mcp-server").to_string_lossy().into_owned(),
+                args: Vec::new(),
+                env: HashMap::default(),
+                cwd: None,
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+        let command = build_command_string(&entry);
+        assert_eq!(
+            command,
+            format!(
+                "~{}bin{}mcp-server",
+                std::path::MAIN_SEPARATOR,
+                std::path::MAIN_SEPARATOR
+            )
         );
     }
 
@@ -692,6 +786,55 @@ mod tests {
             discover_timeout_secs: None,
         };
         assert_eq!(build_command_string(&entry), "https://api.example.com/mcp");
+    }
+
+    /// #346 regression: userinfo credentials and a `?token=`-style query string in a
+    /// http/sse `url` must never appear in `server list`/`server info`/`server validate`
+    /// output; host/path stay readable.
+    #[test]
+    fn test_build_command_string_redacts_secret_url() {
+        let secret = "hunter2";
+        let entry = McpServerEntry {
+            transport: McpTransport::Http {
+                url: format!("https://user:{secret}@api.example.com/mcp?token={secret}"),
+                headers: HashMap::default(),
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+        let command = build_command_string(&entry);
+        assert!(!command.contains(secret));
+        assert!(command.contains("api.example.com/mcp"));
+    }
+
+    /// #346 M3: a `url` that [`RedactedUrl`] cannot parse (e.g. malformed scheme) falls back to
+    /// redacting the whole string, so `server list`'s Command column shows only the placeholder
+    /// with no host at all — documented here so that fallback isn't silently un-exercised.
+    #[test]
+    fn test_build_command_string_unparseable_url_redacts_entirely() {
+        let entry = McpServerEntry {
+            transport: McpTransport::Http {
+                url: "not-a-url".to_string(),
+                headers: HashMap::default(),
+            },
+            connect_timeout_secs: None,
+            discover_timeout_secs: None,
+        };
+        assert_eq!(build_command_string(&entry), REDACTED_PLACEHOLDER);
+    }
+
+    /// #346 S1 regression: `validate_command`'s precheck failure message used to interpolate
+    /// the raw `url`, so a malformed URL that still carried userinfo credentials (e.g. a
+    /// mistyped port) leaked them into `ValidationResult::message`, which is printed
+    /// unconditionally — even though `build_command_string`'s `command` field was already
+    /// redacted, producing the redacted and unredacted forms of the same secret side by side.
+    #[test]
+    fn test_url_precheck_message_redacts_credentials() {
+        let secret = "hunter2";
+        let message =
+            url_precheck_message(&format!("https://alice:{secret}@api.example.com:99999/mcp"));
+        assert!(!message.contains(secret));
+        assert!(message.contains("api.example.com"));
     }
 
     #[tokio::test]

--- a/crates/mcp-core/src/server_config.rs
+++ b/crates/mcp-core/src/server_config.rs
@@ -98,7 +98,7 @@ static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new
 ///
 /// assert!(matches!(config.transport(), Transport::Stdio { .. }));
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "transport", rename_all = "lowercase")]
 pub enum Transport {
     /// Stdio transport: subprocess communication via stdin/stdout.
@@ -168,6 +168,56 @@ pub enum Transport {
         #[serde(default)]
         headers: HashMap<String, String>,
     },
+}
+
+impl fmt::Debug for Transport {
+    /// Redacts the same fields, the same way, as [`ServerConfig`]'s own hand-written impl —
+    /// see the "Security" section on that type's doc comment for the full rationale. Kept as a
+    /// standalone impl (rather than `ServerConfig` delegating to it) so each type's `Debug`
+    /// output stays exactly what it was already documented and tested to be.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::Transport;
+    /// use std::collections::HashMap;
+    ///
+    /// let transport = Transport::Http {
+    ///     url: "https://user:sk-secret@api.example.com/mcp?token=sk-secret".to_string(),
+    ///     headers: HashMap::from([("Authorization".to_string(), "Bearer sk-secret".to_string())]),
+    /// };
+    ///
+    /// let debug_output = format!("{transport:?}");
+    /// assert!(debug_output.contains("Authorization"));
+    /// assert!(debug_output.contains("api.example.com/mcp"));
+    /// assert!(!debug_output.contains("sk-secret"));
+    /// ```
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stdio {
+                command,
+                args,
+                env,
+                cwd,
+            } => f
+                .debug_struct("Stdio")
+                .field("command", &sanitize_path_for_error(Path::new(command)))
+                .field("args", &RedactedItems(args))
+                .field("env", &RedactedMapValues(env))
+                .field("cwd", &cwd.as_deref().map(sanitize_path_for_error))
+                .finish(),
+            Self::Http { url, headers } => f
+                .debug_struct("Http")
+                .field("url", &RedactedUrl(url))
+                .field("headers", &RedactedMapValues(headers))
+                .finish(),
+            Self::Sse { url, headers } => f
+                .debug_struct("Sse")
+                .field("url", &RedactedUrl(url))
+                .field("headers", &RedactedMapValues(headers))
+                .finish(),
+        }
+    }
 }
 
 /// MCP server configuration with command, arguments, and environment.
@@ -1700,5 +1750,59 @@ mod tests {
             r#"{"transport":"stdio","command":"docker","args":["run; rm -rf /"]}"#,
         );
         assert!(result.is_err());
+    }
+
+    /// #345 — `Transport` used to derive plain `Debug`, so `format!("{:?}", transport)` on a
+    /// bare value (e.g. matched out of `ServerConfig::transport()`) leaked secrets even though
+    /// `ServerConfig`'s own `Debug` impl already redacted the same fields.
+    #[test]
+    fn test_transport_debug_redacts_stdio_args_and_env() {
+        let secret_arg = "sk-live-secret-arg-value";
+        let secret_env = "ghp_supersecretvalue";
+        let transport = Transport::Stdio {
+            command: "docker".to_string(),
+            args: vec!["--api-key".to_string(), secret_arg.to_string()],
+            env: HashMap::from([(
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                secret_env.to_string(),
+            )]),
+            cwd: None,
+        };
+
+        let debug_str = format!("{transport:?}");
+        assert!(debug_str.contains("docker"));
+        assert!(debug_str.contains("GITHUB_PERSONAL_ACCESS_TOKEN"));
+        assert!(!debug_str.contains(secret_arg));
+        assert!(!debug_str.contains(secret_env));
+    }
+
+    #[test]
+    fn test_transport_debug_redacts_http_url_and_headers() {
+        let secret = "hunter2";
+        let transport = Transport::Http {
+            url: format!("https://user:{secret}@api.example.com/mcp?token={secret}"),
+            headers: HashMap::from([("Authorization".to_string(), secret.to_string())]),
+        };
+
+        let debug_str = format!("{transport:?}");
+        assert!(debug_str.contains("api.example.com/mcp"));
+        assert!(debug_str.contains("Authorization"));
+        assert!(!debug_str.contains(secret));
+    }
+
+    /// Companion to the `Http` case above — `Transport::Sse` shares the same `url`/`headers`
+    /// shape but is a distinct match arm in the `Debug` impl, so it needs its own coverage.
+    #[test]
+    fn test_transport_debug_redacts_sse_url_and_headers() {
+        let secret = "sk-secret-sse-header-value";
+        let transport = Transport::Sse {
+            url: "https://api.example.com/sse".to_string(),
+            headers: HashMap::from([("Authorization".to_string(), secret.to_string())]),
+        };
+
+        let debug_str = format!("{transport:?}");
+        assert!(debug_str.contains("api.example.com/sse"));
+        assert!(debug_str.contains("Authorization"));
+        assert!(!debug_str.contains(secret));
     }
 }


### PR DESCRIPTION
## Summary

- `Transport` (mcp-core) gains its own hand-written redacting `Debug` impl, closing the gap where it was the only secret-bearing type in the workspace without one — a bare `&Transport` could previously bypass `ServerConfig`'s redaction entirely.
- `server list`/`server info`/`server validate` (mcp-cli) no longer print raw stdio args or http/sse URLs in their unconditional (non-`--verbose`) output. `build_command_string` redacts args wholesale and URLs via `RedactedUrl`, and sanitizes the command path for home-directory/username leakage. The `validate_command` "URL is not well-formed" precheck message is redacted the same way, closing a gap where a malformed-but-credentialed URL still leaked through.

Closes #345, closes #346.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1098 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Rebased onto latest `origin/master`, verified `cargo check --workspace --all-features` after rebase
- [x] Adversarially reviewed: implementation critique found and fixed a blocking gap (raw credentialed URL still leaking through `validate_command`'s precheck message); independent code review approved after the fix