### PR TITLE
fix(skill): enable handlebars strict_mode and drop unused dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mcp-execution-skill`**: `HANDLEBARS` now enables `set_strict_mode(true)`, matching
+  `mcp-execution-codegen`'s `TemplateEngine`. Without it, a template referencing a typo'd or
+  removed field silently rendered an empty string instead of failing at render time.
+
+### Removed
+
+- **`mcp-execution-core`**: dropped the unused `async-trait`, `chrono`, `tracing`, and `uuid`
+  direct dependencies — none were referenced in the crate's own source. Side effect: `uuid`'s
+  `fast-rng` feature (declared only by `mcp-execution-core`, not by `mcp-execution-server`, which
+  also depends on `uuid`) is no longer unified across the workspace build, so
+  `mcp-execution-server`'s `Uuid::new_v4()` calls now use the default RNG path instead of the
+  faster one — a negligible, perf-only effect with no behavioral change.
+- **`mcp-execution-skill`**: dropped the unused `dirs` direct dependency — not referenced in the
+  crate's own source.
+
 ## [0.9.0] - 2026-07-27
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,16 +1337,12 @@ dependencies = [
 name = "mcp-execution-core"
 version = "0.9.0"
 dependencies = [
- "async-trait",
- "chrono",
  "dirs",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -1411,7 +1407,6 @@ dependencies = [
 name = "mcp-execution-skill"
 version = "0.9.0"
 dependencies = [
- "dirs",
  "handlebars",
  "mcp-execution-core",
  "regex",
@@ -2728,7 +2723,6 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -15,14 +15,10 @@ categories = ["development-tools"]
 workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
-chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
-uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mcp-skill/Cargo.toml
+++ b/crates/mcp-skill/Cargo.toml
@@ -22,7 +22,6 @@ serde_norway = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
-dirs = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mcp-skill/src/template.rs
+++ b/crates/mcp-skill/src/template.rs
@@ -34,6 +34,10 @@ const SKILL_MD_TEMPLATE: &str = include_str!("templates/skill-md.hbs");
 /// Templates are parsed and validated on first access.
 static HANDLEBARS: LazyLock<Handlebars<'static>> = LazyLock::new(|| {
     let mut hb = Handlebars::new();
+
+    // Strict mode: fail on missing variables
+    hb.set_strict_mode(true);
+
     hb.register_template_string("skill", SKILL_GENERATION_TEMPLATE)
         .expect("embedded skill-generation template must be valid Handlebars syntax");
     hb.register_template_string("skill-md", SKILL_MD_TEMPLATE)
@@ -70,7 +74,10 @@ fn yaml_quote(s: &str) -> String {
 ///
 /// # Errors
 ///
-/// Returns `TemplateError` if template rendering fails.
+/// Returns `TemplateError` if template rendering fails, including when
+/// `context` is missing a field the template references — Handlebars strict
+/// mode is enabled, so a missing variable hard-fails instead of silently
+/// rendering an empty string.
 ///
 /// # Examples
 ///
@@ -114,7 +121,10 @@ pub fn render_generation_prompt(context: &GenerateSkillResult) -> Result<String,
 ///
 /// # Errors
 ///
-/// Returns [`TemplateError`] if Handlebars rendering fails.
+/// Returns [`TemplateError`] if Handlebars rendering fails, including when
+/// `context` is missing a field the template references — Handlebars strict
+/// mode is enabled, so a missing variable hard-fails instead of silently
+/// rendering an empty string.
 ///
 /// # Examples
 ///
@@ -353,6 +363,55 @@ mod tests {
         assert!(
             md.contains("Injected Heading"),
             "sanitized content must still render, just inert"
+        );
+    }
+
+    /// Pins that `HANDLEBARS` actually has strict mode enabled, rather than relying on
+    /// the missing-variable regression tests below alone: if a future change (or a
+    /// `handlebars` upgrade defaulting strict mode differently) silently flips this
+    /// back off, this test fails immediately instead of only weakening the other two.
+    #[test]
+    fn test_handlebars_strict_mode_enabled() {
+        assert!(HANDLEBARS.strict_mode());
+    }
+
+    /// Issue #370 regression: a context missing a variable the template references
+    /// must hard-fail rendering (`TemplateError::RenderFailed`) rather than silently
+    /// producing an incomplete SKILL.md/prompt. Exercises the actual `HANDLEBARS`
+    /// static and the real embedded templates, not a hand-rolled stand-in.
+    #[test]
+    fn test_render_generation_prompt_fails_on_missing_variable() {
+        let context = serde_json::json!({
+            "server_id": "test",
+            // "skill_name" intentionally omitted — referenced unconditionally by
+            // skill-generation.hbs.
+            "tool_count": 1,
+        });
+
+        let result = HANDLEBARS.render("skill", &context);
+
+        assert!(
+            result.is_err(),
+            "rendering with a missing referenced variable must fail under strict mode, got: {result:?}"
+        );
+    }
+
+    /// Same guarantee as above, exercised against the `skill-md.hbs` template used by
+    /// `render_skill_md`.
+    #[test]
+    fn test_render_skill_md_fails_on_missing_variable() {
+        let context = serde_json::json!({
+            "server_id": "test",
+            // "skill_name" intentionally omitted — referenced unconditionally by
+            // skill-md.hbs.
+            "tool_count": 1,
+        });
+
+        let result = HANDLEBARS.render("skill-md", &context);
+
+        assert!(
+            result.is_err(),
+            "rendering with a missing referenced variable must fail under strict mode, got: {result:?}"
         );
     }
 

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -159,6 +159,13 @@ server-supplied metadata cannot corrupt the frontmatter or inject a sibling
 YAML key (issue's S3 fix). Output is CRLF-normalized to LF for
 cross-platform (Windows CI) consistency.
 
+The shared `HANDLEBARS` instance (both this and `render_generation_prompt`
+render through it) enables `strict_mode(true)`, matching
+`mcp_execution_codegen::TemplateEngine::new` (`specs/codegen/spec.md`, §2).
+A template referencing a field absent from the render context now hard-fails
+with `TemplateError::RenderFailed` instead of silently rendering an empty
+string — the failure mode that regression-tests pin in `template.rs`.
+
 ## 7. `extract_skill_metadata` — Frontmatter Parsing
 
 Extracts the `---`-delimited YAML block via a pre-compiled regex, then


### PR DESCRIPTION
## Summary

- `mcp-execution-skill`'s shared `HANDLEBARS` instance now calls `set_strict_mode(true)`, mirroring `mcp-execution-codegen`'s `TemplateEngine`. A template referencing a missing/renamed field on `GenerateSkillResult` now hard-fails at render time (`TemplateError::RenderFailed`) instead of silently producing incomplete output.
- Removes five direct dependencies with zero usage in their owning crate's source, confirmed by `cargo machete` and manual grep: `async-trait`, `chrono`, `tracing`, `uuid` from `mcp-execution-core`; `dirs` from `mcp-execution-skill`.
- Adds three regression tests exercising the real `HANDLEBARS` static and templates, updates doc comments (`# Errors`) on the two affected public functions, and updates `specs/skill/spec.md` to document the new failure mode.
- CHANGELOG notes a minor perf-only side effect of the `uuid` dependency removal: `mcp-execution-server`'s `Uuid::new_v4()` no longer benefits from workspace-unified `fast-rng`.

Closes #370, closes #372

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1128/1128)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo machete` — confirms all five removed dependencies were unused (one unrelated pre-existing flag in `mcp-execution-server` tracked separately in #373)