### PR TITLE
test: pin RawFrontmatter alias-bomb short-circuit, generalize untrusted-echo guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `fixture-paginated-stdio-server` binary that never signals pagination completion, mirroring the
   existing HTTP-only `PaginatedFixtureHandler` test to prove `list_tools_bounded`'s
   `MAX_TOOL_COUNT` early-bailout also fires over the stdio transport (#332).
+- **`mcp-execution-skill`**: added a regression test pinning `RawFrontmatter`'s alias-bomb
+  short-circuit (ADR-341 §3.3/§5, follow-up to #349). The bomb sits under a YAML key
+  `RawFrontmatter` does not declare, so the test's primary gate is a deterministic outcome flip
+  rather than a wall-clock budget: today parsing succeeds fast because the unknown key is
+  discarded without expanding nested aliases; if a future `#[serde(flatten)]`-style buffering
+  field reopened the amplification path, the same fixture would flip to `Err` on
+  `serde_norway`'s own repetition-limit guard. A wall-clock assertion is kept only as a
+  1-second hang guard, not as the detection mechanism (#350).
 
 ### Added
 
@@ -339,6 +347,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against an agent/LLM-supplied argument — different trust boundaries, so identical confinement
   isn't actually appropriate here. No functional change; a doc comment now records this rationale
   on `validate_output_path` (#318).
+- **`specs/constitution.md`**: generalized the untrusted-source-echo guard in section V beyond
+  the YAML-parser-specific footnote it was scoped to in ADR-341 §3.5/§8. States as a general
+  principle that error text derived from parsing untrusted input must not echo verbatim source
+  excerpts into any LLM/client-facing error surface, independent of which specific parser or
+  dependency is in use, so a future parser swap or new parsing path is checked against this rule
+  up front rather than discovered ad hoc. Cross-references ADR-341 as the originating finding
+  (#351).
 
 ### Breaking
 

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -1179,4 +1179,73 @@ description: 'quoted text'
         assert_eq!(metadata.name, "quoted-name");
         assert_eq!(metadata.description, "quoted text");
     }
+
+    #[test]
+    fn test_extract_skill_metadata_alias_bomb_under_unknown_key_stays_ok() {
+        // ADR-341 §3.3/§5, corrected per review: `RawFrontmatter` has no
+        // `#[serde(deny_unknown_fields)]`, so a key it does not declare is discarded via a
+        // lazy visitor that never expands nested aliases — the bomb below sits under such a
+        // key (`unknown_key`), with `name`/`description` left valid, so parsing succeeds
+        // fast today. A `#[serde(flatten)]`-style buffering field would force every unknown
+        // key to be materialized into a `Content`-like structure before per-field routing,
+        // which *does* expand aliases and trips serde_norway's own repetition-limit guard —
+        // flipping this exact fixture's outcome from `Ok` to `Err`. That deterministic
+        // outcome flip, not wall-clock timing, is the primary thing this test pins: a single
+        // cold-process call's timing noise (measured up to ~1.6ms) is not a safe
+        // discriminator against the ADR's ~4-7ms regression floor. An earlier version of
+        // this test put the bomb on the *declared* `description` field instead, where
+        // serde's derive reads it directly regardless of `flatten` — that fixture could
+        // never detect the regression it claimed to guard, at any budget.
+        //
+        // Fixture shape: 8 anchors (`a0..a7`), each referencing the previous 8 times — 8^8 ≈
+        // 16.7M leaves if ever fully expanded. At a few hundred bytes this sits well under
+        // `MAX_FRONTMATTER_SIZE` (8 KiB); shrinking the branching factor, the anchor count,
+        // or the frontmatter cap changes that margin and must be re-checked against the size
+        // assertion below.
+        //
+        // Deliberately out of scope: retyping `description` itself to a buffering type
+        // (`serde_norway::Value`, an untagged enum, a buffering `deserialize_with`) is a
+        // distinct regression vector this fixture does not cover — tracked separately.
+        use std::fmt::Write as _;
+        use std::time::{Duration, Instant};
+
+        let mut frontmatter =
+            String::from("name: test-skill\ndescription: valid description\nunknown_key:\n");
+        writeln!(frontmatter, "  - &a0 [x, x, x, x, x, x, x, x]").unwrap();
+        for level in 1..=7 {
+            let prev = level - 1;
+            let refs = (0..8)
+                .map(|_| format!("*a{prev}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(frontmatter, "  - &a{level} [{refs}]").unwrap();
+        }
+        writeln!(frontmatter, "  - *a7").unwrap();
+
+        let content = format!("---\n{frontmatter}---\n# Test\n");
+        assert!(
+            content.len() <= MAX_FRONTMATTER_SIZE,
+            "fixture must stay under the frontmatter cap to exercise the parser, not the size guard"
+        );
+
+        let start = Instant::now();
+        let result = extract_skill_metadata(&content);
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_ok(),
+            "expected Ok: an alias bomb under a key RawFrontmatter does not declare must be \
+             ignored today without expansion; if this now errors, RawFrontmatter's field shape \
+             likely changed (e.g. a #[serde(flatten)] field) and reopened the amplification path \
+             serde_norway's own repetition-limit guard then catches at ms-scale cost instead of \
+             being ignored at us-scale cost. got: {result:?}"
+        );
+        // Sanity bound only, not the detection mechanism (see comment above): guards against an
+        // outright hang rather than the ms-scale regression, which the Ok/Err flip already
+        // catches deterministically regardless of timing noise.
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "parse took {elapsed:?}, unexpectedly long even accounting for cold-process noise"
+        );
+    }
 }

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -127,6 +127,15 @@ and issue-number references dedicated to it.
   reaches an LLM-facing prompt, wrapped in an explicit
   `<untrusted-data>...</untrusted-data>` boundary that cannot be forged from
   within.
+- **No untrusted source echo in error text**: error messages derived from
+  parsing or processing untrusted input (YAML, JSON, protocol-specific
+  formats) that reach an LLM or client must not verbatim reproduce source
+  excerpts — only the location of the error and the kind of failure are safe
+  to surface. This applies to every parsing dependency and entry point,
+  independent of which specific parser or format is in use — any future
+  parser swap or new parsing path must validate its error rendering against
+  this principle up front. See ADR-341 (section 3.5) for the concrete case
+  that motivated this rule.
 - **Debug-redaction of secrets**: any type carrying environment variables,
   HTTP headers, CLI args, or URLs implements `Debug` by hand (never
   `#[derive(Debug)]`) to redact values while keeping keys — because these

--- a/specs/decisions/ADR-341-serde-saphyr-vs-serde-norway.md
+++ b/specs/decisions/ADR-341-serde-saphyr-vs-serde-norway.md
@@ -169,9 +169,10 @@ before expanding. Measured effect of changing that shape:
   to today. (An earlier pass of this evaluation claimed this would break
   the short-circuit; that claim was measured and found wrong.)
 - Adding a `#[serde(flatten)]`-style buffering field is what actually
-  breaks it: `serde_norway` then degrades to **4.2 / 5.1 / 6.0 / 7.0 ms**
-  at alias-nesting levels 8/10/12/14 — **scaling with input**, unlike its
-  current flat ~20-28 us.
+  breaks it (note: only when the alias bomb uses undeclared/unknown YAML
+  keys — `flatten` buffers these, not declared fields): `serde_norway`
+  then degrades to **4.2 / 5.1 / 6.0 / 7.0 ms** at alias-nesting levels
+  8/10/12/14 — **scaling with input**, unlike its current flat ~20-28 us.
 - `serde-saphyr` under the redesigned `Budget` (§6) stays **flat at
   1.78 ms** on the identical flattened shape.
 
@@ -396,7 +397,8 @@ issue's stated scope:
    for *any* future parser error text reaching an LLM, rather than
    documented as specific to this evaluation. Both review passes agreed
    this generalization is warranted; it was not applied here since no
-   parser swap is being made yet.
+   parser swap is being made yet. (Implemented as a constitution principle,
+   issue #351.)
 3. `granit-parser`'s inherited exposure (if any) to upstream `saphyr`
    issue #109 (a billion-laughs report open since 2026-03-28, fix PR
    #120 unmerged upstream) was not verified. `serde-saphyr`'s `Budget`


### PR DESCRIPTION
## Summary
- Adds a regression test in `mcp-execution-skill` (`crates/mcp-skill/src/parser.rs`) pinning `RawFrontmatter`'s alias-bomb short-circuit per ADR-341 §3.3/§5. The bomb sits under an undeclared YAML key, and the primary assertion is a deterministic `Ok`/`Err` outcome flip rather than a wall-clock budget, so it stays reliable across debug/release profiles: today it parses `Ok` fast; a future `#[serde(flatten)]`-style buffering field reopening the amplification path would flip it to `Err` on `serde_norway`'s own repetition-limit guard.
- Generalizes the untrusted-source-echo guard in `specs/constitution.md` section V beyond the YAML-parser-specific footnote it was scoped to in ADR-341 §3.5/§8: error text derived from parsing untrusted input must not echo verbatim source excerpts into any LLM/client-facing surface, independent of parser or dependency.
- Adds a one-line precondition clarification to ADR-341 §3.3 (a flatten field only reopens the amplification path for bombs under undeclared keys, not declared fields) and updates §8 item 2 to record #351 as resolved.

## Notes
- A related but distinct regression vector found during review (retyping a *declared* field like `description` to a buffering type) is intentionally out of scope here and will be filed as a separate follow-up issue.
- CHANGELOG.md `[Unreleased]` updated under Testing and Documentation.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1101/1101 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`

Closes #350
Closes #351