### PR TITLE
add ADR-369 protocol version gate test; convert skill.rs to shared emit helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branch push covered by the workflow's triggers.
 - **`mcp-execution-cli`**: extracted `formatters::emit`, a shared helper that formats a value,
   prints it, and returns the given `ExitCode`, collapsing the repeated
-  format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`, and
-  `introspect.rs`'s command handlers. Behavior-preserving refactor only — no change to CLI output
-  or exit codes (#368).
+  format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`,
+  `introspect.rs`, and `skill.rs`'s command handlers. Behavior-preserving refactor only — no
+  change to CLI output or exit codes (#368, #377).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`mcp-execution-introspector`**: added `test_adr_369_protocol_version_latest_gate`, an
+  executable CI gate for ADR-369 §5 asserting `rmcp::model::ProtocolVersion::LATEST ==
+  ProtocolVersion::V_2025_11_25`. Fails the moment `rmcp` promotes `LATEST` to `V_2026_07_28`,
+  which is a trigger to re-open the ADR-369 discussion on adopting rmcp's SEP-2575 stateless
+  discover lifecycle — not authorization to implement it, and not a "fix the assertion" bug
+  (#382).
+
 ### Changed
 
 - **CI**: extracted `cargo build --all-targets --all-features --workspace` out of the `test`

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -18,8 +18,6 @@ use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
-use crate::formatters::format_output;
-
 /// Output of a successful `skill` command invocation.
 #[derive(Debug, Serialize)]
 struct SkillWriteResult {
@@ -157,10 +155,7 @@ pub async fn run(
         warnings: scan_result.warnings,
     };
 
-    let output = format_output(&result, output_format)?;
-    println!("{output}");
-
-    Ok(ExitCode::SUCCESS)
+    crate::formatters::emit(&result, output_format, ExitCode::SUCCESS)
 }
 
 /// Resolves and validates the server's tool directory under `servers_dir` (or its default).
@@ -430,6 +425,7 @@ fn has_path_traversal(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::formatters::format_output;
     use mcp_execution_core::metadata::{
         METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata,
         ToolMetadata,

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -2581,4 +2581,28 @@ mod tests {
         assert!(meta.has_resources);
         assert!(meta.has_prompts);
     }
+
+    // ── ADR-369 §5 revisit gate (finding A) ──────────────────────────────────
+
+    /// Fails the moment `rmcp` promotes `ProtocolVersion::LATEST` to
+    /// `V_2026_07_28`, per ADR-369 §5 (`specs/decisions/ADR-369-rmcp-stateless-lifecycle-adoption.md`).
+    ///
+    /// A red assertion here is a trigger to **re-open** the deferred decision
+    /// on adopting rmcp's SEP-2575 stateless discover lifecycle (finding A) —
+    /// it does not authorize implementing it, and the benefit side of that
+    /// decision (whether servers in the actual population answer
+    /// `server/discover`) must still be re-assessed at that point, not
+    /// assumed. Do not "fix" this assertion by updating the expected version;
+    /// update it only after the ADR-369 discussion has been re-opened and a
+    /// new decision recorded.
+    #[test]
+    fn test_adr_369_protocol_version_latest_gate() {
+        assert_eq!(
+            rmcp::model::ProtocolVersion::LATEST,
+            rmcp::model::ProtocolVersion::V_2025_11_25,
+            "rmcp promoted ProtocolVersion::LATEST — this is the ADR-369 §5 revisit gate for \
+             finding A (specs/decisions/ADR-369-rmcp-stateless-lifecycle-adoption.md): re-open \
+             the ADR-369 discussion for finding A, do NOT just bump the expected constant"
+        );
+    }
 }

--- a/specs/decisions/ADR-369-rmcp-stateless-lifecycle-adoption.md
+++ b/specs/decisions/ADR-369-rmcp-stateless-lifecycle-adoption.md
@@ -222,9 +222,8 @@ yields no `server_info` so risk 1 above is observable instead of silent.
 
 The gate must be an **executable, CI-failing assertion**, not an inferred
 or manually-tracked condition: `rmcp` version bumps arrive via dependabot
-with zero source changes to this workspace, and no workspace code
-currently references `ProtocolVersion::LATEST` or `KNOWN_VERSIONS`, so a
-protocol promotion would land green and go unnoticed without one.
+with zero source changes to this workspace, so without one a protocol
+promotion would land green and go unnoticed.
 
 **Gate condition** (lives in `mcp-introspector`, A's concern): a test
 asserting
@@ -233,7 +232,11 @@ asserting
 assert_eq!(rmcp::model::ProtocolVersion::LATEST, rmcp::model::ProtocolVersion::V_2025_11_25);
 ```
 
-fails the moment `rmcp` promotes `LATEST` to `V_2026_07_28`.
+fails the moment `rmcp` promotes `LATEST` to `V_2026_07_28`. Implemented as
+`test_adr_369_protocol_version_latest_gate` in
+`crates/mcp-introspector/src/lib.rs` (`#[cfg(test)] mod tests`, ADR-369 §5
+section), the only workspace reference to `ProtocolVersion::LATEST` or
+`KNOWN_VERSIONS`.
 
 **What a failing assertion means — and does not mean.** A red assertion is
 a **trigger to re-open the adoption discussion for A**, nothing more. It


### PR DESCRIPTION
## Summary

Two small, independent P3/P4 cleanup items bundled into one branch:

- **#382** — adds `test_adr_369_protocol_version_latest_gate` to `mcp-introspector`, implementing the CI-enforced gate that ADR-369 §5 documented but never wired up. It asserts `rmcp::model::ProtocolVersion::LATEST == ProtocolVersion::V_2025_11_25` and fails the moment `rmcp` promotes `LATEST`, which is meant as a trigger to re-open the ADR-369 discussion, not authorization to implement the stateless lifecycle or a bug to silently fix. Also updates ADR-369 §5, which previously (and now incorrectly) stated no workspace code referenced `ProtocolVersion::LATEST`.
- **#377** — converts `crates/mcp-cli/src/commands/skill.rs`'s hand-rolled format/print/exit-code sequence to `crate::formatters::emit()`, closing the one remaining site left out of #368's consolidation. Behavior-preserving refactor: same output, same exit code, same error propagation.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1133/1133 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Verified the ADR-369 gate is non-tautological against the vendored rmcp 3.1.2 source (`ProtocolVersion` is a newtype over `Cow<'static, str>`, `LATEST` and `V_2025_11_25`/`V_2026_07_28` are distinct const paths)
- [x] Verified `skill.rs`'s new call site matches `server.rs`/`setup.rs`/`introspect.rs` byte-for-byte in pattern

Closes #382, closes #377