### PR TITLE
refactor(files,skill): sort Cargo.toml dependencies alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **workspace**: sorted `[dependencies]` alphabetically in `mcp-execution-files` and
+  `mcp-execution-skill` (#391).
 - **CI**: extracted `cargo build --all-targets --all-features --workspace` out of the `test`
   job into a new, independent `build` job that runs on the same OS/toolchain matrix in
   parallel with `test` (nextest already builds what it needs on its own, so the two no longer

--- a/crates/mcp-files/Cargo.toml
+++ b/crates/mcp-files/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["development-tools", "filesystem"]
 workspace = true
 
 [dependencies]
-dirs.workspace = true
 dhat = { workspace = true, optional = true }
+dirs.workspace = true
 mcp-execution-codegen.workspace = true
 rayon = { workspace = true, optional = true }
 tempfile.workspace = true

--- a/crates/mcp-skill/Cargo.toml
+++ b/crates/mcp-skill/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["mcp", "skill", "claude-code", "codegen"]
 categories = ["development-tools"]
 
 [dependencies]
+handlebars = { workspace = true }
 mcp-execution-core = { workspace = true }
 regex = { workspace = true }
-handlebars = { workspace = true }
-thiserror = { workspace = true }
+schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_norway = { workspace = true }
-schemars = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
 


### PR DESCRIPTION
## Summary
- Reordered the `[dependencies]` block in `crates/mcp-files/Cargo.toml` and `crates/mcp-skill/Cargo.toml` to be strictly alphabetical, matching this project's documented workspace-structure convention.
- Only line order changed — no version, feature, or workspace-inheritance values were touched.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

Closes #391.

## Scope note
During implementation critique, two related items came up but were filed as separate follow-up issues rather than folded into this PR, since #391 scoped itself to exactly these two files:
- #396 — `crates/mcp-cli/Cargo.toml` has its own out-of-order `[dependencies]` entry.
- #397 — no CI gate (`cargo sort --check` or equivalent) currently prevents this from drifting back.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1148 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`