### PR TITLE
characterize SEP-2575 discover advertisement; remove unused regex dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   even though nothing was ever exported and the session's TTL hadn't elapsed, forcing the
   caller back to `introspect_server` just to retry (#371).
 
+### Testing
+
+- **`mcp-execution-server`**: added characterization tests pinning `GeneratorService`'s
+  protocol-version advertisement. `supported_protocol_versions()` and `discover()` are not
+  overridden, so rmcp's defaults apply: the server currently advertises every protocol version
+  the SDK knows (`ProtocolVersion::KNOWN_VERSIONS`, all five entries, checked against an
+  explicit expected list rather than the constant itself), not just the `2025-06-18` fallback
+  `get_info()` pins for unrecognized-version negotiation. One test drives the real `server/discover`
+  RPC handler end to end over an in-process duplex transport, not just its default method-level
+  logic. No behavior changed — these tests exist so a future rmcp version bump that substitutes
+  or clamps the advertised set fails loudly instead of silently drifting (#381).
+
 ### Removed
 
 - **`mcp-execution-core`**: dropped the unused `async-trait`, `chrono`, `tracing`, and `uuid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`mcp-execution-server`**: dropped the unused `regex` direct dependency — not referenced in
+  the crate's own source; `schemars_derive`'s `regex(pattern = ...)` attribute expands to a
+  plain string literal, not a path into the crate (#373).
 - **`mcp-execution-core`**: dropped the unused `async-trait`, `chrono`, `tracing`, and `uuid`
   direct dependencies — none were referenced in the crate's own source. Side effect: `uuid`'s
   `fast-rng` feature (declared only by `mcp-execution-core`, not by `mcp-execution-server`, which

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,6 @@ dependencies = [
  "mcp-execution-files",
  "mcp-execution-introspector",
  "mcp-execution-skill",
- "regex",
  "rmcp",
  "schemars",
  "serde",

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -25,7 +25,6 @@ mcp-execution-core = { workspace = true }
 mcp-execution-files = { workspace = true }
 mcp-execution-introspector = { workspace = true }
 mcp-execution-skill = { workspace = true }
-regex = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
 schemars = { workspace = true, features = ["uuid1", "chrono04"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/mcp-server/tests/integration_tests.rs
+++ b/crates/mcp-server/tests/integration_tests.rs
@@ -10,8 +10,10 @@ use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
 use mcp_execution_server::{
     CategorizedTool, GeneratorService, PendingGeneration, StateManager, SystemClock,
 };
+use rmcp::ServiceExt;
 use rmcp::handler::server::ServerHandler;
 use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 // ============================================================================
 // Service Initialization Tests
@@ -39,6 +41,176 @@ fn test_service_info_has_correct_capabilities() {
     assert!(instructions.contains("progressive loading"));
     assert!(instructions.contains("introspect_server"));
     assert!(instructions.contains("save_categorized_tools"));
+}
+
+/// Characterizes a currently accidental behavior (issue #381): `GeneratorService`
+/// does not override [`ServerHandler::supported_protocol_versions`], so rmcp's
+/// default advertises every protocol version the SDK knows — not just the
+/// `2025-06-18` fallback `get_info()` pins for unrecognized-version negotiation.
+/// This is a regression gate, not an endorsement: if a future rmcp release
+/// changes `KNOWN_VERSIONS` or its default `supported_protocol_versions()`
+/// implementation, this test fails loudly instead of the drift going unnoticed.
+///
+/// The expected list is written out explicitly rather than compared against
+/// `ProtocolVersion::KNOWN_VERSIONS` itself — comparing a value against the very
+/// constant it is derived from is a tautology that can't catch rmcp substituting
+/// one version for another while keeping the same count.
+#[test]
+fn test_service_advertises_all_known_protocol_versions_by_default() {
+    let service = GeneratorService::new();
+
+    let expected = [
+        rmcp::model::ProtocolVersion::V_2024_11_05,
+        rmcp::model::ProtocolVersion::V_2025_03_26,
+        rmcp::model::ProtocolVersion::V_2025_06_18,
+        rmcp::model::ProtocolVersion::V_2025_11_25,
+        rmcp::model::ProtocolVersion::V_2026_07_28,
+    ];
+
+    assert_eq!(
+        service.supported_protocol_versions().as_ref(),
+        expected.as_slice(),
+        "supported_protocol_versions() is not overridden, so it must still equal \
+         rmcp's full KNOWN_VERSIONS set; if this fails, rmcp's default changed"
+    );
+}
+
+/// Characterizes the `server/discover` response `GeneratorService` currently
+/// produces (issue #381), reproducing `ServerHandler::discover`'s default logic
+/// (`DiscoverResult::from_server_info(supported_protocol_versions(), get_info())`,
+/// see rmcp's `handler/server.rs`) directly against the service's public methods.
+/// `from_server_info` moves `supported_versions` through verbatim, so this test's
+/// value is in pinning that the *other* fields (`instructions`, `capabilities`,
+/// `server_info`) are also carried over correctly; the real wire-level `discover()`
+/// round-trip — which this reproduction cannot catch a future clamp inside
+/// `discover()` itself from breaking — is covered separately by
+/// `test_discover_rpc_round_trip_reports_all_known_versions` below.
+#[test]
+fn test_discover_result_from_server_info_reports_all_known_versions() {
+    let service = GeneratorService::new();
+    let info = service.get_info();
+    let expected_capabilities = info.capabilities.clone();
+    let expected_instructions = info.instructions.clone();
+
+    let discover_result = rmcp::model::DiscoverResult::from_server_info(
+        service.supported_protocol_versions().into_owned(),
+        info,
+    );
+
+    assert_eq!(
+        discover_result.supported_versions,
+        rmcp::model::ProtocolVersion::KNOWN_VERSIONS.to_vec()
+    );
+    assert_eq!(discover_result.capabilities, expected_capabilities);
+    assert_eq!(discover_result.instructions, expected_instructions);
+    assert_eq!(
+        discover_result.server_info(),
+        Some(rmcp::model::Implementation::new(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        ))
+    );
+}
+
+/// Exercises the real `server/discover` RPC handler end to end over an in-process
+/// duplex transport — not a reproduction of its default logic (see the test
+/// above) — so a future rmcp release that clamps `discover()`'s response to
+/// `get_info().protocol_version`, rather than the full `supported_protocol_versions()`
+/// set, would be caught here even if it left `ServerHandler`'s method-level
+/// defaults untouched.
+///
+/// `server/discover` always requires the SEP-2575 inline-lifecycle `_meta` pair
+/// (`io.modelcontextprotocol/protocolVersion` + `.../clientCapabilities`) on the
+/// request itself, even on a session that already completed `initialize` — rmcp's
+/// `handler/server.rs` unconditionally requires request metadata for
+/// `ClientRequest::DiscoverRequest`, regardless of the session's negotiated
+/// protocol version. Both keys live nested inside `params._meta` on the wire
+/// (rmcp's `Request<M, P>` `Deserialize` impl extracts `_meta` from `params`,
+/// not from the top-level JSON-RPC envelope).
+#[tokio::test]
+async fn test_discover_rpc_round_trip_reports_all_known_versions() {
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let (server_read, server_write) = tokio::io::split(server);
+    let (client_read, mut client_write) = tokio::io::split(client);
+
+    let service_task = tokio::spawn(async move {
+        let service = GeneratorService::new()
+            .serve((server_read, server_write))
+            .await
+            .expect("initialize handshake must succeed over the duplex stream");
+        service.waiting().await
+    });
+
+    let mut client_reader = BufReader::new(client_read);
+
+    client_write
+        .write_all(
+            br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test-client","version":"0.0.0"}}}
+"#,
+        )
+        .await
+        .expect("write initialize request");
+
+    let mut init_response = String::new();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        client_reader.read_line(&mut init_response),
+    )
+    .await
+    .expect("initialize response must arrive within 5s")
+    .expect("read initialize response");
+    assert!(
+        init_response.contains(r#""id":1"#),
+        "expected an initialize response, got: {init_response}"
+    );
+
+    client_write
+        .write_all(
+            br#"{"jsonrpc":"2.0","id":2,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-06-18","io.modelcontextprotocol/clientCapabilities":{}}}}
+"#,
+        )
+        .await
+        .expect("write server/discover request");
+
+    let mut discover_response = String::new();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        client_reader.read_line(&mut discover_response),
+    )
+    .await
+    .expect("discover response must arrive within 5s")
+    .expect("read discover response");
+
+    let response: serde_json::Value =
+        serde_json::from_str(&discover_response).unwrap_or_else(|e| {
+            panic!("discover response must be valid JSON: {e}, got: {discover_response}")
+        });
+    assert!(
+        response.get("error").is_none(),
+        "expected a successful discover response, got an error: {discover_response}"
+    );
+    let supported_versions: Vec<&str> = response["result"]["supportedVersions"]
+        .as_array()
+        .unwrap_or_else(|| {
+            panic!("response must include a supportedVersions array, got: {discover_response}")
+        })
+        .iter()
+        .map(|v| {
+            v.as_str().unwrap_or_else(|| {
+                panic!("supportedVersions entries must be strings, got: {discover_response}")
+            })
+        })
+        .collect();
+
+    let expected: Vec<&str> = rmcp::model::ProtocolVersion::KNOWN_VERSIONS
+        .iter()
+        .map(rmcp::model::ProtocolVersion::as_str)
+        .collect();
+    assert_eq!(supported_versions, expected);
+
+    drop(client_write);
+    drop(client_reader);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), service_task).await;
 }
 
 #[test]

--- a/specs/NFR-mcp-execution-2026-07-27.md
+++ b/specs/NFR-mcp-execution-2026-07-27.md
@@ -257,7 +257,7 @@ project controls); `MAX_CONCURRENT_REQUESTS` (8, server binary);
 
 | ID | Requirement | Standard/Protocol |
 |----|------------|-------------------|
-| NFR-COM-001 | MCP protocol compliance | Model Context Protocol, version `2025-06-18` (advertised by `mcp-execution-server`'s `get_info()`), via the official `rmcp` SDK (both client and server roles) |
+| NFR-COM-001 | MCP protocol compliance | Model Context Protocol via the official `rmcp` SDK (both client and server roles); `mcp-execution-server`'s `get_info()` pins `2025-06-18` as the negotiation fallback, but the server advertises and can negotiate up to every protocol version the SDK knows (`ProtocolVersion::KNOWN_VERSIONS`, currently through `2026-07-28`) since `supported_protocol_versions()`/`discover()` are not overridden — see `specs/server/spec.md` and issue #381 |
 | NFR-COM-002 | Generated output executes without depending on this project's own runtime | Generated TypeScript is a self-contained package (own `package.json`/`tsconfig.json`) runnable via `tsx`, `deno`, or Node's native TypeScript stripping — not merged into a consumer's own TypeScript build |
 
 ### 6.2 Co-existence

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -104,9 +104,15 @@ impl PendingGeneration {
 | [[#generate_skill]] | Scan a generated server's tools, return an LLM-facing SKILL.md generation prompt | Yes |
 | [[#save_skill]] | Write Claude-composed SKILL.md content, confined to `~/.claude/skills/{server_id}/` | No (deliberately) |
 
-`get_info()` (`ServerHandler`) advertises protocol version `2025-06-18`,
-tools capability enabled, and an `instructions` string describing the
-introspect→categorize→save workflow.
+`get_info()` (`ServerHandler`) pins `protocol_version` to `2025-06-18` as
+the fallback used for negotiation against clients requesting an
+unrecognized version, enables the tools capability, and provides an
+`instructions` string describing the introspect→categorize→save workflow.
+`supported_protocol_versions()` and `discover()` are not overridden, so
+rmcp's defaults apply: the server advertises every protocol version the
+SDK knows (`ProtocolVersion::KNOWN_VERSIONS`), not just `2025-06-18`
+(characterized by tests in `crates/mcp-server/tests/integration_tests.rs`,
+issue #381).
 
 ### `introspect_server`
 


### PR DESCRIPTION
## Summary

- Adds characterization tests pinning `GeneratorService`'s current protocol-version advertisement behavior in `mcp-execution-server`. `supported_protocol_versions()` and `discover()` are not overridden, so rmcp's defaults apply (all known versions advertised) while `get_info()` separately pins a `2025-06-18` fallback used only for unrecognized-version negotiation. Tests assert against an explicit expected version list and exercise a real `server/discover` RPC round trip over an in-process duplex transport, so a future rmcp bump that substitutes or narrows the advertised set fails loudly instead of drifting silently. No behavior changed. Also corrects `specs/server/spec.md` and NFR-COM-001, which described the fallback version as a negotiation ceiling.
- Removes the unused `regex` direct dependency from `mcp-execution-server`'s `Cargo.toml` (flagged by `cargo machete`, confirmed unreferenced by manual review).

Closes #381, closes #373.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1135 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`