### PR TITLE
fix(mcp-server): retain session across post-consume save_categorized_tools failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which is a trigger to re-open the ADR-369 discussion on adopting rmcp's SEP-2575 stateless
   discover lifecycle — not authorization to implement it, and not a "fix the assertion" bug
   (#382).
+- **`mcp-execution-server`**: `StateManager::take_if` — a validate-then-consume primitive that
+  runs a synchronous validation closure against a session while holding the state table's write
+  lock, removing the session only if the closure succeeds, without paying `StateManager::get`'s
+  full deep-clone cost on a failed (and likely retried) attempt; it hands back the entry's
+  already-known `size_bytes` alongside the session so nothing downstream needs to re-derive it
+  (#378). A crate-internal `StateManager::restore` re-inserts a previously-removed session under
+  its original `session_id`, `expires_at`, and `size_bytes`, enforcing the same
+  `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` bounds `store` does rather than silently
+  bypassing them (#379).
 
 ### Changed
 
@@ -35,14 +44,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`mcp-execution-skill`**: `HANDLEBARS` now enables `set_strict_mode(true)`, matching
   `mcp-execution-codegen`'s `TemplateEngine`. Without it, a template referencing a typo'd or
   removed field silently rendered an empty string instead of failing at render time.
+- **`mcp-execution-server`**: `save_categorized_tools` no longer discards its session on a
+  post-consume failure. `categorized_tools` validation now runs via the new
+  `StateManager::take_if`, which consumes the session only once validation passes, without the
+  full session clone the previous `get`-then-`take` pair paid on every failed retry (#378).
+  `output_dir` resolution, codegen, VFS build, and export now all run *after* that consumption,
+  against the session `save_categorized_tools` alone owns; a failure at any of those stages
+  calls `StateManager::restore` to re-insert the session under its original `session_id` and
+  `expires_at` before returning the error. Previously, any failure past the point the session was
+  consumed (codegen, VFS build, the export `spawn_blocking` join, or the export itself)
+  permanently burned the session even for a transient cause (a momentary disk-full or I/O error),
+  forcing the caller back to `introspect_server` just to retry (#379).
 - **`mcp-execution-server`**: `save_categorized_tools` no longer destroys its pending session
-  on a `categorized_tools` validation failure or an `output_dir` resolution failure. Both now
-  run against a non-consuming peek of the session (`StateManager::get`), and the session is
-  only consumed (`StateManager::take`) once every check has passed, immediately before
-  generation and export. Previously, a single bad entry (typo'd tool name, duplicate, too many
-  entries) or a transient output-directory confinement issue permanently burned the session
-  even though nothing was ever exported and the session's TTL hadn't elapsed, forcing the
-  caller back to `introspect_server` just to retry (#371).
+  on a `categorized_tools` validation failure. A failed validation leaves the session in place,
+  at its original expiry, for the caller to retry with the same `session_id` instead of a
+  single bad entry (typo'd tool name, duplicate, too many entries) permanently burning it (#371).
 
 ### Testing
 

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -470,12 +470,27 @@ impl GeneratorService {
     /// categorization. Requires `session_id` from a previous `introspect_server`
     /// call.
     ///
-    /// The session named by `session_id` is only consumed once `categorized_tools` passes
-    /// every validation check (entry-count cap, tool-not-found, duplicate entry, field-length
-    /// limits) and `output_dir` resolves successfully. A failure in either leaves the session
-    /// intact at its original expiry, so the caller can fix the payload (or, for a resolution
-    /// failure caused by something in the filesystem, the environment) and retry with the same
-    /// `session_id` before that expiry is reached (issue #371).
+    /// The session named by `session_id` is only permanently discarded once the whole
+    /// pipeline - `categorized_tools` validation (entry-count cap, tool-not-found, duplicate
+    /// entry, field-length limits), `output_dir` resolution, codegen, VFS build, and export -
+    /// has fully succeeded. `categorized_tools` validation runs via
+    /// [`crate::state::StateManager::take_if`], which removes the session from
+    /// [`crate::state::StateManager`] only once that (fast, in-memory, lock-held) validation
+    /// passes; any failure there leaves the session untouched at its original expiry (issue
+    /// #371). Every later pipeline stage - `output_dir` resolution, codegen, VFS build, export -
+    /// runs against the already-removed, now solely-owned session, and an `Err` returned from any
+    /// of those stages re-inserts it into `StateManager` under its original `session_id`, expiry,
+    /// and byte-size accounting via [`crate::state::StateManager::restore`] before returning the
+    /// error, so a transient failure there (e.g. a momentary I/O error during export) is
+    /// retriable with the same `session_id` too, instead of permanently burning the session the
+    /// way any post-consume failure did before this fix (issue #379). This covers every ordinary
+    /// error return, not every conceivable way the session could be lost: a panic inside
+    /// `generate_and_export`, or this future being dropped mid-await (e.g. process shutdown), still
+    /// loses it with no restore, the same as any pre-#379 code path would - restore only runs on a
+    /// value actually returned from that call. `restore` can also itself decline to re-insert the
+    /// session if the pending-session table is already back at capacity by the time this call's
+    /// checkout window ends; that failure is logged, not propagated to the client, since the
+    /// pipeline's own error is always the more relevant one to report.
     ///
     /// Does not observe request cancellation, unlike `introspect_server` and
     /// `generate_skill`. An earlier version raced the wait for the
@@ -499,171 +514,94 @@ impl GeneratorService {
         &self,
         Parameters(params): Parameters<SaveCategorizedToolsParams>,
     ) -> Result<CallToolResult, McpError> {
-        // Peek (not consume) the pending session so a validation failure below can't destroy
-        // it: every earlier version of this handler called `take` here, which meant a single
-        // bad entry in `categorized_tools` (typo'd tool name, duplicate, too many entries)
-        // permanently burned the session even though nothing was ever exported and the
-        // session's TTL hadn't elapsed, forcing the caller to re-run `introspect_server` just
-        // to retry (issue #371). The session is only actually consumed, via `take` below,
-        // once every validation check in this function has passed.
-        let pending = self
+        // Validate in place and consume only on success, via `StateManager::take_if`: a failed
+        // validation (typo'd tool name, duplicate, too many entries) leaves the session
+        // untouched at its original expiry instead of burning it (issue #371), and - unlike an
+        // earlier `get`-then-`take` version of this fix - does so without deep-cloning the whole
+        // session (every introspected tool's schema) on every failed attempt (issue #378).
+        // `validate_categorized_tools` runs synchronously while `take_if` holds the state
+        // table's write lock, so it must stay limited to fast, in-memory checks - no I/O.
+        let take_result = self
             .state
-            .get(params.session_id)
-            .await
-            .ok_or_else(session_not_found_error)?;
-        tracing::Span::current().record("server_id", tracing::field::display(&pending.server_id));
-
-        // Validate categorized tools match introspected tools.
-        //
-        // #307: `pending.server_info.tools[].name` is raw — it's the actual introspection
-        // data, kept unsanitized because it's also used to build the `.ts` files themselves.
-        // Claude never sees these raw names directly: it only ever saw a *display* form of
-        // each one, produced by `build_introspected_summaries` + `wrap_introspect_result`
-        // from `introspect_server` (issues #292, #307). Matching a `categorized_tools` entry
-        // against what was introspected must key off that display form, while codegen
-        // (`generate_with_categorization`, below) must key off the raw name it actually looks
-        // tools up by — conflating the two by using the echoed name as both the match key and
-        // the codegen key desynced categorization from any tool name containing a control
-        // character, line terminator, or `&`/`<`/`>`.
-        //
-        // S2: a raw name can legitimately be echoed back in either of [`display_forms`]'s two
-        // forms (the literal escaped text, or the same text with entities decoded), so both are
-        // accepted as keys for the same raw tool.
-        //
-        // S3: if two DISTINCT raw tool names ever produce the same display key (via either
-        // form), which raw tool a caller meant by that key is genuinely ambiguous. A plain
-        // `HashMap::collect` would silently keep only the last one, misattributing one tool's
-        // categorization to a different tool's `_meta.json` entry with no error surfaced.
-        // Instead, `owners` tracks every raw name that could produce each key, and any key with
-        // more than one distinct owner is dropped from `display_to_raw` entirely, so a caller
-        // trying to use it hits the "not found" branch below explicitly.
-        let mut display_key_owners: HashMap<String, HashSet<&str>> = HashMap::new();
-        for tool in &pending.server_info.tools {
-            let raw = tool.name.as_str();
-            for key in display_forms(raw) {
-                display_key_owners.entry(key).or_default().insert(raw);
-            }
-        }
-        let display_to_raw: HashMap<String, &str> = display_key_owners
-            .into_iter()
-            .filter_map(|(key, owners)| {
-                if owners.len() == 1 {
-                    owners.into_iter().next().map(|raw| (key, raw))
-                } else {
-                    None
-                }
+            .take_if(params.session_id, |pending| {
+                validate_categorized_tools(pending, &params.categorized_tools)
             })
-            .collect();
+            .await;
 
-        // A legitimate call can never submit more entries than there are introspected tools.
-        // Reject early, before any per-entry validation, HashMap insertion, or codegen work
-        // (CWE-400 - see issue #197).
-        //
-        // Bounded by the true introspected tool count (`pending.server_info.tools.len()`), not
-        // `display_to_raw.len()`: S2 means a single raw tool can legitimately own two display
-        // keys, and S3 means an ambiguous key is excluded from the map entirely — neither of
-        // those should shrink or inflate this bound. `MAX_TOOL_FILES` is the same per-server
-        // tool-count ceiling `generate_skill` already enforces (via
-        // `mcp_execution_skill::scan_tools_directory`), so reusing it here keeps the two stages
-        // consistent - otherwise this call could happily generate more tool files than
-        // `generate_skill` will later accept.
-        let introspected_tool_count = pending.server_info.tools.len();
-        let max_allowed_tools = introspected_tool_count.min(MAX_TOOL_FILES);
-        if params.categorized_tools.len() > max_allowed_tools {
-            return Err(McpError::invalid_params(
-                format!(
-                    "categorized_tools has {} entries but at most {} are allowed \
-                     (min of {} introspected tools and the {} tool-file cap; \
-                     duplicates are not allowed)",
-                    params.categorized_tools.len(),
-                    max_allowed_tools,
-                    introspected_tool_count,
-                    MAX_TOOL_FILES,
-                ),
-                None,
-            ));
-        }
+        let (pending, size_bytes, (categorization, categories)) = match take_result {
+            None => return Err(session_not_found_error()),
+            Some(Err(e)) => return Err(e),
+            Some(Ok(validated)) => validated,
+        };
 
-        // Validate each entry and build the codegen categorization map in a single pass,
-        // resolving `cat_tool.name` to its raw tool name once via `display_to_raw` (issue #307
-        // M3) — a prior version re-derived the same lookup in a second pass, relying on an
-        // `expect()` to justify why it couldn't fail there; doing it once removes that panic
-        // path by construction instead of just asserting it unreachable.
-        let tool_count = params.categorized_tools.len();
-        // Keyed by RESOLVED RAW NAME, not by `cat_tool.name` (the submitted display key):
-        // `display_forms` (S2) deliberately lets one raw tool own two distinct display keys
-        // (its escaped and unescaped forms), so two entries with different `name` strings can
-        // still resolve to the same introspected tool. Deduping on the submitted string would
-        // miss that case entirely, letting the second entry silently overwrite the first's
-        // categorization in the map below with no error surfaced (issue #307 N1).
-        let mut seen_raw_names: HashSet<&str> = HashSet::with_capacity(tool_count);
-        let mut categorization: HashMap<String, &CategorizedTool> =
-            HashMap::with_capacity(tool_count);
-        let mut categories: HashMap<String, usize> = HashMap::with_capacity(tool_count);
-
-        for cat_tool in &params.categorized_tools {
-            let Some(&raw_name) = display_to_raw.get(cat_tool.name.as_str()) else {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "Tool '{}' not found in introspected tools (or its sanitized display \
-                         name is ambiguous between two or more introspected tools)",
-                        cat_tool.name
-                    ),
-                    None,
-                ));
-            };
-
-            if !seen_raw_names.insert(raw_name) {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "Tool '{}' appears more than once in categorized_tools (resolves to \
-                         the same introspected tool as an earlier entry)",
-                        cat_tool.name
-                    ),
-                    None,
-                ));
+        // From here on the session has been removed from `StateManager`: this call is its sole
+        // owner. Everything below - `output_dir` resolution, codegen, VFS build, export - is
+        // fallible I/O/CPU work that used to run after an unconditional `take`, so any failure
+        // here previously discarded the session permanently even for a transient cause (issue
+        // #379). `generate_and_export` borrows `pending` rather than consuming it so a failure
+        // can hand it back to `StateManager::restore` under its original `session_id`, expiry,
+        // and already-known `size_bytes`, leaving it retriable exactly as a pre-consume
+        // validation failure already is.
+        match self
+            .generate_and_export(&pending, &categorization, categories)
+            .await
+        {
+            Ok(result) => Ok(CallToolResult::success(vec![ContentBlock::text(
+                serde_json::to_string_pretty(&result).map_err(|e| {
+                    McpError::internal_error(format!("Failed to serialize result: {e}"), None)
+                })?,
+            )])),
+            Err(e) => {
+                self.restore_or_log(params.session_id, pending, size_bytes)
+                    .await;
+                Err(e)
             }
-
-            check_categorized_field_length(
-                &cat_tool.name,
-                "name",
-                &cat_tool.name,
-                MAX_CATEGORIZED_TOOL_NAME_LEN,
-            )?;
-            check_categorized_field_length(
-                &cat_tool.name,
-                "category",
-                &cat_tool.category,
-                MAX_CATEGORY_LEN,
-            )?;
-            check_categorized_field_length(
-                &cat_tool.name,
-                "keywords",
-                &cat_tool.keywords,
-                MAX_KEYWORDS_LEN,
-            )?;
-            check_categorized_field_length(
-                &cat_tool.name,
-                "short_description",
-                &cat_tool.short_description,
-                MAX_SHORT_DESCRIPTION_LEN,
-            )?;
-
-            categorization.insert(raw_name.to_string(), cat_tool);
-            *categories.entry(cat_tool.category.clone()).or_default() += 1;
         }
+    }
 
-        // Resolve and confine the output directory before consuming the session (moved ahead
-        // of `take`, rather than run afterward as in an earlier version of this fix): this -
-        // not the preview stored on `pending.output_dir` - is what creates the confinement
-        // chain's directories and rejects a symlink planted anywhere along it, including at
-        // `server_id`'s own directory. Running this here rather than once at `introspect_server`
-        // time closes the TOCTOU window a cached, pre-resolved path would leave open for the
-        // session's full lifetime (issue #216). Running it before `take` extends the same
-        // retry-with-the-same-session_id guarantee #371 gives `categorized_tools` validation to
-        // `ServerDirIsSymlink`/`NotADirectory`/`Escape`, which are environment-dependent and
-        // otherwise fixable between retries — a stale confinement violation shouldn't force a
-        // caller back to `introspect_server` any more than a stale tool name should.
+    /// Hands a session back to [`StateManager::restore`](crate::state::StateManager::restore)
+    /// after a post-consume pipeline failure, logging rather than propagating the rare case where
+    /// `restore` itself can't (the pending-session table's `MAX_PENDING_SESSIONS`/
+    /// `MAX_TOTAL_PENDING_BYTES` caps - the same ones `store` is held to - are already full by the
+    /// time this session's checkout window ends). The caller's own pipeline error is always what
+    /// gets returned to the client either way; this only affects whether a retry with the same
+    /// `session_id` will still find the session.
+    async fn restore_or_log(
+        &self,
+        session_id: uuid::Uuid,
+        pending: PendingGeneration,
+        size_bytes: usize,
+    ) {
+        if let Err(e) = self.state.restore(session_id, pending, size_bytes).await {
+            tracing::error!(
+                %session_id,
+                error = %e,
+                "failed to restore session after a post-consume pipeline failure; \
+                 the session is now permanently lost and a retry will need introspect_server again"
+            );
+        }
+    }
+
+    /// Runs `save_categorized_tools`'s post-validation pipeline: resolves and confines
+    /// `output_dir`, generates TypeScript code for `categorization`, builds the in-memory VFS,
+    /// and exports it to disk.
+    ///
+    /// Takes `pending` by reference (rather than consuming it) specifically so a caller that
+    /// already removed the session from [`StateManager`](crate::state::StateManager) can restore
+    /// it on failure without needing to reconstruct or re-clone it - see
+    /// [`Self::save_categorized_tools`], the only caller.
+    async fn generate_and_export(
+        &self,
+        pending: &PendingGeneration,
+        categorization: &HashMap<String, &CategorizedTool>,
+        categories: HashMap<String, usize>,
+    ) -> Result<SaveCategorizedToolsResult, McpError> {
+        // Resolve and confine the output directory: this - not the preview stored on
+        // `pending.output_dir` - is what creates the confinement chain's directories and rejects
+        // a symlink planted anywhere along it, including at `server_id`'s own directory. Running
+        // this here rather than once at `introspect_server` time closes the TOCTOU window a
+        // cached, pre-resolved path would leave open for the session's full lifetime (issue
+        // #216).
         let output_dir = resolve_output_dir(
             &self.servers_base_dir(),
             pending.server_id.as_str(),
@@ -684,32 +622,6 @@ impl GeneratorService {
             }
         })?;
 
-        // Release the peeked clone before consuming the session: `StateManager::get` deep-clones
-        // the entire session, including every introspected tool's schema, and holding that clone
-        // alive alongside the copy `take` returns below would double peak memory (up to ~140MB
-        // for a maximum-sized session, per `MAX_SINGLE_SESSION_BYTES`) across codegen, VFS build,
-        // and the export that follow. `display_to_raw`/`seen_raw_names` both borrow `pending`, so
-        // they're dropped first to end those borrows before `pending` itself is dropped.
-        drop(display_to_raw);
-        drop(seen_raw_names);
-        drop(pending);
-
-        // All validation above has passed: only now consume the session. `pending` is
-        // re-fetched (rather than reusing the peeked clone) so a session removed by a
-        // concurrent call for the same `session_id` between the peek above and this `take`
-        // is caught here and reported the same way a first-time miss would be, instead of
-        // this call proceeding to export with a copy of the session that's no longer the
-        // authoritative, still-owned one. `output_dir` and `categorization` above were derived
-        // from the dropped peek, not this re-fetch, but that's sound: `StateManager` exposes no
-        // method that mutates a stored session in place (only `store`/`take`/`get`), so a
-        // session's contents cannot change between a successful peek and a successful `take` of
-        // the same `session_id` - only disappear entirely, which the `ok_or_else` below catches.
-        let pending = self
-            .state
-            .take(params.session_id)
-            .await
-            .ok_or_else(session_not_found_error)?;
-
         // Generate code with categorization
         let generator = ProgressiveGenerator::new().map_err(|e| {
             McpError::internal_error(
@@ -718,13 +630,13 @@ impl GeneratorService {
             )
         })?;
 
-        let code = generate_with_categorization(&generator, &pending.server_info, &categorization)
+        let code = generate_with_categorization(&generator, &pending.server_info, categorization)
             .map_err(|e| {
-                McpError::internal_error(
-                    format!("Failed to generate code: {}", describe_with_causes(&e)),
-                    None,
-                )
-            })?;
+            McpError::internal_error(
+                format!("Failed to generate code: {}", describe_with_causes(&e)),
+                None,
+            )
+        })?;
 
         // Build virtual filesystem
         let vfs = FilesBuilder::from_generated_code(code, "/")
@@ -757,19 +669,13 @@ impl GeneratorService {
             .map_err(|e| McpError::internal_error(format!("Task join error: {e}"), None))?
             .map_err(|e| McpError::internal_error(format!("Failed to export files: {e}"), None))?;
 
-        let result = SaveCategorizedToolsResult {
+        Ok(SaveCategorizedToolsResult {
             success: true,
             files_generated,
             output_dir: output_dir.display().to_string(),
             categories,
             errors: vec![],
-        };
-
-        Ok(CallToolResult::success(vec![ContentBlock::text(
-            serde_json::to_string_pretty(&result).map_err(|e| {
-                McpError::internal_error(format!("Failed to serialize result: {e}"), None)
-            })?,
-        )]))
+        })
     }
 
     /// List all servers with generated progressive loading files.
@@ -1243,6 +1149,163 @@ fn caller_or_internal_error(err: &mcp_execution_core::Error, internal_prefix: &s
     }
 }
 
+/// The codegen categorization map (`raw_tool_name -> submitted CategorizedTool`) plus a
+/// per-category tally, both produced by [`validate_categorized_tools`].
+type CategorizedToolsValidation<'p> =
+    (HashMap<String, &'p CategorizedTool>, HashMap<String, usize>);
+
+/// Validates `categorized_tools` against `pending`'s introspected tools and builds the codegen
+/// categorization map, without consuming `pending`.
+///
+/// Runs as the `validate` closure passed to [`crate::state::StateManager::take_if`] by
+/// [`GeneratorService::save_categorized_tools`] - synchronous and I/O-free by construction, since
+/// `take_if` runs it while holding the state table's write lock.
+///
+/// #307: `pending.server_info.tools[].name` is raw — it's the actual introspection data, kept
+/// unsanitized because it's also used to build the `.ts` files themselves. Claude never sees
+/// these raw names directly: it only ever saw a *display* form of each one, produced by
+/// `build_introspected_summaries` + `wrap_introspect_result` from `introspect_server` (issues
+/// #292, #307). Matching a `categorized_tools` entry against what was introspected must key off
+/// that display form, while codegen (`generate_with_categorization`) must key off the raw name it
+/// actually looks tools up by — conflating the two by using the echoed name as both the match key
+/// and the codegen key desynced categorization from any tool name containing a control character,
+/// line terminator, or `&`/`<`/`>`.
+///
+/// S2: a raw name can legitimately be echoed back in either of [`display_forms`]'s two forms (the
+/// literal escaped text, or the same text with entities decoded), so both are accepted as keys
+/// for the same raw tool.
+///
+/// S3: if two DISTINCT raw tool names ever produce the same display key (via either form), which
+/// raw tool a caller meant by that key is genuinely ambiguous. A plain `HashMap::collect` would
+/// silently keep only the last one, misattributing one tool's categorization to a different
+/// tool's `_meta.json` entry with no error surfaced. Instead, `owners` tracks every raw name that
+/// could produce each key, and any key with more than one distinct owner is dropped from
+/// `display_to_raw` entirely, so a caller trying to use it hits the "not found" branch below
+/// explicitly.
+fn validate_categorized_tools<'p>(
+    pending: &PendingGeneration,
+    categorized_tools: &'p [CategorizedTool],
+) -> Result<CategorizedToolsValidation<'p>, McpError> {
+    tracing::Span::current().record("server_id", tracing::field::display(&pending.server_id));
+
+    let mut display_key_owners: HashMap<String, HashSet<&str>> = HashMap::new();
+    for tool in &pending.server_info.tools {
+        let raw = tool.name.as_str();
+        for key in display_forms(raw) {
+            display_key_owners.entry(key).or_default().insert(raw);
+        }
+    }
+    let display_to_raw: HashMap<String, &str> = display_key_owners
+        .into_iter()
+        .filter_map(|(key, owners)| {
+            if owners.len() == 1 {
+                owners.into_iter().next().map(|raw| (key, raw))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // A legitimate call can never submit more entries than there are introspected tools.
+    // Reject early, before any per-entry validation, HashMap insertion, or codegen work
+    // (CWE-400 - see issue #197).
+    //
+    // Bounded by the true introspected tool count (`pending.server_info.tools.len()`), not
+    // `display_to_raw.len()`: S2 means a single raw tool can legitimately own two display
+    // keys, and S3 means an ambiguous key is excluded from the map entirely — neither of
+    // those should shrink or inflate this bound. `MAX_TOOL_FILES` is the same per-server
+    // tool-count ceiling `generate_skill` already enforces (via
+    // `mcp_execution_skill::scan_tools_directory`), so reusing it here keeps the two stages
+    // consistent - otherwise this call could happily generate more tool files than
+    // `generate_skill` will later accept.
+    let introspected_tool_count = pending.server_info.tools.len();
+    let max_allowed_tools = introspected_tool_count.min(MAX_TOOL_FILES);
+    if categorized_tools.len() > max_allowed_tools {
+        return Err(McpError::invalid_params(
+            format!(
+                "categorized_tools has {} entries but at most {} are allowed \
+                 (min of {} introspected tools and the {} tool-file cap; \
+                 duplicates are not allowed)",
+                categorized_tools.len(),
+                max_allowed_tools,
+                introspected_tool_count,
+                MAX_TOOL_FILES,
+            ),
+            None,
+        ));
+    }
+
+    // Validate each entry and build the codegen categorization map in a single pass,
+    // resolving `cat_tool.name` to its raw tool name once via `display_to_raw` (issue #307
+    // M3) — a prior version re-derived the same lookup in a second pass, relying on an
+    // `expect()` to justify why it couldn't fail there; doing it once removes that panic
+    // path by construction instead of just asserting it unreachable.
+    let tool_count = categorized_tools.len();
+    // Keyed by RESOLVED RAW NAME, not by `cat_tool.name` (the submitted display key):
+    // `display_forms` (S2) deliberately lets one raw tool own two distinct display keys
+    // (its escaped and unescaped forms), so two entries with different `name` strings can
+    // still resolve to the same introspected tool. Deduping on the submitted string would
+    // miss that case entirely, letting the second entry silently overwrite the first's
+    // categorization in the map below with no error surfaced (issue #307 N1).
+    let mut seen_raw_names: HashSet<&str> = HashSet::with_capacity(tool_count);
+    let mut categorization: HashMap<String, &CategorizedTool> = HashMap::with_capacity(tool_count);
+    let mut categories: HashMap<String, usize> = HashMap::with_capacity(tool_count);
+
+    for cat_tool in categorized_tools {
+        let Some(&raw_name) = display_to_raw.get(cat_tool.name.as_str()) else {
+            return Err(McpError::invalid_params(
+                format!(
+                    "Tool '{}' not found in introspected tools (or its sanitized display \
+                     name is ambiguous between two or more introspected tools)",
+                    cat_tool.name
+                ),
+                None,
+            ));
+        };
+
+        if !seen_raw_names.insert(raw_name) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "Tool '{}' appears more than once in categorized_tools (resolves to \
+                     the same introspected tool as an earlier entry)",
+                    cat_tool.name
+                ),
+                None,
+            ));
+        }
+
+        check_categorized_field_length(
+            &cat_tool.name,
+            "name",
+            &cat_tool.name,
+            MAX_CATEGORIZED_TOOL_NAME_LEN,
+        )?;
+        check_categorized_field_length(
+            &cat_tool.name,
+            "category",
+            &cat_tool.category,
+            MAX_CATEGORY_LEN,
+        )?;
+        check_categorized_field_length(
+            &cat_tool.name,
+            "keywords",
+            &cat_tool.keywords,
+            MAX_KEYWORDS_LEN,
+        )?;
+        check_categorized_field_length(
+            &cat_tool.name,
+            "short_description",
+            &cat_tool.short_description,
+            MAX_SHORT_DESCRIPTION_LEN,
+        )?;
+
+        categorization.insert(raw_name.to_string(), cat_tool);
+        *categories.entry(cat_tool.category.clone()).or_default() += 1;
+    }
+
+    Ok((categorization, categories))
+}
+
 /// Validates one [`CategorizedTool`] field against its byte-length limit, matching the
 /// wording each check used before this helper existed: the tool's own `name` field
 /// renders as `Tool name '<name>'`, every other field as `<field_label> for tool
@@ -1388,12 +1451,17 @@ fn capacity_error(message: String) -> McpError {
 }
 
 /// Builds the [`McpError`] `save_categorized_tools` returns when `session_id` names no live
-/// pending session, whether from [`crate::state::StateManager::get`] (the initial peek) or
-/// [`crate::state::StateManager::take`] (the final consume). Shared so both call sites report
-/// the identical message a caller can match on, regardless of which lookup missed.
+/// pending session, i.e. [`crate::state::StateManager::take_if`] returned `None`.
+///
+/// This is also what a *concurrent* call for the same `session_id` sees while an in-flight call
+/// has it checked out (removed from `StateManager` for the duration of its own codegen/export
+/// pipeline, restored only if that pipeline fails) — the wording below covers that case too
+/// rather than asserting the session is definitely gone for good.
 fn session_not_found_error() -> McpError {
     McpError::invalid_params(
-        "Session not found or expired. Please run introspect_server again.",
+        "Session not found, expired, or already in use by another in-flight request for the \
+         same session_id. If a concurrent request is in flight, wait for it to finish and retry; \
+         otherwise, run introspect_server again.",
         None,
     )
 }
@@ -2902,7 +2970,7 @@ mod tests {
     /// introspected must fail validation without destroying the session, so the caller can
     /// retry with a corrected payload and the same `session_id`. Before the fix, the first
     /// (failing) call already consumed the session via `take`, so this retry would fail with
-    /// "Session not found or expired" instead of succeeding.
+    /// "Session not found" instead of succeeding.
     #[tokio::test]
     async fn test_save_categorized_tools_retries_after_tool_mismatch_with_same_session() {
         use tempfile::TempDir;
@@ -3019,7 +3087,7 @@ mod tests {
         let err = repeat_result
             .expect_err("a session consumed by a successful call must not be reusable");
         assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
-        assert!(err.message.contains("Session not found or expired"));
+        assert!(err.message.contains("Session not found"));
     }
 
     #[tokio::test]
@@ -3786,6 +3854,79 @@ mod tests {
             retry_result.is_ok(),
             "retry with the same session_id after an output_dir resolution failure must \
              succeed once the confinement violation is fixed: {:?}",
+            retry_result.err()
+        );
+    }
+
+    /// Issue #379 core scenario: a *post-consume* failure that has nothing to do with
+    /// `output_dir` resolution - here, `export_to_filesystem` itself failing because its sibling
+    /// staging directory can't be created - must not permanently discard the session either.
+    /// `server_id`'s own directory is pre-created while `servers_base_dir` is still writable so
+    /// `resolve_output_dir` succeeds without needing to create anything; only then is
+    /// `servers_base_dir` made read-only, so the failure is forced specifically inside
+    /// `generate_and_export`'s export step, after `StateManager::take_if` has already removed
+    /// the session from the table - proving `StateManager::restore` is reached from that stage
+    /// of the pipeline too, not just from `output_dir` resolution.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_save_categorized_tools_retries_after_export_io_failure_with_same_session() {
+        use std::os::unix::fs::PermissionsExt;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::create_dir_all(temp_dir.path().join("server-a"))
+            .await
+            .unwrap();
+
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let pending = pending_with_server_id_and_tool_count("server-a", 1);
+        let session_id = service.state.store(pending).await.unwrap();
+
+        // Make `servers_base_dir` read-only so `export_to_filesystem`'s sibling staging
+        // directory (created next to `servers_base_dir/server-a`, i.e. inside
+        // `servers_base_dir` itself) cannot be created, without preventing
+        // `resolve_output_dir` from resolving the already-existing `server-a` directory.
+        let original_permissions = std::fs::metadata(temp_dir.path()).unwrap().permissions();
+        std::fs::set_permissions(temp_dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let failing_params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("tool0")],
+        };
+        let failing_result = service
+            .save_categorized_tools(Parameters(failing_params))
+            .await;
+
+        // Restore permissions before any assertion can early-return/panic and leak a
+        // read-only temp directory that `TempDir`'s own drop cleanup can't remove.
+        std::fs::set_permissions(temp_dir.path(), original_permissions).unwrap();
+
+        let err = failing_result.expect_err("export must fail while servers_base_dir is read-only");
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("Failed to export files"));
+
+        // The session must still be present - not just for a second attempt via
+        // `save_categorized_tools`, but observably still in `StateManager` - proving the
+        // pipeline failure was handled via `restore`, not merely a coincidentally-successful
+        // retry through some other path.
+        assert!(
+            service.state.get(session_id).await.is_some(),
+            "a transient export failure must not discard the session"
+        );
+
+        let retry_params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool("tool0")],
+        };
+        let retry_result = service
+            .save_categorized_tools(Parameters(retry_params))
+            .await;
+        assert!(
+            retry_result.is_ok(),
+            "retry with the same session_id after a transient export failure must succeed \
+             once the underlying I/O condition clears: {:?}",
             retry_result.err()
         );
     }

