### PR TITLE
add regression coverage for take_if concurrency and restore-near-expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`,
   `introspect.rs`, and `skill.rs`'s command handlers. Behavior-preserving refactor only — no
   change to CLI output or exit codes (#368, #377).
+- **`mcp-execution-server`**: when `save_categorized_tools`'s post-consume pipeline fails *and*
+  the subsequent `StateManager::restore` also can't put the session back (the pending-session
+  table already back at its `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` caps), the error
+  returned to the client now says so explicitly, instead of reading like an ordinary transient
+  failure safe to retry with the same `session_id`. Previously this compound failure was only
+  logged server-side; the client had no way to tell it apart from a `restore` that succeeded
+  short of a second failed attempt. The message now also names the actual `restore` failure
+  cause (`AtCapacity` vs `MemoryBudgetExceeded`) instead of a single hardcoded wording, and
+  `data` carries a machine-checkable `session_restore_failure_reason` field so a programmatic
+  client doesn't have to substring-match prose (#387).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its original `session_id`, `expires_at`, and `size_bytes`, enforcing the same
   `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` bounds `store` does rather than silently
   bypassing them (#379).
+- **`mcp-execution-server`**: two regression tests closing gaps left by #378/#379 —
+  `test_restore_does_not_extend_ttl_past_original_expiry` proves `restore` re-inserts a session
+  under its original `expires_at` rather than granting it a fresh TTL, and
+  `test_concurrent_take_if_same_session_exactly_one_succeeds` proves exactly one of several
+  callers racing `take_if` on the same `session_id` succeeds (#387).
 
 ### Changed
 

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -7,7 +7,7 @@
 
 use crate::clock::{Clock, SystemClock};
 use crate::output_dir::{OutputDirError, relative_subpath, resolve_output_dir};
-use crate::state::StateManager;
+use crate::state::{StateError, StateManager};
 use crate::types::{
     CategorizedTool, GeneratedServerInfo, IntrospectServerParams, IntrospectServerResult,
     IntrospectedToolSummary, ListGeneratedServersParams, ListGeneratedServersResult,
@@ -489,8 +489,11 @@ impl GeneratorService {
     /// loses it with no restore, the same as any pre-#379 code path would - restore only runs on a
     /// value actually returned from that call. `restore` can also itself decline to re-insert the
     /// session if the pending-session table is already back at capacity by the time this call's
-    /// checkout window ends; that failure is logged, not propagated to the client, since the
-    /// pipeline's own error is always the more relevant one to report.
+    /// checkout window ends; that compound failure is logged and also folded into the error
+    /// returned to the client (see [`Self::restore_after_pipeline_failure`]), so a well-behaved
+    /// caller can tell "transient pipeline failure, retry with the same `session_id`" apart from
+    /// "the session is also gone, run `introspect_server` again" instead of only discovering the
+    /// difference on a second failed attempt (issue #387 gap 3).
     ///
     /// Does not observe request cancellation, unlike `introspect_server` and
     /// `generate_skill`. An earlier version raced the wait for the
@@ -551,34 +554,41 @@ impl GeneratorService {
                     McpError::internal_error(format!("Failed to serialize result: {e}"), None)
                 })?,
             )])),
-            Err(e) => {
-                self.restore_or_log(params.session_id, pending, size_bytes)
-                    .await;
-                Err(e)
-            }
+            Err(e) => Err(self
+                .restore_after_pipeline_failure(params.session_id, pending, size_bytes, e)
+                .await),
         }
     }
 
     /// Hands a session back to [`StateManager::restore`](crate::state::StateManager::restore)
-    /// after a post-consume pipeline failure, logging rather than propagating the rare case where
-    /// `restore` itself can't (the pending-session table's `MAX_PENDING_SESSIONS`/
-    /// `MAX_TOTAL_PENDING_BYTES` caps - the same ones `store` is held to - are already full by the
-    /// time this session's checkout window ends). The caller's own pipeline error is always what
-    /// gets returned to the client either way; this only affects whether a retry with the same
-    /// `session_id` will still find the session.
-    async fn restore_or_log(
+    /// after a post-consume pipeline failure, returning the `McpError` that should be reported to
+    /// the client for `pipeline_err`.
+    ///
+    /// `restore` can itself decline to re-insert the session (the pending-session table's
+    /// `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` caps - the same ones `store` is held to -
+    /// already full by the time this session's checkout window ends). When that happens the
+    /// session is genuinely lost, not just this attempt's pipeline work, so `pipeline_err` alone
+    /// would mislead a client into retrying a `session_id` that `session_not_found_error` will
+    /// reject; [`session_lost_after_restore_failure`] folds that distinction into the returned
+    /// message instead (issue #387 gap 3). The failure is always logged either way.
+    async fn restore_after_pipeline_failure(
         &self,
         session_id: uuid::Uuid,
         pending: PendingGeneration,
         size_bytes: usize,
-    ) {
-        if let Err(e) = self.state.restore(session_id, pending, size_bytes).await {
-            tracing::error!(
-                %session_id,
-                error = %e,
-                "failed to restore session after a post-consume pipeline failure; \
-                 the session is now permanently lost and a retry will need introspect_server again"
-            );
+        pipeline_err: McpError,
+    ) -> McpError {
+        match self.state.restore(session_id, pending, size_bytes).await {
+            Ok(()) => pipeline_err,
+            Err(e) => {
+                tracing::error!(
+                    %session_id,
+                    error = %e,
+                    "failed to restore session after a post-consume pipeline failure; \
+                     the session is now permanently lost and a retry will need introspect_server again"
+                );
+                session_lost_after_restore_failure(&pipeline_err, &e)
+            }
         }
     }
 
@@ -1463,6 +1473,49 @@ fn session_not_found_error() -> McpError {
          same session_id. If a concurrent request is in flight, wait for it to finish and retry; \
          otherwise, run introspect_server again.",
         None,
+    )
+}
+
+/// Builds the [`McpError`] `save_categorized_tools` returns when its post-consume pipeline
+/// failed with `pipeline_err` *and* [`crate::state::StateManager::restore`] also failed with
+/// `restore_err` (the pending-session table's `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES`
+/// caps were already full by the time the checkout window ended).
+///
+/// Preserves `pipeline_err`'s code and appends a note that the session itself is now gone, so a
+/// retry with the same `session_id` would only hit [`session_not_found_error`] rather than
+/// re-running the pipeline - without this, the client sees only `pipeline_err`'s message, which
+/// reads exactly like an ordinary transient failure safe to retry in place. The appended text
+/// interpolates `restore_err`'s own `Display` (e.g. "too many pending generation sessions: at
+/// capacity limit of 1000" vs "...exceed the aggregate memory budget of ... bytes") rather than
+/// a single hardcoded cause, so [`StateError::AtCapacity`] and
+/// [`StateError::MemoryBudgetExceeded`] are reported accurately instead of both reading as a
+/// session-count problem.
+///
+/// The distinction is also machine-checkable, not prose-only: `data` carries a
+/// `session_restore_failure_reason` field set to `"at_capacity"` or
+/// `"memory_budget_exceeded"`. `pipeline_err`'s own `data` is dropped rather than merged in,
+/// since every `McpError` this file builds currently passes `data: None` - there is nothing to
+/// preserve today, and merging into a payload that might not always be a JSON object would be
+/// speculative machinery for a case that cannot yet occur (issue #387 gap 3).
+fn session_lost_after_restore_failure(
+    pipeline_err: &McpError,
+    restore_err: &StateError,
+) -> McpError {
+    let reason = match restore_err {
+        StateError::AtCapacity { .. } => "at_capacity",
+        StateError::MemoryBudgetExceeded { .. } => "memory_budget_exceeded",
+    };
+
+    let message = format!(
+        "{}. Additionally, the session could not be kept for retry because {restore_err}; run \
+         introspect_server again instead of retrying with the same session_id.",
+        pipeline_err.message.trim_end_matches('.'),
+    );
+
+    McpError::new(
+        pipeline_err.code,
+        message,
+        Some(serde_json::json!({ "session_restore_failure_reason": reason })),
     )
 }
 
@@ -3929,6 +3982,125 @@ mod tests {
              once the underlying I/O condition clears: {:?}",
             retry_result.err()
         );
+    }
+
+    /// Issue #387 gap 3 — when a post-consume pipeline failure coincides with `restore` itself
+    /// being rejected (the pending-session table already back at capacity), the client must be
+    /// told the session is gone, not just handed the pipeline's own error as if a same-session
+    /// retry would still work. Exercises `restore_after_pipeline_failure` directly with the table
+    /// filled to `MAX_PENDING_SESSIONS` during the session's checkout window, mirroring
+    /// `state::tests::test_restore_rejects_when_at_capacity`.
+    #[tokio::test]
+    async fn test_restore_after_pipeline_failure_folds_capacity_rejection_into_message() {
+        let service = GeneratorService::new();
+        let pending = pending_with_tool_count(1);
+        let session_id = service.state.store(pending).await.unwrap();
+
+        let (taken, size_bytes, ()) = service
+            .state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Fill the table to capacity while this session is checked out, so the `restore` inside
+        // `restore_after_pipeline_failure` below is rejected.
+        for _ in 0..crate::state::MAX_PENDING_SESSIONS {
+            service
+                .state
+                .store(pending_with_tool_count(1))
+                .await
+                .unwrap();
+        }
+
+        let pipeline_err = McpError::internal_error("Failed to export files: disk full", None);
+        let returned = service
+            .restore_after_pipeline_failure(session_id, taken, size_bytes, pipeline_err)
+            .await;
+
+        assert_eq!(returned.code, ErrorCode::INTERNAL_ERROR);
+        assert!(
+            returned
+                .message
+                .contains("Failed to export files: disk full"),
+            "the original pipeline error must still be present: {}",
+            returned.message
+        );
+        assert!(
+            returned.message.contains("introspect_server again"),
+            "the compound failure must tell the client a same-session retry will not work: {}",
+            returned.message
+        );
+        assert!(
+            returned.message.contains("at capacity limit of"),
+            "an AtCapacity rejection must be reported by its actual cause: {}",
+            returned.message
+        );
+        assert!(
+            !returned.message.contains("memory budget"),
+            "an AtCapacity rejection must not be reported using MemoryBudgetExceeded's wording: {}",
+            returned.message
+        );
+        assert_eq!(
+            returned.data,
+            Some(serde_json::json!({ "session_restore_failure_reason": "at_capacity" })),
+            "the cause must also be machine-checkable via `data`, not prose-only"
+        );
+        assert!(
+            service.state.get(session_id).await.is_none(),
+            "a session restore rejected as AtCapacity must not have been silently inserted anyway"
+        );
+    }
+
+    /// Issue #387 gap 3 (critic S4) — companion to the `AtCapacity` case above, proving
+    /// `restore`'s *other* capacity failure mode is reported by its own cause too, instead of
+    /// [`session_lost_after_restore_failure`] hardcoding "at capacity" regardless of which
+    /// `StateError` variant actually fired. Forces `MemoryBudgetExceeded` by seeding
+    /// `total_bytes` directly via `set_total_bytes_for_test`, mirroring
+    /// `state::tests::test_restore_rejects_when_would_exceed_memory_budget` (reaching the real
+    /// ~1GB budget organically would be a slow, wasteful allocation on every CI run).
+    #[tokio::test]
+    async fn test_restore_after_pipeline_failure_folds_memory_budget_rejection_into_message() {
+        let service = GeneratorService::new();
+        let pending = pending_with_tool_count(1);
+        let session_id = service.state.store(pending).await.unwrap();
+
+        let (taken, size_bytes, ()) = service
+            .state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Simulate another concurrent session refilling the entire memory budget while this
+        // one is checked out, so `restore` inside `restore_after_pipeline_failure` below is
+        // rejected as `MemoryBudgetExceeded`, not `AtCapacity`.
+        service
+            .state
+            .set_total_bytes_for_test(crate::state::MAX_TOTAL_PENDING_BYTES)
+            .await;
+
+        let pipeline_err = McpError::internal_error("Failed to export files: disk full", None);
+        let returned = service
+            .restore_after_pipeline_failure(session_id, taken, size_bytes, pipeline_err)
+            .await;
+
+        assert_eq!(returned.code, ErrorCode::INTERNAL_ERROR);
+        assert!(
+            returned.message.contains("memory budget"),
+            "a MemoryBudgetExceeded rejection must not be reported as a session-count problem: {}",
+            returned.message
+        );
+        assert!(
+            !returned.message.contains("at capacity limit of"),
+            "must not use AtCapacity's wording for a MemoryBudgetExceeded rejection: {}",
+            returned.message
+        );
+        assert_eq!(
+            returned.data,
+            Some(serde_json::json!({ "session_restore_failure_reason": "memory_budget_exceeded" }))
+        );
+        assert!(service.state.get(session_id).await.is_none());
     }
 
     /// Positive counterpart to the confinement-rejection tests above: a legitimate, relative

--- a/crates/mcp-server/src/state.rs
+++ b/crates/mcp-server/src/state.rs
@@ -553,6 +553,16 @@ impl StateManager {
         table.sweep_expired(self.clock.as_ref());
         before - table.entries.len()
     }
+
+    /// Test-only hook to seed the table's running byte total directly, without paying for a
+    /// multi-hundred-megabyte allocation to organically reach [`MAX_TOTAL_PENDING_BYTES`] (this
+    /// module's own `test_store_rejects_when_would_exceed_memory_budget` does the same via direct
+    /// field access; `service.rs`'s tests need this instead, since `pending` is private to this
+    /// module).
+    #[cfg(test)]
+    pub(crate) async fn set_total_bytes_for_test(&self, total_bytes: usize) {
+        self.pending.write().await.total_bytes = total_bytes;
+    }
 }
 
 #[cfg(test)]
@@ -1033,5 +1043,100 @@ mod tests {
             matches!(result, Err(StateError::AtCapacity { limit }) if limit == MAX_PENDING_SESSIONS)
         );
         assert!(state.get(session_id).await.is_none());
+    }
+
+    /// Issue #387 gap 1 — `restore` re-inserts a session under its *original* `expires_at`
+    /// rather than granting a fresh TTL. Correct by construction (`restore` never touches that
+    /// field), but nothing previously exercised it: advances the shared clock past the session's
+    /// original expiry between checkout and `restore`, then proves the restored session is
+    /// immediately treated as expired by both `get` and `take_if` instead of being resurrected.
+    #[tokio::test]
+    async fn test_restore_does_not_extend_ttl_past_original_expiry() {
+        let start = chrono::Utc::now();
+        let clock = Arc::new(TestClock::new(start));
+        let state = StateManager::with_clock(Arc::clone(&clock) as Arc<dyn Clock>);
+
+        let pending = create_test_pending_with_clock(clock.as_ref());
+        let session_id = state.store(pending).await.unwrap();
+
+        let (generation, size_bytes, ()) = state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Advance the clock past the session's original expiry before restoring it.
+        clock.set(
+            start
+                + chrono::Duration::minutes(PendingGeneration::DEFAULT_TIMEOUT_MINUTES)
+                + chrono::Duration::seconds(1),
+        );
+
+        state
+            .restore(session_id, generation, size_bytes)
+            .await
+            .unwrap();
+
+        assert!(
+            state.get(session_id).await.is_none(),
+            "restore must not resurrect a session past its original expires_at"
+        );
+        let take_if_after_restore = state
+            .take_if(session_id, |_generation| Ok::<_, &str>(()))
+            .await;
+        assert!(
+            take_if_after_restore.is_none(),
+            "an expired restored session must not be handed to take_if's validate closure"
+        );
+    }
+
+    /// Issue #387 gap 2 - the write lock `take_if` holds across its whole validate-then-remove
+    /// sequence is what makes exactly one racing caller succeed; only `store`'s concurrency path
+    /// (`test_concurrent_access` above) had a regression test for this.
+    ///
+    /// Deliberately runs on a multi-thread runtime, an explicit, justified exception to this
+    /// project's no-`multi_thread`-by-default convention: under the default `current_thread`
+    /// runtime, spawned tasks are cooperatively scheduled on a single OS thread and can never
+    /// actually run in parallel inside `take_if`'s critical section, so a `current_thread`
+    /// version of this test is structurally incapable of detecting a broken (non-atomic)
+    /// `take_if`, no matter how many times it's repeated - only `multi_thread` gives concurrent
+    /// callers a chance to genuinely interleave there. Even under `multi_thread`, a single round
+    /// of this particular race is an unreliable detector, so it's repeated many times within the
+    /// test rather than run once; the whole test still completes in a few milliseconds, so the
+    /// extra rounds are effectively free.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_take_if_same_session_exactly_one_succeeds() {
+        let state = Arc::new(StateManager::new());
+
+        for _ in 0..200 {
+            let session_id = state.store(create_test_pending()).await.unwrap();
+
+            let mut handles = vec![];
+            for _ in 0..10 {
+                let state_clone = Arc::clone(&state);
+                handles.push(tokio::spawn(async move {
+                    state_clone
+                        .take_if(session_id, |_generation| Ok::<_, &str>(()))
+                        .await
+                }));
+            }
+
+            let mut successes = 0;
+            let mut misses = 0;
+            for handle in handles {
+                match handle.await.unwrap() {
+                    Some(Ok(_)) => successes += 1,
+                    None => misses += 1,
+                    Some(Err(e)) => panic!("validate always returns Ok in this test, got {e:?}"),
+                }
+            }
+
+            assert_eq!(successes, 1, "exactly one racing take_if must succeed");
+            assert_eq!(
+                misses, 9,
+                "every other racing take_if must observe the session as gone"
+            );
+            assert!(state.get(session_id).await.is_none());
+        }
     }
 }

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -236,11 +236,20 @@ issue #381).
    enforces the same `MAX_PENDING_SESSIONS`/`MAX_TOTAL_PENDING_BYTES` bounds
    `store` does (issue #379 S1 — see [[#State Management (StateManager)]]); if the
    table is already back at capacity by the time this call's checkout window ends,
-   `restore` returns `Err` and the session is genuinely lost — that failure is
-   logged (`GeneratorService::restore_or_log`), not surfaced to the client, since
-   the pipeline's own error is always the more relevant one to report. Only once
-   step 3 fully succeeds, or `restore` runs (successfully or not), is the session's
-   fate settled.
+   `restore` returns `Err` and the session is genuinely lost. That failure is
+   always logged server-side via `GeneratorService::restore_after_pipeline_failure`,
+   and — since issue #387 gap 3 — also folded into the `McpError` returned to the
+   client instead of being silently swallowed: the pipeline error's own message is
+   preserved, with `restore`'s actual `StateError` (`AtCapacity` or
+   `MemoryBudgetExceeded`, reported by its own `Display` text rather than a single
+   hardcoded cause) appended along with guidance to run `introspect_server` again
+   instead of retrying with the same `session_id`. `data` additionally carries a
+   machine-checkable `session_restore_failure_reason` field (`"at_capacity"` or
+   `"memory_budget_exceeded"`) via `session_lost_after_restore_failure`, so a
+   programmatic client doesn't have to substring-match prose to tell this compound
+   failure apart from an ordinary retriable pipeline error. Only once step 3 fully
+   succeeds, or `restore` runs (successfully or not), is the session's fate
+   settled.
 5. Does **not** observe request cancellation — a documented, deliberate
    choice: an earlier version raced the *lock wait* (not the export
    itself, which was already excluded) against cancellation, but that


### PR DESCRIPTION
## Summary

- Adds two regression tests flagged as non-blocking gaps during #386's review: `restore` re-inserting a session under its original `expires_at` rather than a fresh TTL, and exactly one of several racing `take_if` callers on the same `session_id` succeeding.
- Evaluates gap 3 (UX polish: capacity-rejected `restore` silently lost to the client) and implements a scoped fix — `restore_after_pipeline_failure` now folds the actual `restore` failure cause into the client-facing error, with a machine-checkable `session_restore_failure_reason` field in `data`.
- Updates `specs/server/spec.md` and `CHANGELOG.md` accordingly.

Closes #387.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1148 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New concurrency test verified non-flaky (multi_thread runtime, 200 repeated rounds; independently re-run 15x standalone with no failures)