### PR TITLE
fix(cli,core): redact secret URLs from rmcp log lines and error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`mcp-execution-core`**: added `redact_urls_in_text`, which scans arbitrary already-assembled
+  text for `scheme://…` tokens and hands each one to `RedactedUrl` for the actual redaction, so
+  the masking decision itself can't drift between the two — though the heuristic used to find a
+  token's boundaries in free-form prose is necessarily looser than `RedactedUrl`'s own "fails
+  closed on a whole field" guarantee (see the doc comment for the documented residual gap). Closes
+  two secret-leak paths (#353) rooted in `reqwest`/`rmcp` transport errors
+  whose `Display` embeds the full request URL, query string included, in prose that never passes
+  through this project's field-level `Debug` redaction: `mcp-execution-cli`'s `runner::init_logging`
+  now wraps the tracing fmt layer's writer so every dependency's formatted log line (not just
+  `rmcp::transport::worker`'s `ERROR` line, which triggers on every http/sse command's connection
+  failure) is redacted before reaching stderr; and `formatters::escape_error_text`'s contract has
+  broadened from "neutralize control characters" to "make error text safe for stderr" — it now
+  redacts embedded URLs before truncating, closing a second leak where `CoreError::ConnectionFailed`'s
+  boxed `rmcp` source printed the same secret query string into `introspect`/`generate`'s visible
+  `Error:` report.
 - **`mcp-execution-core`**: `Transport` now has its own hand-written `Debug` impl, redacting
   `args`/`env`/`headers`/`url` the same way as `ServerConfig`'s existing impl, instead of
   deriving a plain `Debug` that echoed every secret verbatim. This closes the gap noted below

--- a/crates/mcp-cli/src/formatters.rs
+++ b/crates/mcp-cli/src/formatters.rs
@@ -89,17 +89,27 @@ pub fn escape_display(s: &str) -> String {
 /// [`escape_error_text`] at all — see `runner::sanitized_error_report`'s doc comment).
 const MAX_ERROR_TEXT_LEN: usize = 4000;
 
-/// Neutralizes control characters — including line breaks — and bounds the length of `s` to 4000
-/// `char`s before it reaches a terminal or log sink that does not itself escape untrusted content.
+/// Makes `s` safe to print to a terminal or log sink that does not itself escape untrusted content.
 ///
-/// Delegates to [`mcp_execution_core::untrusted::sanitize_untrusted_text`], the project's one
-/// implementation of this defense, rather than maintaining a second, weaker sanitizer in this
-/// crate: every character `char::is_control` reports (the full C0 and C1 ranges, covering `\r`,
-/// `\n`, ESC, BEL, and friends) plus the Markdown/ECMAScript line separators U+2028/U+2029 is
-/// replaced with a space, and the result is capped to 4000 `char`s (`MAX_ERROR_TEXT_LEN`, not
-/// itself public — its value is documented here since a reader of this function's public docs
-/// cannot otherwise resolve it). Used to sanitize command errors and log messages that may embed
-/// content from an untrusted MCP server before they reach the terminal.
+/// Neutralizes control characters (including line breaks), redacts any embedded URL's
+/// credentials/query string, and bounds the result to 4000 `char`s.
+///
+/// Redaction runs *before* truncation deliberately — truncating first could cut a redacted URL's
+/// marker off and leave a bare secret prefix as the last thing printed.
+///
+/// Delegates to two single-source-of-truth helpers rather than maintaining parallel logic here:
+/// [`mcp_execution_core::redact_urls_in_text`] finds and redacts every `scheme://…` token in `s`
+/// (a `reqwest`/`rmcp` transport error's `Display` routinely embeds the full request URL,
+/// including a `?token=…`-style query string, inline in prose — see `runner::sanitized_error_report`,
+/// whose whole reason for calling this function per-cause is to catch exactly that), and
+/// [`mcp_execution_core::untrusted::sanitize_untrusted_text`] then neutralizes every character
+/// `char::is_control` reports (the full C0 and C1 ranges, covering `\r`, `\n`, ESC, BEL, and
+/// friends) plus the Markdown/ECMAScript line separators U+2028/U+2029, replacing each with a
+/// space, and caps the result to 4000 `char`s (`MAX_ERROR_TEXT_LEN`, not itself public — its value
+/// is documented here since a reader of this function's public docs cannot otherwise resolve it).
+/// Used to sanitize command errors and log messages that may embed content from an untrusted MCP
+/// server, or a URL the user themselves supplied with a secret in its query string, before they
+/// reach the terminal.
 ///
 /// `s` is treated as a single unit of untrusted text with no internal structure worth preserving
 /// — including any newline it contains, which this collapses like every other control character.
@@ -138,9 +148,21 @@ const MAX_ERROR_TEXT_LEN: usize = 4000;
 /// assert!(!escaped.contains('\n'));
 /// assert!(escaped.contains("boom"));
 /// ```
+///
+/// A URL embedded in the text has its credentials/query string redacted too:
+///
+/// ```
+/// use mcp_execution_cli::formatters::escape_error_text;
+///
+/// let cause = "error sending request for url (https://api.example.com/mcp?token=hunter2secret)";
+/// let escaped = escape_error_text(cause);
+/// assert!(!escaped.contains("hunter2secret"));
+/// assert!(escaped.contains("https://api.example.com/mcp?<redacted>"));
+/// ```
 #[must_use]
 pub fn escape_error_text(s: &str) -> String {
-    mcp_execution_core::untrusted::sanitize_untrusted_text(s, MAX_ERROR_TEXT_LEN)
+    let redacted = mcp_execution_core::redact_urls_in_text(s);
+    mcp_execution_core::untrusted::sanitize_untrusted_text(&redacted, MAX_ERROR_TEXT_LEN)
 }
 
 /// JSON output formatting.
@@ -525,6 +547,42 @@ mod tests {
         let hostile = "before\rafter";
         let escaped = escape_error_text(hostile);
         assert!(!escaped.contains('\r'));
+    }
+
+    /// Leak B regression (see the security audit behind this fix): a
+    /// `reqwest`/`rmcp` transport error's `Display` text embeds the full
+    /// request URL, query string included, inline in prose. This must be
+    /// redacted, not merely control-char-escaped.
+    #[test]
+    fn test_escape_error_text_redacts_embedded_url_secret() {
+        let cause = "Client error: error sending request for url (http://127.0.0.1:1/mcp?token=REFUSEDSECRET), when send initialize request";
+        let escaped = escape_error_text(cause);
+        assert!(!escaped.contains("REFUSEDSECRET"));
+        assert!(escaped.contains("http://127.0.0.1:1/mcp?<redacted>"));
+        assert!(escaped.contains("when send initialize request"));
+    }
+
+    /// Redaction must run on the full text before the length cap is applied, so a secret
+    /// straddling the truncation boundary is still fully redacted rather than surviving as a
+    /// chopped-off prefix. `secret` is positioned so the `MAX_ERROR_TEXT_LEN`-char cut lands 5
+    /// characters into it: a truncate-first implementation would keep exactly `secret[..5]` (a
+    /// real prefix of the secret, not an unrelated substring) in its output.
+    #[test]
+    fn test_escape_error_text_redacts_secret_straddling_truncation_boundary() {
+        let secret = "verysecretvalue";
+        let url_prefix = "https://host.example.com/p?token=";
+        let chars_before_secret = MAX_ERROR_TEXT_LEN - 5;
+        let padding_len = chars_before_secret - 1 - url_prefix.chars().count();
+        let padding = "x".repeat(padding_len);
+        let cause = format!("{padding} {url_prefix}{secret}");
+        assert_eq!(
+            cause.chars().count(),
+            MAX_ERROR_TEXT_LEN - 5 + secret.chars().count()
+        );
+
+        let escaped = escape_error_text(&cause);
+        assert!(!escaped.contains(secret));
+        assert!(!escaped.contains(&secret[..5]));
     }
 
     #[test]

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains the main command execution loop and logging initialization.
 
+use std::io::{self, Write};
+
 use anyhow::Result;
 use mcp_execution_core::Error as CoreError;
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
@@ -13,10 +15,46 @@ use crate::commands;
 use crate::commands::common::ServerSource;
 use crate::formatters::escape_error_text;
 
+/// [`Write`] wrapper that redacts embedded secrets out of each buffer before forwarding it to the
+/// inner sink.
+///
+/// Exists because `rmcp`'s own `tracing` targets (e.g. `rmcp::transport::worker`'s `ERROR` line on
+/// a connection failure) format a `reqwest::Error` whose `Display` embeds the full request URL,
+/// query string included, and log it directly — bypassing every redacting `Debug` impl this
+/// project applies to its own types, since this project never constructs that line's text.
+/// `tracing-subscriber`'s fmt layer formats each event into a buffer and issues exactly one
+/// [`write_all`](Write::write_all) call per event (verified against `tracing-subscriber` 0.3.23's
+/// `fmt_layer` internals), so `write` here always receives one whole formatted event line, which
+/// [`mcp_execution_core::redact_urls_in_text`] can scan and redact as a unit.
+///
+/// Generic over the inner writer so tests can redirect to an in-memory buffer instead of the real
+/// `stderr` [`init_logging`] wraps it around.
+struct RedactingWriter<W>(W);
+
+impl<W: Write> Write for RedactingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let text = String::from_utf8_lossy(buf);
+        self.0
+            .write_all(mcp_execution_core::redact_urls_in_text(&text).as_bytes())?;
+        // The whole input was consumed and forwarded (redaction only ever
+        // changes the byte count written *downstream*, not how much of
+        // `buf` this call accounts for), so report all of it as written.
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
 /// Initializes logging infrastructure.
 ///
 /// Sets up tracing with appropriate log levels based on verbosity flag.
-/// Writes log messages to stderr.
+/// Writes log messages to stderr, with any embedded URL's credentials/query string redacted (via
+/// a wrapping [`Write`] adapter around the fmt layer's writer) — this covers `rmcp` and any other
+/// dependency's log lines, not just this
+/// project's own, since a dependency's `tracing` output cannot go through this crate's
+/// `Debug`/[`escape_error_text`] redaction paths.
 ///
 /// # Arguments
 ///
@@ -48,7 +86,7 @@ pub fn init_logging(verbose: bool) -> Result<()> {
 
     tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(tracing_subscriber::fmt::layer().with_writer(|| RedactingWriter(io::stderr())))
         .init();
 
     Ok(())
@@ -661,5 +699,124 @@ mod tests {
                 "captured backtrace did not survive: {report}"
             );
         }
+    }
+
+    /// Leak B regression: `CoreError::ConnectionFailed`'s boxed `source` is an opaque
+    /// `Box<dyn Error + Send + Sync>` that, for an http/sse transport, is really `rmcp`'s wrapped
+    /// `reqwest::Error` — whose `Display` embeds the full request URL, query string included. This
+    /// simulates that exact shape (the security audit's captured `rmcp` output) without a live
+    /// network connection, and asserts the secret never reaches the printed report.
+    #[test]
+    fn test_sanitized_error_report_redacts_connection_failed_source_url_secret() {
+        let source: Box<dyn std::error::Error + Send + Sync> = concat!(
+            "Client error: error sending request for url ",
+            "(http://127.0.0.1:1/mcp?token=REFUSEDSECRET), when send initialize request"
+        )
+        .into();
+        let err = wrap(CoreError::ConnectionFailed {
+            server: "test".to_string(),
+            source,
+        });
+
+        let report = sanitized_error_report(&err);
+        assert!(!report.contains("REFUSEDSECRET"), "secret leaked: {report}");
+        assert!(report.contains("http://127.0.0.1:1/mcp?<redacted>"));
+        assert!(report.contains("MCP server connection failed: test"));
+    }
+
+    /// C2 regression at this leak's real entry point: an IPv6-literal authority must not defeat
+    /// redaction here either. Mirrors the critic's live repro
+    /// (`introspect --http "http://[::1]:1/mcp?token=..."`), which printed the secret in this
+    /// exact report on the unfixed version.
+    #[test]
+    fn test_sanitized_error_report_redacts_connection_failed_source_ipv6_url_secret() {
+        let source: Box<dyn std::error::Error + Send + Sync> = concat!(
+            "Client error: error sending request for url ",
+            "(http://[::1]:1/mcp?token=IPV6LEAKTEST), when send initialize request"
+        )
+        .into();
+        let err = wrap(CoreError::ConnectionFailed {
+            server: "test".to_string(),
+            source,
+        });
+
+        let report = sanitized_error_report(&err);
+        assert!(!report.contains("IPV6LEAKTEST"), "secret leaked: {report}");
+        assert!(report.contains("http://[::1]:1/mcp?<redacted>"));
+    }
+
+    #[test]
+    fn test_redacting_writer_redacts_url_secret_before_forwarding() {
+        let mut sink = Vec::new();
+        {
+            let mut writer = RedactingWriter(&mut sink);
+            let line = "ERROR rmcp::transport::worker: worker quit with fatal: Client error: error sending request for url (https://api.example.invalid/mcp?token=hunter2secret), when send initialize request\n";
+            let n = writer.write(line.as_bytes()).unwrap();
+            assert_eq!(n, line.len());
+        }
+        let written = String::from_utf8(sink).unwrap();
+        assert!(!written.contains("hunter2secret"));
+        assert!(written.contains("https://api.example.invalid/mcp?<redacted>"));
+        assert!(written.contains("worker quit with fatal"));
+    }
+
+    #[test]
+    fn test_redacting_writer_passes_through_text_without_urls() {
+        let mut sink = Vec::new();
+        RedactingWriter(&mut sink)
+            .write_all(b"INFO some ordinary log line\n")
+            .unwrap();
+        assert_eq!(sink, b"INFO some ordinary log line\n");
+    }
+
+    /// Pins the assumption `RedactingWriter`'s doc comment relies on but the two tests above
+    /// don't exercise: that `tracing-subscriber`'s fmt layer issues exactly one `write_all` per
+    /// event, so `RedactingWriter::write` always sees a whole formatted line. Wires the real
+    /// `fmt::layer()` (not a direct `RedactingWriter::write` call) through a scoped subscriber
+    /// into a shared buffer, so a future `tracing-subscriber` upgrade that splits an event across
+    /// multiple writes -- which would let a URL straddling the split leak unredacted -- fails this
+    /// test instead of failing silently in production.
+    #[test]
+    fn test_redacting_writer_wired_into_real_fmt_layer_redacts_full_event() {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().write(buf)
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                self.0.lock().unwrap().flush()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = {
+            let buf = buf.clone();
+            move || RedactingWriter(SharedBuf(buf.clone()))
+        };
+
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(make_writer)
+                .with_ansi(false),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(
+                "error sending request for url (https://api.example.invalid/mcp?token=hunter2secret), when send initialize request"
+            );
+        });
+
+        let written = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            !written.contains("hunter2secret"),
+            "secret leaked: {written}"
+        );
+        assert!(written.contains("https://api.example.invalid/mcp?<redacted>"));
+        assert!(written.contains("when send initialize request"));
     }
 }

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -62,4 +62,6 @@ pub use command::{
 pub use path::{contains_parent_dir, sanitize_path_for_error, validate_path_segment};
 
 // Re-export Debug-redaction helpers shared by secret-shaped fields
-pub use redact::{REDACTED_PLACEHOLDER, RedactedItems, RedactedMapValues, RedactedUrl};
+pub use redact::{
+    REDACTED_PLACEHOLDER, RedactedItems, RedactedMapValues, RedactedUrl, redact_urls_in_text,
+};

--- a/crates/mcp-core/src/redact.rs
+++ b/crates/mcp-core/src/redact.rs
@@ -8,6 +8,12 @@
 //! types here are the single source of truth — implement it once, reuse it
 //! everywhere a `{:?}` might otherwise leak a credential into a log line or
 //! error message.
+//!
+//! [`RedactedUrl`] redacts a value already isolated behind its own field.
+//! [`redact_urls_in_text`] handles the other shape: a URL buried inside
+//! already-assembled prose (a `reqwest`/`rmcp` error's `Display` text, a log
+//! line) where there is no field boundary to wrap — it locates each
+//! URL-shaped token itself and redacts it with the same rules.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -177,6 +183,211 @@ impl fmt::Debug for RedactedUrl<'_> {
     }
 }
 