--- a/crates/mcp-server/src/state.rs
+++ b/crates/mcp-server/src/state.rs
@@ -118,6 +118,31 @@ impl PendingTable {
             keep
         });
     }
+
+    /// Checks whether adding `size_bytes` worth of new entry data would stay within
+    /// [`MAX_PENDING_SESSIONS`]/[`MAX_TOTAL_PENDING_BYTES`], without mutating anything.
+    ///
+    /// Shared by [`StateManager::store`] and [`StateManager::restore`] so both insertion paths
+    /// enforce the exact same CWE-400 bounds — `restore` re-inserting a session it previously
+    /// removed must not be able to silently bypass the caps a fresh `store` would be held to
+    /// (issue #379 S1: without this, a caller could free up budget with concurrent `store`s
+    /// during another session's checkout window, then have that session's `restore` land on top
+    /// of the refilled budget).
+    fn check_capacity(&self, size_bytes: usize) -> Result<(), StateError> {
+        if self.entries.len() >= MAX_PENDING_SESSIONS {
+            return Err(StateError::AtCapacity {
+                limit: MAX_PENDING_SESSIONS,
+            });
+        }
+
+        if self.total_bytes.saturating_add(size_bytes) > MAX_TOTAL_PENDING_BYTES {
+            return Err(StateError::MemoryBudgetExceeded {
+                limit: MAX_TOTAL_PENDING_BYTES,
+            });
+        }
+
+        Ok(())
+    }
 }
 
 /// State manager for pending generation sessions.
