### PR TITLE
refactor(cli): extract shared emit-and-exit helper for output formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`mcp-execution-cli`**: extracted `formatters::emit`, a shared helper that formats a value,
+  prints it, and returns the given `ExitCode`, collapsing the repeated
+  format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`, and
+  `introspect.rs`'s command handlers. Behavior-preserving refactor only — no change to CLI output
+  or exit codes (#368).
+
 ### Fixed
 
 - **`mcp-execution-skill`**: `HANDLEBARS` now enables `set_strict_mode(true)`, matching

--- a/crates/mcp-cli/src/commands/introspect.rs
+++ b/crates/mcp-cli/src/commands/introspect.rs
@@ -217,12 +217,8 @@ pub async fn run(
     let result = build_result(&server_info, detailed);
 
     // Format and display output
-    let formatted = crate::formatters::format_output(&result, output_format)
-        .context("failed to format introspection results")?;
-
-    println!("{formatted}");
-
-    Ok(ExitCode::SUCCESS)
+    crate::formatters::emit(&result, output_format, ExitCode::SUCCESS)
+        .context("failed to format introspection results")
 }
 
 /// Builds the introspection result from server info.

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -291,9 +291,7 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
         let server_list = ServerList {
             servers: Vec::new(),
         };
-        let formatted = crate::formatters::format_output(&server_list, output_format)?;
-        println!("{formatted}");
-        return Ok(ExitCode::SUCCESS);
+        return crate::formatters::emit(&server_list, output_format, ExitCode::SUCCESS);
     }
 
     // Each server's status check may include a full MCP introspection
@@ -316,10 +314,7 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
     let entries = futures_util::future::join_all(checks).await;
 
     let server_list = ServerList { servers: entries };
-    let formatted = crate::formatters::format_output(&server_list, output_format)?;
-    println!("{formatted}");
-
-    Ok(ExitCode::SUCCESS)
+    crate::formatters::emit(&server_list, output_format, ExitCode::SUCCESS)
 }
 
 /// Shows detailed information about a specific server.
@@ -342,12 +337,11 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
                 server,
                 escape_error_text(&e.to_string())
             );
-            let formatted = crate::formatters::format_output(
+            return crate::formatters::emit(
                 &unavailable_server_info(server, command),
                 output_format,
-            )?;
-            println!("{formatted}");
-            return Ok(ExitCode::ERROR);
+                ExitCode::ERROR,
+            );
         }
     };
 
@@ -389,10 +383,7 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
                 capabilities,
             };
 
-            let formatted = crate::formatters::format_output(&server_info, output_format)?;
-            println!("{formatted}");
-
-            Ok(ExitCode::SUCCESS)
+            crate::formatters::emit(&server_info, output_format, ExitCode::SUCCESS)
         }
         Err(e) => {
             warn!(
@@ -401,13 +392,11 @@ async fn show_server_info(server: String, output_format: OutputFormat) -> Result
                 escape_error_text(&e.to_string())
             );
 
-            let formatted = crate::formatters::format_output(
+            crate::formatters::emit(
                 &unavailable_server_info(server, command),
                 output_format,
-            )?;
-            println!("{formatted}");
-
-            Ok(ExitCode::ERROR)
+                ExitCode::ERROR,
+            )
         }
     }
 }
@@ -442,9 +431,7 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
                 valid: false,
                 message: format!("Server not found in configuration: {e}"),
             };
-            let formatted = crate::formatters::format_output(&result, output_format)?;
-            println!("{formatted}");
-            return Ok(ExitCode::ERROR);
+            return crate::formatters::emit(&result, output_format, ExitCode::ERROR);
         }
     };
 
@@ -472,9 +459,7 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
             valid: false,
             message,
         };
-        let formatted = crate::formatters::format_output(&result, output_format)?;
-        println!("{formatted}");
-        return Ok(ExitCode::ERROR);
+        return crate::formatters::emit(&result, output_format, ExitCode::ERROR);
     }
 
     // The precheck above catches the common malformed-URL/missing-command cases, but
@@ -490,9 +475,7 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
                 valid: false,
                 message: format!("Server '{server_name}' has an invalid configuration: {e}"),
             };
-            let formatted = crate::formatters::format_output(&result, output_format)?;
-            println!("{formatted}");
-            return Ok(ExitCode::ERROR);
+            return crate::formatters::emit(&result, output_format, ExitCode::ERROR);
         }
     };
 
@@ -509,9 +492,7 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
                     "Server '{server_name}' is available and responds to MCP protocol"
                 ),
             };
-            let formatted = crate::formatters::format_output(&result, output_format)?;
-            println!("{formatted}");
-            Ok(ExitCode::SUCCESS)
+            crate::formatters::emit(&result, output_format, ExitCode::SUCCESS)
         }
         Err(e) => {
             warn!(
@@ -532,9 +513,7 @@ async fn validate_command(server_name: String, output_format: OutputFormat) -> R
                 valid: false,
                 message,
             };
-            let formatted = crate::formatters::format_output(&result, output_format)?;
-            println!("{formatted}");
-            Ok(ExitCode::ERROR)
+            crate::formatters::emit(&result, output_format, ExitCode::ERROR)
         }
     }
 }

--- a/crates/mcp-cli/src/commands/setup.rs
+++ b/crates/mcp-cli/src/commands/setup.rs
@@ -105,12 +105,10 @@ pub async fn run(output_format: OutputFormat) -> Result<ExitCode> {
 
     if output_format == OutputFormat::Pretty {
         print_pretty_summary(&result);
-    } else {
-        let formatted = crate::formatters::format_output(&result, output_format)?;
-        println!("{formatted}");
+        return Ok(ExitCode::SUCCESS);
     }
 
-    Ok(ExitCode::SUCCESS)
+    crate::formatters::emit(&result, output_format, ExitCode::SUCCESS)
 }
 
 /// Prints the human-readable setup summary (the `Pretty` format rendering).

--- a/crates/mcp-cli/src/formatters.rs
+++ b/crates/mcp-cli/src/formatters.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use colored::Colorize;
-use mcp_execution_core::cli::OutputFormat;
+use mcp_execution_core::cli::{ExitCode, OutputFormat};
 use serde::Serialize;
 
 /// Format data according to the specified output format.
@@ -46,6 +46,38 @@ pub fn format_output<T: Serialize>(data: &T, format: OutputFormat) -> Result<Str
         OutputFormat::Text => text::format(data),
         OutputFormat::Pretty => pretty::format(data),
     }
+}
+
+/// Formats `data` per `format`, prints it to stdout, and returns `exit_code`.
+///
+/// Collapses the format/print/return-exit-code sequence repeated across every CLI command
+/// handler's branches into a single call site, so each branch only has to state which exit code
+/// it wants.
+///
+/// # Errors
+///
+/// Returns an error if formatting `data` fails (see [`format_output`]).
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_cli::formatters::emit;
+/// use mcp_execution_core::cli::{ExitCode, OutputFormat};
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Data {
+///     value: i32,
+/// }
+///
+/// let code = emit(&Data { value: 42 }, OutputFormat::Json, ExitCode::SUCCESS)?;
+/// assert_eq!(code, ExitCode::SUCCESS);
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn emit<T: Serialize>(data: &T, format: OutputFormat, exit_code: ExitCode) -> Result<ExitCode> {
+    let formatted = format_output(data, format)?;
+    println!("{formatted}");
+    Ok(exit_code)
 }
 
 /// Escapes a string for safe interpolation into hand-crafted `Text`/`Pretty` output lines.


### PR DESCRIPTION
## Summary
- Extracted `formatters::emit(data, format, exit_code) -> Result<ExitCode>` in `crates/mcp-cli/src/formatters.rs`, consolidating the repeated format/print/return-exit-code sequence.
- Replaced all 12 call sites: `server.rs` (10: `list_servers`, `show_server_info`, `validate_command`), `setup.rs` (1), `introspect.rs` (1, preserving its `.context(...)` chain).
- Pure behavior-preserving refactor — no change to CLI output or exit codes.

Closes #368

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1125 passed)
- [x] `cargo test --doc --all-features --workspace` (incl. new `emit` doctest)
- [x] Adversarial critique confirmed exit codes and error propagation match 1:1 across all 12 sites
- [x] Independent code review approved