+/// Characters legal in a URI scheme, per [`RedactedUrl`]'s own scheme check.
+const fn is_scheme_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')
+}
+
+/// Characters that end a bare URL token embedded in prose: whitespace,
+/// control characters, and the punctuation a human or a log formatter
+/// commonly wraps a whole URL in (quotes, backtick, parens).
+///
+/// Deliberately narrow: `[`/`]` (RFC 3986 IP-literal delimiters, needed
+/// verbatim inside an IPv6 authority like `http://[::1]:1/path`) and every
+/// other RFC 3986 "unsafe" character (`<` `>` `{` `}` `\` `|` `^`) are *not*
+/// terminators here, even though none of them can legally appear unescaped
+/// in a URL. Terminating on them would truncate the token before the query
+/// string that [`RedactedUrl`] needs to see in full to redact it — a
+/// dependency's `Display` impl routinely embeds a query value verbatim,
+/// unescaped, exactly where this scan runs. Erring toward capturing *too
+/// much* surrounding text into the token (over-redaction) is safe; erring
+/// toward cutting a token short before its secret is not.
+fn is_token_terminator(c: char) -> bool {
+    c.is_whitespace() || c.is_control() || matches!(c, '"' | '\'' | '`' | '(' | ')')
+}
+
+/// Finds every URL-shaped token in `text` and redacts each one.
+///
+/// Each token is redacted by handing it to [`RedactedUrl`] — the actual masking decision (what
+/// counts as authority/query, what gets hidden) always defers to that one implementation, so it
+/// can't drift between the two.
+///
+/// Unlike [`RedactedUrl`], which redacts a value already isolated behind its
+/// own field, this scans arbitrary already-assembled text — typically a
+/// `reqwest`/`rmcp` transport error's `Display` output, which embeds the
+/// full request URL (query string included) inline in a sentence — and
+/// redacts each `scheme://…` run it finds in place, leaving the surrounding
+/// prose untouched.
+///
+/// A token's boundaries are found by walking left from `://` over
+/// scheme-legal characters, then walking right to the first whitespace,
+/// control character, or wrapping-punctuation character (quote, backtick,
+/// paren — or the end of `text`), then trimming trailing sentence
+/// punctuation (`,` `.` `;` `:`) that a log message or `Display` impl
+/// commonly appends after a URL. That terminator set is deliberately
+/// narrower than "every character invalid in a URL" — RFC 3986 IP-literal
+/// delimiters (`[`/`]`, needed verbatim for an IPv6 authority like
+/// `http://[::1]:1/path`) and every other RFC 3986 "unsafe" character are
+/// left out on purpose, because capturing too much into the token is the
+/// safe failure mode here, unlike [`RedactedUrl`]'s ambiguity handling,
+/// which fails closed by redacting a whole *field* in full. This function
+/// instead fails toward widening a *token*: it does not know a URL's true
+/// end any more precisely than "the next character a log line would use to
+/// wrap one", so a token capturing a few extra characters of trailing
+/// prose is the accepted cost of never capturing too few and truncating a
+/// secret.
+///
+/// The one residual gap from this heuristic: a raw, un-percent-encoded
+/// instance of *any* terminator character — whitespace and control
+/// characters, not just the quote/backtick/paren wrappers (`"` `'` `` ` ``
+/// `(` `)`), though the latter is the realistic case, since a real
+/// `reqwest`-sent URL would already have percent-encoded whitespace/control
+/// bytes — *inside* the secret itself, rather than used by the surrounding
+/// log line to wrap the URL, still ends the token early, exactly the same
+/// class of unencoded-delimiter ambiguity [`RedactedUrl`] documents for an
+/// unencoded `/` or `?` inside userinfo. Distinguishing the two would need
+/// a real URL parser; this module stays parse-free by design (see
+/// [`RedactedUrl`]'s doc comment).
+///
+/// One boundary case needs a deliberate widening step on the *left* side
+/// too: if the character immediately left of the scheme run is itself a
+/// non-scheme, non-terminator character (e.g. `ghp_leakedtoken://host.com/`,
+/// where `_` breaks the scheme-char walk but isn't a terminator either), the
+/// token is widened left to the nearest terminator before redaction.
+/// Without this, the walk would stop at `_`, treat `leakedtoken` as a valid
+/// scheme, and leave `ghp_leakedtoken` exposed — whereas `RedactedUrl` given
+/// that same text as a whole string redacts it in full, because
+/// `leakedtoken` alone isn't what the malformed-scheme check sees. Widening
+/// first makes the two agree: the widened token's "scheme"
+/// (`ghp_leakedtoken`) fails `RedactedUrl`'s validity check and so is
+/// redacted wholesale. This widening never looks further left than the end
+/// of the previous token this function already emitted — it cannot rewind
+/// into text it has already committed to the output.
+///
+/// Widening only ever runs when at least one scheme-legal character
+/// immediately precedes `://` (`leakedtoken` above): if the very first
+/// character to its left is itself not scheme-legal (e.g. `tok_://host.com/`,
+/// where `_` sits right against `://`), there is no scheme run to widen from
+/// at all, and the whole `://` is left untouched as ordinary text rather
+/// than redacted — not a realistic URL shape a dependency's `Display` impl
+/// would ever produce, so not a regression from before this function
+/// existed, but also not the same guarantee `RedactedUrl` gives a whole
+/// string containing that same text.
+///
+/// Known accepted limitation, inherited unchanged from `RedactedUrl`: a
+/// secret glued to a URL by scheme-*legal* characters (letters, digits,
+/// `+`, `-`, `.` — e.g. `Bearer sk-abc.https://h/p?t=1`) is absorbed into
+/// the token as part of its "scheme" and survives redaction, since nothing
+/// distinguishes it from a URL that legitimately has a long scheme name.
+/// This is exact parity with what `RedactedUrl` itself does when given that
+/// same string, not a gap introduced here, and is not worth a heuristic
+/// that would risk swallowing legitimate text instead.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::redact_urls_in_text;
+///
+/// let line = "error sending request for url (https://api.example.com/mcp?token=hunter2), \
+///             when send initialize request";
+/// let redacted = redact_urls_in_text(line);
+/// assert!(!redacted.contains("hunter2"));
+/// assert!(redacted.contains("https://api.example.com/mcp?<redacted>"));
+/// assert!(redacted.contains("when send initialize request"));
+/// ```
+///
+/// An IPv6-literal authority is redacted correctly — `[`/`]` are RFC 3986
+/// authority syntax, not token boundaries, so the query string after them
+/// is still reached and hidden:
+///
+/// ```
+/// use mcp_execution_core::redact_urls_in_text;
+///
+/// let line = "error sending request for url (http://[::1]:1/mcp?token=hunter2), when send initialize request";
+/// let redacted = redact_urls_in_text(line);
+/// assert!(!redacted.contains("hunter2"));
+/// assert!(redacted.contains("http://[::1]:1/mcp?<redacted>"));
+/// ```
+///
+/// Text with no URL at all passes through unchanged, and a malformed
+/// "scheme" glued to secret-shaped text is redacted in full:
+///
+/// ```
+/// use mcp_execution_core::redact_urls_in_text;
+///
+/// assert_eq!(redact_urls_in_text("connecting to 127.0.0.1:18801"), "connecting to 127.0.0.1:18801");
+///
+/// let leaked = "weird ghp_leakedtoken://host.com/ token";
+/// let redacted = redact_urls_in_text(leaked);
+/// assert!(!redacted.contains("ghp_leakedtoken"));
+/// ```
+#[must_use]
+pub fn redact_urls_in_text(text: &str) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+
+    while let Some(relative) = text[cursor..].find("://") {
+        let separator = cursor + relative;
+
+        let mut start = separator;
+        for (i, c) in text[cursor..separator].char_indices().rev() {
+            if is_scheme_char(c) {
+                start = cursor + i;
+            } else {
+                break;
+            }
+        }
+
+        if start == separator {
+            // No scheme characters immediately precede "://" -- nothing to
+            // redact here, emit it literally and keep scanning past it.
+            out.push_str(&text[cursor..separator + 3]);
+            cursor = separator + 3;
+            continue;
+        }
+
+        if let Some(preceding) = text[..start].chars().next_back()
+            && !is_token_terminator(preceding)
+        {
+            // Bounded to `text[cursor..start]`, never `text[..start]`: widening
+            // past `cursor` would rewind `start` behind the start of the still-
+            // unemitted slice below, an out-of-order range that panics. Falling
+            // back to `cursor` itself (not `0`) when no terminator appears in
+            // that bounded window keeps the same invariant.
+            start = text[cursor..start]
+                .rfind(is_token_terminator)
+                .and_then(|i| {
+                    text[cursor + i..]
+                        .chars()
+                        .next()
+                        .map(|c| cursor + i + c.len_utf8())
+                })
+                .unwrap_or(cursor);
+        }
+
+        let mut end = text.len();
+        for (i, c) in text[separator + 3..].char_indices() {
+            if is_token_terminator(c) {
+                end = separator + 3 + i;
+                break;
+            }
+        }
+
+        let token = text[start..end].trim_end_matches([',', '.', ';', ':']);
+
+        out.push_str(&text[cursor..start]);
+        // Infallible: `String`'s `fmt::Write` impl never returns `Err`.
+        let _ = write!(out, "{:?}", RedactedUrl(token));
+        out.push_str(&text[start + token.len()..end]);
+        cursor = end;
+    }
+
+    out.push_str(&text[cursor..]);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,5 +507,184 @@ mod tests {
         let debug_output = format!("{:?}", RedactedUrl(&format!("{secret}://host.com/")));
         assert_eq!(debug_output, REDACTED_PLACEHOLDER);
         assert!(!debug_output.contains(secret));
+    }
+
+    #[test]
+    fn redact_urls_in_text_hides_query_string_keeps_surrounding_prose() {
+        let line = "error sending request for url (https://api.example.invalid/mcp?token=hunter2secret), when send initialize request";
+        let redacted = redact_urls_in_text(line);
+        assert!(!redacted.contains("hunter2secret"));
+        assert!(redacted.contains("error sending request for url ("));
+        assert!(redacted.contains("https://api.example.invalid/mcp?<redacted>"));
+        assert!(redacted.contains("when send initialize request"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_leaves_plain_text_unchanged() {
+        let line = "connecting to 127.0.0.1:18801 with no scheme";
+        assert_eq!(redact_urls_in_text(line), line);
+    }
+
+    #[test]
+    fn redact_urls_in_text_leaves_urls_without_secrets_unchanged() {
+        let line = "see https://docs.rs/rmcp for details";
+        assert_eq!(redact_urls_in_text(line), line);
+    }
+
+    #[test]
+    fn redact_urls_in_text_redacts_multiple_urls_in_one_line() {
+        let line = "two urls http://a.com/p?x=1 and http://b.com/q?y=2 done";
+        let redacted = redact_urls_in_text(line);
+        assert!(!redacted.contains("x=1"));
+        assert!(!redacted.contains("y=2"));
+        assert!(redacted.contains("http://a.com/p?<redacted>"));
+        assert!(redacted.contains("http://b.com/q?<redacted>"));
+        assert!(redacted.starts_with("two urls "));
+        assert!(redacted.ends_with(" done"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_hides_glued_prefix_that_breaks_a_naive_scheme_walk() {
+        // Regression for the audit-flagged edge case: a naive left-walk over
+        // scheme characters stops at '_', would treat "leakedtoken" as a
+        // valid scheme, and would leave "ghp_leakedtoken" exposed --
+        // whereas `RedactedUrl` on the same whole string redacts it fully.
+        // Widening the token left to the nearest terminator before handing
+        // it to `RedactedUrl` must match that behavior exactly.
+        let secret = "ghp_leakedtoken";
+        let line = format!("weird {secret}://host.com/ token");
+        let redacted = redact_urls_in_text(&line);
+        assert!(!redacted.contains(secret));
+        assert!(!redacted.contains("leakedtoken"));
+        assert_eq!(redacted, format!("weird {REDACTED_PLACEHOLDER} token"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_quoted_and_paren_wrapped_shapes() {
+        let quoted = redact_urls_in_text(
+            r#"url "https://user:hunter2@api.example.com/mcp?token=s3cr3t" failed"#,
+        );
+        assert!(!quoted.contains("hunter2"));
+        assert!(!quoted.contains("s3cr3t"));
+        assert!(quoted.contains(r#""https://<redacted>@api.example.com/mcp?<redacted>""#));
+
+        let paren = redact_urls_in_text(
+            "error sending request for url (http://127.0.0.1:1/mcp?token=REFUSEDSECRET), when send initialize request",
+        );
+        assert!(!paren.contains("REFUSEDSECRET"));
+        assert!(paren.contains("(http://127.0.0.1:1/mcp?<redacted>)"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_handles_non_ascii_prose() {
+        let line = "unicode ünïcode https://h.example.com/p?t=sec end";
+        let redacted = redact_urls_in_text(line);
+        assert!(!redacted.contains("t=sec"));
+        assert!(redacted.contains("unicode ünïcode "));
+        assert!(redacted.ends_with(" end"));
+    }
+
+    #[test]
+    fn redact_urls_in_text_documents_residual_scheme_legal_glue_limitation() {
+        // Accepted parity limitation (see doc comment): a secret glued to a
+        // URL by scheme-*legal* characters is absorbed into the token's
+        // "scheme" and survives, identically to `RedactedUrl` on the same
+        // whole string. Pin the behavior so a future change doesn't silently
+        // alter it without updating the doc comment.
+        let line = "Bearer sk-abc.https://h.example.com/p?t=1 tail";
+        let redacted = redact_urls_in_text(line);
+        assert!(redacted.contains("sk-abc.https://h.example.com/p?<redacted>"));
+        assert!(redacted.ends_with(" tail"));
+    }
+
+    /// Regression for a critic-found panic (C1): a second `://` run whose left-widen step
+    /// scanned unbounded back to the start of `text` (instead of stopping at the previous
+    /// token's already-emitted end) could rewind `start` behind `cursor`, producing an
+    /// out-of-order range in a later slice and panicking. Each of these four inputs panicked on
+    /// the unfixed version; they must now redact without panicking.
+    #[test]
+    fn redact_urls_in_text_does_not_panic_on_adjacent_scheme_runs() {
+        for input in [
+            "_://a://b",
+            "msg: _://a://b",
+            "prefix ?://a_bc://x tail",
+            "ü://abc://x",
+        ] {
+            let _ = redact_urls_in_text(input);
+        }
+    }
+
+    /// Regression for the actual #353 vulnerability (C2): an IPv6-literal authority
+    /// (`http://[::1]:1/...`) must still be recognized and have its query string redacted.
+    /// `[`/`]` are RFC 3986 authority syntax, not prose delimiters, so they must not terminate
+    /// the token before the query string is reached -- unlike the pre-fix version, which cut the
+    /// token at `[`, leaving everything after it (the secret) exposed.
+    #[test]
+    fn redact_urls_in_text_redacts_ipv6_literal_authority_query_string() {
+        let line = "error sending request for url (http://[::1]:1/mcp?token=IPV6LEAKTEST), when send initialize request";
+        let redacted = redact_urls_in_text(line);
+        assert!(
+            !redacted.contains("IPV6LEAKTEST"),
+            "secret leaked: {redacted}"
+        );
+        assert!(redacted.contains("http://[::1]:1/mcp?<redacted>"));
+        assert!(redacted.contains("when send initialize request"));
+    }
+
+    /// Same IPv6 case without a trailing paren wrapper, to confirm the fix isn't an artifact of
+    /// that shape specifically.
+    #[test]
+    fn redact_urls_in_text_redacts_ipv6_literal_authority_at_end_of_text() {
+        let line = "connecting to http://[::1]:8080/mcp?token=IPV6LEAKTEST2";
+        let redacted = redact_urls_in_text(line);
+        assert!(
+            !redacted.contains("IPV6LEAKTEST2"),
+            "secret leaked: {redacted}"
+        );
+        assert!(redacted.contains("http://[::1]:8080/mcp?<redacted>"));
+    }
+
+    /// A query value containing `|`, `^`, or `\` -- RFC 3986 "unsafe" characters that can appear
+    /// raw in an unescaped secret -- must not truncate the token and leak the remainder, unlike
+    /// the pre-fix terminator set which treated all three as token boundaries.
+    #[test]
+    fn redact_urls_in_text_redacts_query_value_containing_unsafe_chars() {
+        let line = "url http://host.example.com/p?token=abc|def^ghi\\jkl failed";
+        let redacted = redact_urls_in_text(line);
+        // `assert_eq!` against the exact expected string, not just a `!contains` check: the
+        // pre-fix terminator set already passed a `!contains(secret)` assertion here too, since
+        // `abc` (before the first unsafe char) was already swallowed into the marker -- only an
+        // exact match on the whole line proves the *rest* of the query (`def^ghi\jkl`) didn't
+        // survive as trailing raw text after an early-truncated token.
+        assert_eq!(redacted, "url http://host.example.com/p?<redacted> failed");
+    }
+
+    /// Documents the residual gap left by narrowing the terminator set to close C2: a raw quote
+    /// or paren character *inside* the secret itself (not used by the log line to wrap the URL)
+    /// still ends the token early. Everything in the query *before* the embedded quote is safely
+    /// swallowed into the redaction marker, but the quote is still treated as a token-ending
+    /// wrapper, so whatever follows it survives verbatim -- the same class of ambiguity
+    /// `RedactedUrl` accepts for an unencoded `/` or `?` inside userinfo. Pinned so a future
+    /// change to the terminator set doesn't silently alter this without updating the doc comment.
+    #[test]
+    fn redact_urls_in_text_residual_gap_raw_quote_inside_secret_still_truncates() {
+        let line = r#"url http://host.example.com/p?token=abc"def failed"#;
+        let redacted = redact_urls_in_text(line);
+        assert!(!redacted.contains("abc"));
+        assert!(redacted.contains("http://host.example.com/p?<redacted>"));
+        assert!(redacted.contains("def"));
+    }
+
+    /// Applying `redact_urls_in_text` to text that already contains a `RedactedUrl`-redacted URL
+    /// (e.g. a `ServerConfig` `Debug` line, then re-scanned by `RedactingWriter`) must not double
+    /// up the marker into `?<redacted><redacted>`. Since `[`/`]`/`<`/`>` are no longer terminators
+    /// (C2 fix), the whole already-redacted URL is re-captured as one token and handed back to
+    /// `RedactedUrl`, which reproduces the same output -- making the function idempotent on its
+    /// own output rather than needing a dedicated already-redacted check.
+    #[test]
+    fn redact_urls_in_text_is_idempotent_on_already_redacted_url() {
+        let line = "url http://127.0.0.1:1/mcp?<redacted> failed";
+        let redacted = redact_urls_in_text(line);
+        assert_eq!(redacted, line);
     }
 }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -434,6 +434,13 @@ async fn main() -> Result<()> {
                 .unwrap_or_else(|_| EnvFilter::new("info,mcp_execution_server=debug")),
         )
         .with(
+            // Not wrapped in `mcp-execution-cli::runner`'s URL-redacting writer (see #353):
+            // this process only ever builds a stdio server config from `IntrospectServerParams`
+            // (see `service::build_stdio_server_config`), which has no `url` field, and no other
+            // path here constructs an http/sse config -- so there is no `reqwest`/`rmcp` transport
+            // error whose `Display` could embed a secret-bearing URL for this writer to reach. The
+            // #209 regression test (`service.rs`) guards that invariant; if a future change adds
+            // an http/sse client path to this crate, wire the same writer in at that point.
             tracing_subscriber::fmt::layer()
                 .with_writer(std::io::stderr)
                 .with_target(true),

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -153,6 +153,32 @@ fixed for (#336; tracked for a structural fix, redacting `Debug` on
 must format the `ServerConfig`/`TransportArgs`/`McpTransport` wrapper, never
 `Transport` directly.
 
+Neither of the above covers a *dependency's own* log lines (issue #353):
+`rmcp::transport::worker` logs an `ERROR` line on connection failure that
+formats a `reqwest::Error` whose `Display` embeds the full request URL,
+query string included — this project's `Debug` impls never see that text,
+since `rmcp` builds it internally. `runner::init_logging` closes this by
+wrapping the fmt layer's writer: `fmt::layer().with_writer(|| RedactingWriter(io::stderr()))`,
+where `RedactingWriter<W: io::Write>` runs every buffer through
+`mcp_execution_core::redact_urls_in_text` before forwarding it to `W`. This
+is viable because `tracing-subscriber`'s fmt layer formats each event into a
+buffer and issues exactly one `write_all` per event, so `write` always
+receives one whole formatted line to scan. This makes the writer
+target-agnostic — it covers every dependency's `tracing` output, not just
+`rmcp`'s, and survives `rmcp` renaming or relocating the log line that
+leaked in the first place.
+
+The same issue's second leak was in this crate's own error path:
+`escape_error_text`'s contract has broadened from "neutralize control
+characters" to "make error text safe for stderr" — it now redacts embedded
+URLs (via `mcp_execution_core::redact_urls_in_text`) *before* truncating,
+then sanitizes control characters as before. This one chokepoint covers
+`sanitized_error_report`'s whole chain (where `CoreError::ConnectionFailed`'s
+boxed `source` — `rmcp`'s error, for an http/sse transport — otherwise
+leaked the same URL into the visible `Error:` report) and every `warn!`
+call site in `commands::server` that already routed through it, present and
+future.
+
 ## 5. `runner.rs` — Dispatch and Exit-Code Classification
 
 ```rust

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -280,12 +280,59 @@ pub const REDACTED_PLACEHOLDER: &str = "<redacted>";
 pub struct RedactedMapValues<'a>(pub &'a HashMap<String,String>); // Debug: keys visible, values redacted
 pub struct RedactedItems<'a>(pub &'a [String]);                  // Debug: every entry redacted wholesale
 pub struct RedactedUrl<'a>(pub &'a str);                         // Debug: userinfo + query redacted, host/path kept
+pub fn redact_urls_in_text(text: &str) -> String;                // scans free text, redacts every URL-shaped token found
 ```
 `RedactedUrl` is deliberately parse-free (no `url` crate dependency) and
 redacts the **whole** input if it cannot unambiguously identify the
 authority boundary (e.g. an unencoded `/` or `?` inside userinfo) or if the
 scheme contains an invalid character — fails closed toward over-redaction
 rather than partial leakage.
+
+`redact_urls_in_text` (issue #353) handles the case `RedactedUrl` doesn't: a
+URL buried inside already-assembled prose rather than isolated behind its
+own field — the shape a `reqwest`/`rmcp` transport error's `Display` takes,
+embedding the full request URL (query string included) inline in a
+sentence. It locates each `scheme://…` token by walking left over
+scheme-legal characters from `://`, walking right to the first whitespace,
+control character, or wrapping-punctuation character (quote, backtick,
+paren — or text's end), and trimming trailing sentence punctuation (`,` `.`
+`;` `:`); the resulting token is redacted by handing it to `RedactedUrl`'s
+own `Debug` impl, so the *masking* decision — what counts as
+authority/query, what gets hidden — can never drift between the two.
+
+The token-*boundary* rules are deliberately looser than `RedactedUrl`'s own
+"fails closed" stance, not the same: `RedactedUrl` redacts a whole field in
+full whenever it's ambiguous, but this function only ever sees a substring
+of prose it must first isolate, so it fails toward capturing more text into
+a token rather than less — RFC 3986 IP-literal delimiters (`[`/`]`, needed
+verbatim for an IPv6 authority) and every other RFC 3986 "unsafe" character
+are deliberately *not* terminators, since ending the token on one of them
+would cut it short before a query string embedded raw (unescaped) right
+after — the exact shape a dependency's `Display` impl produces. The
+remaining terminator set (whitespace, control characters, quote/backtick/
+paren wrappers) is a heuristic, not a parser: a raw instance of *any* of
+those characters — not just the quote/backtick/paren wrappers, though
+whitespace/control chars surviving raw inside a secret is the less likely
+case, since a real `reqwest`-sent URL would already have percent-encoded
+them — appearing *inside* the secret itself (rather than used by the
+surrounding log line to wrap the URL) still ends the token early — the same
+class of unencoded-delimiter ambiguity `RedactedUrl` documents for an
+unencoded `/` or `?` inside userinfo, inherited here rather than newly
+introduced, since resolving it needs a real URL parser this module
+deliberately does not depend on.
+
+One widening step keeps parity with `RedactedUrl`'s malformed-scheme rule:
+if a non-scheme, non-terminator character glues more text onto the scheme
+run's left (e.g. `ghp_leakedtoken://host.com/`, where `_` breaks the
+scheme-char walk without being a terminator either), the token is widened
+left to the nearest terminator — bounded to text not yet emitted by a prior
+token, so it can never rewind past output already committed — before
+redaction, so the widened "scheme" fails `RedactedUrl`'s validity check and
+the whole run is redacted, not just its scheme-shaped tail. Known accepted
+limitation, inherited unchanged from `RedactedUrl`: a secret glued to a URL
+by scheme-*legal* characters (e.g. `Bearer sk-abc.https://h/p?t=1`) is
+absorbed into the token's "scheme" and survives, exact parity with what
+`RedactedUrl` itself does on that same string.
 
 ### `untrusted` module (`src/untrusted.rs`)
 


### PR DESCRIPTION
## Summary

Closes #353. Commit 6fdc4da (#352) redacted secrets in this project's own structured output (Transport Debug, RedactedUrl in server list/info/validate), but a security audit against this issue found two remaining leak paths, both rooted in a `reqwest::Error` whose Debug/Display embeds the full request URL (including query-string secrets) reaching stderr unredacted:

- **Leak A (filed)**: `rmcp::transport::worker`'s own ERROR-level tracing line (and other rmcp transport targets) leaks the URL on connection failure, across `server list`/`info`/`validate`, `introspect`, and `generate`.
- **Leak B (found during audit, same root cause, not in the original filing)**: this project's own `sanitized_error_report` prints the anyhow error chain through `escape_error_text`, which sanitized control characters but not URLs — so `introspect`/`generate`'s visible `Error:` report leaked the secret directly.

## Changes

- Added `mcp_execution_core::redact_urls_in_text` (`crates/mcp-core/src/redact.rs`): scans arbitrary text for `scheme://...` tokens and delegates each one to `RedactedUrl`'s existing redaction rules (DRY reuse, not a reimplementation).
- `escape_error_text` (`crates/mcp-cli/src/formatters.rs`) now redacts URLs before truncating, closing Leak B.
- New `RedactingWriter` wrapping the tracing fmt layer's writer in `init_logging` (`crates/mcp-cli/src/runner.rs`), closing Leak A target-agnostically (covers all rmcp transport targets, not just the one in the filed issue, and survives future rmcp target renames).
- `specs/core/spec.md` and `specs/cli/spec.md` updated per this project's spec-driven workflow.
- `CHANGELOG.md` updated under `[Unreleased]` > Security.

Two rejected alternatives (documented in the security audit, not re-litigated in code): an `EnvFilter` directive silencing rmcp's tracing target (misses other rmcp targets, breaks silently on rmcp renames, gets clobbered by a user's own `RUST_LOG`), and a thread-local `tracing::subscriber::with_default` scope around the reachability probe (rmcp's worker runs in a separate `tokio::spawn`ed task, so a thread-local dispatcher never observes it).

An internal adversarial review round found and confirmed the fix for two blocking gaps before this reached final review: a range-ordering panic in the token-widening logic on adversarial/untrusted input, and a fail-open leak for IPv6-literal URLs (`http://[::1]:1/...`) where the original terminator set treated `[`/`]` as token boundaries. Both are now covered by regression tests, including a fuzz-verified sweep for the panic and a live-verified IPv6 repro.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1121 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Live-verified the issue's original repro (`introspect --http` against an unreachable host with a query-string secret) no longer leaks
- [x] Live-verified an IPv6-literal-URL repro no longer leaks