@@ -227,18 +252,7 @@ impl StateManager {
         {
             let mut table = self.pending.write().await;
             table.sweep_expired(self.clock.as_ref());
-
-            if table.entries.len() >= MAX_PENDING_SESSIONS {
-                return Err(StateError::AtCapacity {
-                    limit: MAX_PENDING_SESSIONS,
-                });
-            }
-
-            if table.total_bytes.saturating_add(size_bytes) > MAX_TOTAL_PENDING_BYTES {
-                return Err(StateError::MemoryBudgetExceeded {
-                    limit: MAX_TOTAL_PENDING_BYTES,
-                });
-            }
+            table.check_capacity(size_bytes)?;
 
             table.entries.insert(
                 session_id,
@@ -330,6 +344,170 @@ impl StateManager {
             .get(&session_id)
             .filter(|entry| !entry.generation.is_expired(clock))
             .map(|entry| entry.generation.clone())
+    }
+
+    /// Validates a pending generation in place and consumes it only if validation succeeds.
+    ///
+    /// `validate` runs against the live entry while the write lock is held, so a failed
+    /// validation (e.g. a retried call with a bad tool name) never pays [`PendingGeneration`]'s
+    /// clone cost the way a `get`-then-`take` pattern would (issue #378) — [`Self::get`] deep
+    /// clones the entire session, including every introspected tool's schema, up to
+    /// `MAX_SINGLE_SESSION_BYTES` worth of data per call.
+    ///
+    /// Returns `None` if the session is not found or has expired — the same miss reported by
+    /// [`Self::get`]/[`Self::take`]. Returns `Some(Err(e))` if `validate` rejected the entry,
+    /// leaving the session in place at its original expiry so the caller can retry with the same
+    /// `session_id`. Returns `Some(Ok((generation, size_bytes, value)))` if `validate` accepted
+    /// it: the entry is removed from the table and its owned [`PendingGeneration`] is handed back
+    /// alongside its already-known `size_bytes` (the exact value this call's own removal just
+    /// subtracted from the table's running total — nothing is re-derived) and `validate`'s
+    /// output, so a caller that needs the session's data for further (fallible) work downstream
+    /// of validation can restore both to `Self::restore` without re-fetching, re-cloning, or
+    /// re-serializing anything.
+    ///
+    /// `validate` must be synchronous and touch only its `&PendingGeneration` argument — it runs
+    /// while the table's write lock is held, so anything slower (I/O, another lock) would block
+    /// every other session in the table for its duration.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the internal `expect` on the successful-validation path removes the
+    /// same entry that was just looked up moments earlier under the same continuously-held write
+    /// lock, so it cannot have disappeared in between.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_server::state::StateManager;
+    /// # use mcp_execution_server::types::PendingGeneration;
+    /// # use mcp_execution_core::{ServerId, ServerConfig};
+    /// # use mcp_execution_introspector::ServerInfo;
+    ///
+    /// # async fn example(pending: PendingGeneration) {
+    /// let state = StateManager::new();
+    /// let session_id = state.store(pending).await.unwrap();
+    ///
+    /// // A failed validation leaves the session in place.
+    /// let rejected = state
+    ///     .take_if(session_id, |_generation| Err::<(), _>("bad input"))
+    ///     .await;
+    /// assert!(matches!(rejected, Some(Err("bad input"))));
+    /// assert!(state.get(session_id).await.is_some());
+    ///
+    /// // A successful validation consumes the session and hands back all three parts.
+    /// let accepted = state
+    ///     .take_if(session_id, |generation| Ok::<_, &str>(generation.server_id.clone()))
+    ///     .await;
+    /// assert!(accepted.is_some());
+    /// let (generation, _size_bytes, server_id) = accepted.unwrap().unwrap();
+    /// assert_eq!(generation.server_id, server_id);
+    /// assert!(state.get(session_id).await.is_none());
+    /// # }
+    /// ```
+    pub async fn take_if<T, E>(
+        &self,
+        session_id: Uuid,
+        validate: impl FnOnce(&PendingGeneration) -> Result<T, E>,
+    ) -> Option<Result<(PendingGeneration, usize, T), E>> {
+        let mut table = self.pending.write().await;
+        table.sweep_expired(self.clock.as_ref());
+
+        let entry = table.entries.get(&session_id)?;
+        if entry.generation.is_expired(self.clock.as_ref()) {
+            return None;
+        }
+
+        let outcome = match validate(&entry.generation) {
+            Ok(value) => {
+                let entry = table
+                    .entries
+                    .remove(&session_id)
+                    .expect("entry was just looked up above under the same held write lock");
+                table.total_bytes -= entry.size_bytes;
+                Ok((entry.generation, entry.size_bytes, value))
+            }
+            Err(e) => Err(e),
+        };
+        drop(table);
+        Some(outcome)
+    }
+
+    /// Re-inserts a previously-[`Self::take`]n or [`Self::take_if`]-consumed session under its
+    /// original `session_id`, preserving its original `expires_at` rather than granting a fresh
+    /// TTL.
+    ///
+    /// Used to undo a consuming removal when the work the caller intended to do with the session
+    /// afterward fails for a transient, retriable reason (e.g. a downstream I/O error during
+    /// export) — so the caller isn't forced back to re-establishing the session from scratch for
+    /// a failure that has nothing to do with the session's own validity (issue #379). `size_bytes`
+    /// must be the value [`Self::take_if`] (or [`estimate_size_bytes`]) previously computed for
+    /// `generation`, so re-inserting it never re-serializes the session to re-derive a size this
+    /// call's caller already had (issue #378 S2).
+    ///
+    /// Enforces the exact same [`MAX_PENDING_SESSIONS`]/[`MAX_TOTAL_PENDING_BYTES`] bounds as
+    /// [`Self::store`] (issue #379 S1): without this, a session checked out via `take_if` is
+    /// briefly unaccounted for while its caller's own pipeline runs, and a client could exploit
+    /// that window — filling the freed budget with fresh `store`s, then having this call land on
+    /// top of it — to park the table above its configured caps for the remainder of the original
+    /// session's TTL. A caller whose `restore` fails this way has no better option than the
+    /// session genuinely being lost: silently dropping the cap instead would defeat the exact
+    /// protection [`StateError`] exists to provide.
+    ///
+    /// `pub(crate)`, not `pub`: unlike `store`/`take`/`get`, nothing outside this crate can call
+    /// it correctly — a caller needs `size_bytes` to already be the exact value this same
+    /// `generation` was measured at, a value [`estimate_size_bytes`] (private) is the only way to
+    /// produce, and passing an arbitrary `session_id` bypasses `store`'s minted-`Uuid` invariant.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError::AtCapacity`] or [`StateError::MemoryBudgetExceeded`] under the same
+    /// conditions as [`Self::store`], in which case `generation` is dropped rather than
+    /// re-inserted — the session is genuinely lost, exactly as a fresh `store` under the same
+    /// pressure would be rejected rather than silently exceeding the configured caps.
+    ///
+    /// # Examples
+    ///
+    /// Illustrative only (`ignore`d, not compiled): `restore` is `pub(crate)`, so it cannot be
+    /// called from a doc-test, which compiles as a separate external crate.
+    ///
+    /// ```ignore
+    /// let state = StateManager::new();
+    /// let session_id = state.store(pending).await.unwrap();
+    ///
+    /// let (taken, size_bytes, ()) = state
+    ///     .take_if(session_id, |_generation| Ok::<_, &str>(()))
+    ///     .await
+    ///     .unwrap()
+    ///     .unwrap();
+    /// assert!(state.get(session_id).await.is_none());
+    ///
+    /// // Simulated downstream failure: hand the session back.
+    /// state.restore(session_id, taken, size_bytes).await.unwrap();
+    /// assert!(state.get(session_id).await.is_some());
+    /// ```
+    pub(crate) async fn restore(
+        &self,
+        session_id: Uuid,
+        generation: PendingGeneration,
+        size_bytes: usize,
+    ) -> Result<(), StateError> {
+        let mut table = self.pending.write().await;
+        table.sweep_expired(self.clock.as_ref());
+        table.check_capacity(size_bytes)?;
+
+        if let Some(previous) = table.entries.insert(
+            session_id,
+            PendingEntry {
+                generation,
+                size_bytes,
+            },
+        ) {
+            table.total_bytes -= previous.size_bytes;
+        }
+        table.total_bytes += size_bytes;
+        drop(table);
+
+        Ok(())
     }
 
     /// Returns the current pending session count (excluding expired).
@@ -691,5 +869,169 @@ mod tests {
         // ...and swept back out once `cleanup_expired` runs.
         state.cleanup_expired().await;
         assert_eq!(state.pending.read().await.total_bytes, 0);
+    }
+
+    // ── take_if / restore (issues #378, #379) ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_take_if_success_consumes_session_and_returns_value() {
+        let state = StateManager::new();
+        let pending = create_test_pending();
+        let session_id = state.store(pending.clone()).await.unwrap();
+
+        let result = state
+            .take_if(session_id, |generation| {
+                Ok::<_, &str>(generation.server_id.clone())
+            })
+            .await;
+
+        let (generation, size_bytes, server_id) =
+            result.expect("session was present").expect("Ok result");
+        assert_eq!(generation.server_id, pending.server_id);
+        assert_eq!(server_id, pending.server_id);
+        assert_eq!(size_bytes, estimate_size_bytes(&pending));
+
+        // Consumed: no longer retrievable.
+        assert!(state.get(session_id).await.is_none());
+        assert_eq!(state.pending.read().await.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn test_take_if_validation_failure_retains_session_without_cloning() {
+        let state = StateManager::new();
+        let pending = create_test_pending();
+        let session_id = state.store(pending).await.unwrap();
+        let total_bytes_before = state.pending.read().await.total_bytes;
+
+        let first = state
+            .take_if(session_id, |_generation| Err::<(), _>("bad input"))
+            .await;
+        assert!(matches!(first, Some(Err("bad input"))));
+
+        // Session is still present, at the same accounted size, for a repeated
+        // clone-free retry against the same live entry.
+        assert!(state.get(session_id).await.is_some());
+        assert_eq!(state.pending.read().await.total_bytes, total_bytes_before);
+
+        let second = state
+            .take_if(session_id, |_generation| Err::<(), _>("bad input again"))
+            .await;
+        assert!(matches!(second, Some(Err("bad input again"))));
+        assert!(state.get(session_id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_take_if_missing_session_returns_none() {
+        let state = StateManager::new();
+        let result = state
+            .take_if(Uuid::new_v4(), |_generation| Ok::<_, &str>(()))
+            .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_take_if_expired_session_returns_none_and_does_not_call_validate() {
+        let state = StateManager::new();
+        let session_id = state.store(create_expired_pending()).await.unwrap();
+
+        let mut validate_called = false;
+        let result = state
+            .take_if(session_id, |_generation| {
+                validate_called = true;
+                Ok::<_, &str>(())
+            })
+            .await;
+
+        assert!(result.is_none());
+        assert!(!validate_called);
+    }
+
+    #[tokio::test]
+    async fn test_restore_reinserts_under_same_session_id_and_is_retryable() {
+        let state = StateManager::new();
+        let pending = create_test_pending();
+        let session_id = state.store(pending.clone()).await.unwrap();
+
+        // Simulate `save_categorized_tools` consuming the session via `take_if`
+        // and then hitting a transient downstream failure (codegen/export).
+        let (generation, size_bytes, ()) = state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(state.get(session_id).await.is_none());
+
+        state
+            .restore(session_id, generation, size_bytes)
+            .await
+            .unwrap();
+
+        // Retryable: the same session_id is usable again, with its original data intact.
+        let retried = state.get(session_id).await;
+        assert!(retried.is_some());
+        assert_eq!(retried.unwrap().server_id, pending.server_id);
+        assert_eq!(
+            state.pending.read().await.total_bytes,
+            estimate_size_bytes(&pending)
+        );
+    }
+
+    /// Issue #379 S1 — `restore` must not be able to push the table above the same
+    /// `MAX_TOTAL_PENDING_BYTES` budget a fresh `store` is held to, even though the session being
+    /// restored was briefly unaccounted for during its checkout window. Simulates the exploit the
+    /// critic flagged: another session fills the budget back up while this one is checked out via
+    /// `take_if`, so by the time `restore` runs there is no room left for it.
+    #[tokio::test]
+    async fn test_restore_rejects_when_would_exceed_memory_budget() {
+        let state = StateManager::new();
+        let pending = create_test_pending();
+        let session_id = state.store(pending).await.unwrap();
+
+        let (generation, size_bytes, ()) = state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.pending.read().await.total_bytes, 0);
+
+        // Another concurrent session refills the entire budget while this one is checked out.
+        {
+            let mut table = state.pending.write().await;
+            table.total_bytes = MAX_TOTAL_PENDING_BYTES;
+        }
+
+        let result = state.restore(session_id, generation, size_bytes).await;
+
+        assert!(
+            matches!(result, Err(StateError::MemoryBudgetExceeded { limit }) if limit == MAX_TOTAL_PENDING_BYTES)
+        );
+        // The rejected session must not have been silently inserted anyway.
+        assert!(state.get(session_id).await.is_none());
+    }
+
+    /// Same invariant as the byte-budget test above, but for the session-count cap.
+    #[tokio::test]
+    async fn test_restore_rejects_when_at_capacity() {
+        let state = StateManager::new();
+        let pending = create_test_pending();
+        let session_id = state.store(pending).await.unwrap();
+
+        let (generation, size_bytes, ()) = state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Fill the table to capacity while this session is checked out.
+        for _ in 0..MAX_PENDING_SESSIONS {
+            state.store(create_test_pending()).await.unwrap();
+        }
+
+        let result = state.restore(session_id, generation, size_bytes).await;
+
+        assert!(
+            matches!(result, Err(StateError::AtCapacity { limit }) if limit == MAX_PENDING_SESSIONS)
+        );
+        assert!(state.get(session_id).await.is_none());
     }
 }

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -77,8 +77,15 @@ impl StateManager {
     pub async fn store(&self, generation: PendingGeneration) -> Result<Uuid, StateError>;
     pub async fn take(&self, session_id: Uuid) -> Option<PendingGeneration>;
     pub async fn get(&self, session_id: Uuid) -> Option<PendingGeneration>;
+    pub async fn take_if<T, E>(
+        &self,
+        session_id: Uuid,
+        validate: impl FnOnce(&PendingGeneration) -> Result<T, E>,
+    ) -> Option<Result<(PendingGeneration, usize, T), E>>; // usize = the entry's known size_bytes
     pub async fn pending_count(&self) -> usize;
     pub async fn cleanup_expired(&self) -> usize;
+    // pub(crate) async fn restore(&self, session_id: Uuid, generation: PendingGeneration,
+    //     size_bytes: usize) -> Result<(), StateError>; -- crate-internal, see below
 }
 pub const MAX_PENDING_SESSIONS: usize = 1000;
 pub const MAX_TOTAL_PENDING_BYTES: usize; // = 4 * per-session-estimate (see below)
@@ -156,21 +163,28 @@ issue #381).
 `SaveCategorizedToolsParams { session_id: Uuid, categorized_tools: Vec<CategorizedTool> }`
 → `SaveCategorizedToolsResult { success, files_generated, output_dir, categories: HashMap<String,usize>, errors: Vec<ToolGenerationError> }`.
 
-1. `state.get(session_id)` — a non-consuming peek. The session must exist and not be
-   expired, or `invalid_params`. Nothing is removed from `StateManager` yet: both
-   validation steps below (2 and 3) run against this peeked copy, so a failure in
-   either leaves the session in place, at its original expiry, for the caller
-   to retry with the same `session_id` (issue #371). Only step 4 actually consumes
-   it, via `state.take(session_id)` — which re-checks existence/expiry against the
-   live table and can itself still miss (e.g. a concurrent call for the same
-   `session_id` already consumed it between steps 1 and 4), reporting the identical
-   `invalid_params` error as step 1's miss.
-2. Builds a display-name→raw-name lookup (`display_to_raw`) before validating
-   any entry, since a caller can only ever echo back the *display* form of a
-   tool name `introspect_server` showed it, never the raw one. For each
-   introspected tool, both plausible display forms are computed (`display_forms`):
-   the fully escaped form actually shown (`sanitize_untrusted_text` followed by
-   `&`/`<`/`>` → `&amp;`/`&lt;`/`&gt;` entity-escaping, mirroring
+1. `state.take_if(session_id, validate)` — validates in place and consumes the session
+   only if `validate` succeeds, without ever deep-cloning it (issue #378; see
+   [[#State Management (StateManager)]]). `validate` is `validate_categorized_tools`
+   (step 2 below), a synchronous closure that runs while `take_if` holds the state
+   table's write lock — deliberately restricted to fast, in-memory checks with no I/O.
+   Returns `None` if the session doesn't exist, has expired, or is currently checked
+   out by another in-flight `save_categorized_tools` call for the same `session_id`
+   (`invalid_params` — wording covers all three, since a concurrent caller can't tell
+   which applies); `Some(Err(e))` if `validate` rejected the entry, leaving the
+   session in place at its original expiry for the caller to retry with the same
+   `session_id` (issue #371); `Some(Ok((pending, size_bytes, (categorization,
+   categories))))` if `validate` accepted it — the session is removed from
+   `StateManager` at this point and this call is its sole owner from here on.
+   `size_bytes` is the entry's already-known size (computed once, at `store` time),
+   threaded through so a later `restore` (step 4) never has to re-serialize the
+   session to re-derive it (issue #378 S2 follow-up).
+2. `validate_categorized_tools` builds a display-name→raw-name lookup
+   (`display_to_raw`) before validating any entry, since a caller can only ever echo
+   back the *display* form of a tool name `introspect_server` showed it, never the
+   raw one. For each introspected tool, both plausible display forms are computed
+   (`display_forms`): the fully escaped form actually shown (`sanitize_untrusted_text`
+   followed by `&`/`<`/`>` → `&amp;`/`&lt;`/`&gt;` entity-escaping, mirroring
    `wrap_untrusted_block`'s own escaping) and the same text with those entities
    decoded back, since `wrap_untrusted_block`'s preamble explicitly invites the
    reader to do so. If two **distinct** raw tool names collide on the same
@@ -196,22 +210,38 @@ issue #381).
    (`MAX_CATEGORIZED_TOOL_NAME_LEN`=128, `MAX_CATEGORY_LEN`=100,
    `MAX_KEYWORDS_LEN`=500, `MAX_SHORT_DESCRIPTION_LEN`=320 — each checked via a
    single private `check_categorized_field_length` helper called once per field).
-3. **Resolves `output_dir` fresh, right here, still before consuming the session** —
-   not from any value cached on the session — via `output_dir::resolve_output_dir`
-   (see [[#Output directory resolution]]). Moved ahead of step 4 as part of #371: a
-   `ServerDirIsSymlink`/`NotADirectory`/`Escape` failure here is environment-dependent
-   and thus retriable, so it gets the same session-preserving treatment as step 2's
-   validation instead of destroying the session the way it did before #371.
-4. Drops the peeked session (and `display_to_raw`/`seen_raw_names`, which borrow it)
-   now that steps 2-3 have both passed, then calls `state.take(session_id)` to
-   actually consume it (see step 1). Dropping first bounds peak memory to one live
-   session copy instead of two across the codegen/export work below —
-   `state.get`'s peek in step 1 is a full deep clone of the session, including every
-   introspected tool's schema.
-5. `ProgressiveGenerator::generate_with_categories` → `FilesBuilder::from_generated_code(code, "/")` → `vfs.file_count()` captured.
-6. Exports inside `spawn_blocking`, holding a **per-`output_dir`** lock for
-   the duration (see [[#Per-resource locking]]).
-7. Does **not** observe request cancellation — a documented, deliberate
+3. `generate_and_export` runs the rest of the pipeline against the now-owned
+   `pending`, **borrowed** (not consumed) so the caller can hand it back on failure:
+   resolves and confines `output_dir` fresh, right here — not from any value cached
+   on the session — via `output_dir::resolve_output_dir` (see [[#Output directory
+   resolution]]); `ProgressiveGenerator::generate_with_categories` →
+   `FilesBuilder::from_generated_code(code, "/")` → `vfs.file_count()` captured;
+   exports inside `spawn_blocking`, holding a **per-`output_dir`** lock for the
+   duration (see [[#Per-resource locking]]).
+4. **Any `Err` returned from step 3 - `output_dir` resolution, codegen, VFS build,
+   the `spawn_blocking` join, or export - calls `state.restore(session_id, pending,
+   size_bytes)` before returning that same error** (issue #379); a result-
+   serialization failure after a successful step 3 is treated as unreachable
+   (`SaveCategorizedToolsResult`'s fields cannot fail to serialize) and simply
+   propagates via `?`, matching this project's convention against handling
+   scenarios that can't happen. `restore` re-inserts the session under its original
+   `session_id`, `expires_at` (not a fresh TTL), and `size_bytes`, so a transient
+   failure anywhere in step 3 - a symlink planted after `take_if` ran, a momentary
+   disk-full or permission error during export - is retriable with the same
+   `session_id`, the same guarantee step 1 already gives a pre-consume validation
+   failure. This covers every ordinary error return, not literally everything that
+   could lose the session: a panic inside `generate_and_export`, or the request
+   future being dropped mid-await (process shutdown, transport teardown), still
+   loses it with no restore, same as any pre-#379 code path. `restore` itself
+   enforces the same `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` bounds
+   `store` does (issue #379 S1 — see [[#State Management (StateManager)]]); if the
+   table is already back at capacity by the time this call's checkout window ends,
+   `restore` returns `Err` and the session is genuinely lost — that failure is
+   logged (`GeneratorService::restore_or_log`), not surfaced to the client, since
+   the pipeline's own error is always the more relevant one to report. Only once
+   step 3 fully succeeds, or `restore` runs (successfully or not), is the session's
+   fate settled.
+5. Does **not** observe request cancellation — a documented, deliberate
    choice: an earlier version raced the *lock wait* (not the export
    itself, which was already excluded) against cancellation, but that
    produced two successive correctness bugs (a leaked lock-table entry, or
@@ -282,10 +312,47 @@ required:
   (a serialization failure is treated as `usize::MAX`, i.e. always
   exceeding any bound, rather than silently under-counting).
 
-`StateManager::store`/`take`/`get`/`pending_count`/`cleanup_expired` all
-consult the **injected** `Clock`, not `Utc::now()` directly — verified by a
-dedicated test that jumps a shared `TestClock` far past the TTL and asserts
-every one of those methods observes the same jump.
+`StateManager::store`/`take`/`get`/`take_if`/`restore`/`pending_count`/
+`cleanup_expired` all consult the **injected** `Clock`, not `Utc::now()`
+directly — verified by a dedicated test that jumps a shared `TestClock` far
+past the TTL and asserts every one of those methods observes the same jump.
+
+`take_if` (issue #378) validates a session in place and removes it from the
+table only if the caller-supplied closure returns `Ok` — run synchronously
+while the write lock is held, so it never pays `get`'s full deep-clone cost
+(up to `MAX_SINGLE_SESSION_BYTES`) on a failed attempt, the common case for a
+caller retrying a rejected `categorized_tools` payload. On success it hands
+back the removed session, its already-known `size_bytes`, and the closure's
+output; on failure the session is left untouched at its original expiry,
+identically to what a `get`-then-validate-then-`take` sequence would leave
+behind, but without ever cloning to get there.
+
+`restore` (`pub(crate)`, issue #379) re-inserts a previously-removed session
+(via `take` or a successful `take_if`) under its original `session_id` and
+`size_bytes`, preserving its original `expires_at` rather than granting a
+fresh TTL. Used by `save_categorized_tools` to undo a `take_if` consumption
+when the pipeline step that was supposed to follow it (`output_dir`
+resolution, codegen, VFS build, export) fails for a retriable reason — see
+step 4 in [[#save_categorized_tools]]. `size_bytes` must be the value
+`take_if` (or `store`) already computed for this exact session, so `restore`
+never re-serializes it to re-derive a size its caller already had (issue #378
+S2). Enforces the identical `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES`
+bounds `store` does, returning `Err` and dropping `generation` rather than
+inserting it if either would be exceeded (issue #379 S1): a session removed
+by `take_if` is briefly unaccounted for while its caller's pipeline runs
+(the data is still resident in the handler's memory, just not reflected in
+`total_bytes`), so without this check a client could refill the freed budget
+with concurrent `store`s during that window and have `restore` land on top
+of it, parking the table above its configured caps for the rest of the
+original session's TTL. `pub(crate)` rather than `pub` because no caller
+outside this crate can supply a valid `size_bytes` for an arbitrary
+`generation` — `estimate_size_bytes` (private) is the only way to produce
+one — and an external caller could otherwise pass an arbitrary `session_id`,
+bypassing `store`'s minted-`Uuid` invariant entirely. If `session_id` already
+names an entry (only possible via a colliding UUID from a concurrent
+`store`), it is silently overwritten rather than rejected, since restoring
+the caller's own already-consumed session takes priority over that
+astronomically unlikely edge case.
 
 ## 5. Per-Resource Locking
 
@@ -326,14 +393,18 @@ rather than a file:
   fast, commit to nothing, create nothing.
 - `resolve_output_dir` (filesystem-touching: creates and confinement-checks
   every intermediate directory, symlink-strict at `server_id`'s own
-  directory) is called **only from `save_categorized_tools`**, as the last
-  validation step before the session is consumed (see step 3 in
+  directory) is called **only from `save_categorized_tools`**, as the first
+  step of the post-consume pipeline (see step 3 in
   [[#save_categorized_tools]]) — not once at `introspect_server` time with
   the result cached on the session. Caching it would leave a window (up to
   the full 30-minute session lifetime) in which a symlink planted after
   resolution is never re-checked, and would create directories for any
   `introspect_server` call regardless of whether a matching
-  `save_categorized_tools` ever follows.
+  `save_categorized_tools` ever follows. Running it after the session is
+  already consumed (rather than before, as an earlier version of this fix
+  had it) is safe specifically because a failure here now triggers
+  `state.restore` (issue #379) exactly like any other post-consume pipeline
+  failure, so it costs nothing in retriability.
 - The **final** target directory is confinement-checked but deliberately
   **not created** here — `FileSystem::export_to_filesystem` publishes it
   atomically via a staged rename, and pre-creating it would defeat that


### PR DESCRIPTION
## Summary

- Adds `StateManager::take_if`, a validate-then-consume primitive that removes a pending session only once a synchronous validation closure succeeds, avoiding the full deep-clone `StateManager::get` paid on every failed (and likely retried) `categorized_tools` validation attempt.
- Moves `output_dir` resolution, codegen, VFS build, and export to run after that consumption, against a session `save_categorized_tools` alone owns. On any downstream failure, the new crate-internal `StateManager::restore` re-inserts the session under its original `session_id` and `expires_at` before returning the error, so a transient failure (disk-full, momentary I/O error) no longer forces the caller back to `introspect_server`.
- `restore` enforces the same `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` caps `store` does, closing a capacity-bypass window found during implementation review (a restore could otherwise land on top of budget already refilled by concurrent sessions during the checkout window).
- Updates `specs/server/spec.md` and `CHANGELOG.md` for the new `StateManager` contract and retention semantics.

Closes #378, closes #379.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1140/1140)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New unit tests: `take_if` success/validation-failure-no-clone/missing/expired, `restore` reinsert-retryable, `restore` capacity-rejection (reproduces the concurrent-refill exploit)
- [x] New integration test forcing a real export I/O failure (chmod, unix-only) and verifying the session survives and a retry succeeds