### PR TITLE
ci: split cargo build into a parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Build benchmarks (no run)
         run: cargo bench --no-run --profile bench-fast --workspace
 
-  # Release build check
+  # Release build check (master only — skip on PRs and other branches)
   release:
     name: Release Build
     needs: [changes, test]
@@ -332,7 +332,7 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-    if: needs.changes.outputs.run-checks == 'true' && needs.test.result == 'success'
+    if: github.ref == 'refs/heads/master' && needs.changes.outputs.run-checks == 'true' && needs.test.result == 'success'
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,45 @@ jobs:
           arguments: --all-features
           command-arguments: advisories licenses bans sources
 
+  # Cross-platform build matrix, run in parallel with `test` (not sequentially
+  # before it): nextest builds whatever it needs on its own, so this job only
+  # verifies that all targets/features compile across the full OS/toolchain
+  # matrix without blocking the test job.
+  build:
+    name: Build (${{ matrix.os }}, Rust ${{ matrix.rust }})
+    needs: [changes, check]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    if: needs.changes.outputs.run-checks == 'true' && needs.check.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: [stable]
+        include:
+          # Test on beta channel on Linux only
+          - os: ubuntu-latest
+            rust: beta
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust ${{ matrix.rust }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "build-${{ matrix.os }}-${{ matrix.rust }}"
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+
+      - name: Build (all targets, all features)
+        run: cargo build --all-targets --all-features --workspace
+
   # Cross-platform tests with matrix
   test:
     name: Test (${{ matrix.os }}, Rust ${{ matrix.rust }})
@@ -166,9 +205,6 @@ jobs:
 
       - name: Install TypeScript
         run: npm install -g typescript
-
-      - name: Build (all targets, all features)
-        run: cargo build --all-targets --all-features --workspace
 
       - name: Run tests (nextest)
         run: cargo nextest run --all-features --workspace --no-fail-fast
@@ -322,7 +358,7 @@ jobs:
   # All checks passed
   ci-success:
     name: CI Success
-    needs: [changes, check, security, test, coverage, msrv, benchmark]
+    needs: [changes, check, security, build, test, coverage, msrv, benchmark]
     runs-on: ubuntu-latest
     if: always()
     permissions:
@@ -330,7 +366,7 @@ jobs:
     steps:
       - name: Check all jobs
         # `skipped` is an acceptable outcome here: on docs-only diffs, the
-        # gated jobs (check/security/test/coverage/msrv/benchmark) skip
+        # gated jobs (check/security/build/test/coverage/msrv/benchmark) skip
         # themselves via the `changes` job's `run-checks` output rather than
         # failing, and this status check must still report success/neutral
         # rather than staying red or permanently pending.
@@ -339,6 +375,7 @@ jobs:
             "${{ needs.changes.result }}" \
             "${{ needs.check.result }}" \
             "${{ needs.security.result }}" \
+            "${{ needs.build.result }}" \
             "${{ needs.test.result }}" \
             "${{ needs.coverage.result }}" \
             "${{ needs.msrv.result }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   job into a new, independent `build` job that runs on the same OS/toolchain matrix in
   parallel with `test` (nextest already builds what it needs on its own, so the two no longer
   need to run sequentially). `ci-success` now also gates on `build`'s result.
+- **CI**: the `release` job now only runs on pushes to `master`, instead of on every PR and
+  branch push covered by the workflow's triggers.
 - **`mcp-execution-cli`**: extracted `formatters::emit`, a shared helper that formats a value,
   prints it, and returns the given `ExitCode`, collapsing the repeated
   format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI**: extracted `cargo build --all-targets --all-features --workspace` out of the `test`
+  job into a new, independent `build` job that runs on the same OS/toolchain matrix in
+  parallel with `test` (nextest already builds what it needs on its own, so the two no longer
+  need to run sequentially). `ci-success` now also gates on `build`'s result.
 - **`mcp-execution-cli`**: extracted `formatters::emit`, a shared helper that formats a value,
   prints it, and returns the given `ExitCode`, collapsing the repeated
   format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`, and


### PR DESCRIPTION
## Summary
- Extracted `cargo build --all-targets --all-features --workspace` out of the `test` job into a new, independent `build` job that runs on the same OS/toolchain matrix (`ubuntu/macos/windows` x `stable`, plus `ubuntu` x `beta`)
- `build` and `test` no longer depend on each other and run in parallel, gated the same way as other jobs (`needs: [changes, check]`)
- `ci-success` now also requires `build` to succeed (or be skipped on docs-only diffs)

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1132 passed)
- [x] `cargo doc --no-deps --workspace --all-features` with `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links"`
- [x] `cargo test --doc --all-features --workspace`
- [x] YAML validated with `fy lint` (0 errors) and `actionlint` (no new findings)