### PR TITLE
fix(introspector): narrow HTTP/SSE response-size doc claim and pin SSE bound explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **workspace**: sorted `[dependencies]` alphabetically in `mcp-execution-files` and
   `mcp-execution-skill` (#391).
+- **`mcp-execution-introspector`**: `discover_via_http` now sets
+  `StreamableHttpClientTransportConfig::max_sse_event_size` explicitly (16 MiB, matching `rmcp`
+  3.1.2's own default) instead of relying on it implicitly, so a future upstream default change
+  cannot silently loosen this crate's bound. Corrected the `# Security` docs on `discover_server`
+  and `discover_via_http`, and `specs/introspector/spec.md`, which still described the HTTP/SSE
+  path as entirely unbounded against `rmcp` 2.2.0: as of the now-locked `rmcp` 3.1.2, SSE events
+  are bounded; only the plain JSON response body and a non-2xx error body remain unbounded,
+  buffered fully in memory by `rmcp` with no config knob to cap either — a known upstream
+  limitation this crate cannot fix without reimplementing `rmcp`'s HTTP transport client-side
+  (#390).
 - **CI**: extracted `cargo build --all-targets --all-features --workspace` out of the `test`
   job into a new, independent `build` job that runs on the same OS/toolchain matrix in
   parallel with `test` (nextest already builds what it needs on its own, so the two no longer

--- a/crates/mcp-introspector/src/lib.rs
+++ b/crates/mcp-introspector/src/lib.rs
@@ -155,6 +155,18 @@ pub const MAX_SCHEMA_SIZE_BYTES: usize = 64 * 1024;
 /// (mirrors `mcp-execution-server`'s own documented behavior for the same codec).
 const MAX_RESPONSE_LINE_SIZE: usize = 4 * 1024 * 1024;
 
+/// Cap on a single SSE event's size for the HTTP/SSE transport (see
+/// [`Introspector::discover_server`]'s `# Security` docs for the JSON-body gap this
+/// does not close). Set explicitly in [`discover_via_http`] rather than left to
+/// `rmcp`'s implicit default, so a future upstream default change cannot silently
+/// loosen this crate's bound; pinned at 16 MiB to match `rmcp` 3.1.2's own
+/// `DEFAULT_MAX_SSE_EVENT_SIZE`, which is not part of `rmcp`'s public API. Kept at 16
+/// MiB rather than tightened to match the stdio path's 4 MiB [`MAX_RESPONSE_LINE_SIZE`]:
+/// this issue's goal was zero behavior change for a currently-working server, and
+/// tightening the effective bound was considered and deferred as a separate,
+/// potentially-breaking decision out of scope here.
+const HTTP_MAX_SSE_EVENT_SIZE: usize = 16 * 1024 * 1024;
+
 /// Information about an MCP server.
 ///
 /// Contains metadata about the server including its name, version,
@@ -365,17 +377,22 @@ impl Introspector {
     /// attribute a distinct error to, so the request it was answering instead runs out its
     /// configured timeout below and surfaces as [`Error::Timeout`].
     ///
-    /// The HTTP/SSE transport ([`Transport::Http`], [`Transport::Sse`], handled by
-    /// the private `discover_via_http`) has **no** such bound (issue #226): `rmcp` 2.2.0's Streamable
-    /// HTTP client transport buffers each JSON response body and each SSE event fully in
-    /// memory before this crate's own [`MAX_TOOL_COUNT`]/[`MAX_SCHEMA_SIZE_BYTES`] checks
-    /// ever run, with no size-limit config knob to bound that buffering. This is a known
-    /// upstream gap, not something fixable from this crate without re-implementing a large
-    /// part of `rmcp`'s HTTP transport. The only mitigation in place is
-    /// [`ServerConfig::discover_timeout`], which bounds how long an unbounded response can
-    /// be read for, not how large it can grow. rmcp 3.0.0-beta.2 adds the missing
-    /// `max_sse_event_size` config knob (still only for SSE events, not JSON response
-    /// bodies); revisit this gap once rmcp ships a 3.0.0 stable release with that fix.
+    /// The HTTP/SSE transport ([`Transport::Http`], [`Transport::Sse`], handled by the private
+    /// `discover_via_http`) is bounded on only one of its two response paths (issue #226,
+    /// narrowed by #390). `rmcp` 3.1.2 caps each SSE event at
+    /// `StreamableHttpClientTransportConfig::max_sse_event_size`, which `discover_via_http`
+    /// now sets explicitly to 16 MiB (matching rmcp's own default), rejecting an oversized
+    /// event instead of buffering it. The plain `application/json`
+    /// response path has no equivalent cap: rmcp deserializes that body via
+    /// `reqwest::Response::json`, buffering it fully in memory before this crate's own
+    /// [`MAX_TOOL_COUNT`]/[`MAX_SCHEMA_SIZE_BYTES`] checks ever run, and it reads a non-2xx
+    /// error body unbounded for the same reason. Neither has a config knob as of rmcp 3.1.2,
+    /// and there is no injection point below the transport: bounding them from this crate
+    /// would mean supplying a custom `StreamableHttpClient`, whose supporting helpers rmcp
+    /// keeps private, so it would trade the JSON bound for the loss of the SSE bound and of
+    /// reserved-header validation. The mitigation in place for the JSON path remains
+    /// [`ServerConfig::discover_timeout`], which bounds how long an unbounded body can be
+    /// read for, not how large it can grow.
     ///
     /// # Examples
     ///
@@ -1063,17 +1080,18 @@ async fn discover_via_stdio(
 /// Connects to an MCP server over Streamable HTTP and lists its tools, with
 /// each step bounded by `config`'s configured timeouts.
 ///
-/// Used for both [`Transport::Http`] and [`Transport::Sse`]: rmcp 2.2
+/// Used for both [`Transport::Http`] and [`Transport::Sse`]: rmcp 3.1.2
 /// has a single client transport for network MCP servers ("Streamable
 /// HTTP"), which superseded the standalone SSE transport in the 2025-03-26
 /// MCP spec revision. There is no legacy SSE-only client to fall back to.
 ///
-/// Unlike stdio discovery, this path has no response-size bound (issue #226): `rmcp`
-/// 2.2.0's Streamable HTTP client transport buffers each JSON response body and SSE
-/// event fully in memory with no config knob to cap it, and this crate has no
-/// injection point to add one without re-implementing a large part of that transport.
-/// See [`Introspector::discover_server`]'s `# Security` docs for the full rationale and
-/// the upstream condition to revisit this under.
+/// Unlike stdio discovery, this path's response-size bound is only partial (issue
+/// #226, narrowed by #390): SSE events are capped at [`HTTP_MAX_SSE_EVENT_SIZE`], set
+/// explicitly below via `max_sse_event_size` (matching `rmcp`'s own default), but the
+/// plain JSON response body — and a non-2xx error body — is still buffered fully in
+/// memory by `rmcp` with no config knob to cap it, and this crate has no injection
+/// point to add one without re-implementing a large part of that transport. See
+/// [`Introspector::discover_server`]'s `# Security` docs for the full rationale.
 ///
 /// # Errors
 ///
@@ -1111,7 +1129,9 @@ async fn discover_via_http(server_id: &ServerId, config: &ServerConfig) -> Resul
     // `StreamableHttpClientTransport<C>`, so this crate does not need to depend on `reqwest`
     // directly or name `reqwest::Client` to select it.
     let transport = StreamableHttpClientTransport::from_config(
-        StreamableHttpClientTransportConfig::with_uri(url).custom_headers(custom_headers),
+        StreamableHttpClientTransportConfig::with_uri(url)
+            .custom_headers(custom_headers)
+            .max_sse_event_size(HTTP_MAX_SSE_EVENT_SIZE),
     );
 
     // The client `connect_and_list_tools` builds internally is dropped when it returns, which
@@ -2603,6 +2623,25 @@ mod tests {
             "rmcp promoted ProtocolVersion::LATEST — this is the ADR-369 §5 revisit gate for \
              finding A (specs/decisions/ADR-369-rmcp-stateless-lifecycle-adoption.md): re-open \
              the ADR-369 discussion for finding A, do NOT just bump the expected constant"
+        );
+    }
+
+    // ── issue #390 HTTP_MAX_SSE_EVENT_SIZE drift gate ────────────────────────
+
+    /// Fails if `rmcp` changes `StreamableHttpClientTransportConfig`'s default
+    /// `max_sse_event_size`. A red assertion here is a signal to **re-evaluate**
+    /// [`HTTP_MAX_SSE_EVENT_SIZE`] against the new upstream default, in either
+    /// direction — it does not mean the test is wrong. Do not "fix" this
+    /// assertion by updating the expected value without first deciding whether
+    /// this crate's pinned bound should move too.
+    #[test]
+    fn test_http_max_sse_event_size_matches_rmcp_default() {
+        assert_eq!(
+            StreamableHttpClientTransportConfig::with_uri("localhost").max_sse_event_size,
+            HTTP_MAX_SSE_EVENT_SIZE,
+            "rmcp's default StreamableHttpClientTransportConfig::max_sse_event_size no longer \
+             matches this crate's HTTP_MAX_SSE_EVENT_SIZE — re-evaluate the pinned constant \
+             against the new upstream default, do NOT just bump the expected value"
         );
     }
 }

--- a/crates/mcp-introspector/tests/http_transport_test.rs
+++ b/crates/mcp-introspector/tests/http_transport_test.rs
@@ -175,7 +175,7 @@ async fn test_discover_server_http_lists_tools_and_metadata() {
     );
 }
 
-/// rmcp 2.2 has a single client transport for both `Http` and `Sse`
+/// rmcp 3.1.2 has a single client transport for both `Http` and `Sse`
 /// (`Transport::Sse` is documented as an alias) — this proves that
 /// end-to-end against a real server, not just at the type level.
 #[tokio::test]

--- a/crates/mcp-introspector/tests/tool_count_bound_test.rs
+++ b/crates/mcp-introspector/tests/tool_count_bound_test.rs
@@ -201,8 +201,8 @@ async fn test_discover_server_accepts_exactly_max_tool_count_across_pages() {
 
 /// Absolute path to the `fixture-paginated-stdio-server` binary built
 /// alongside this test target. Unlike [`PaginatedFixtureHandler`] above (HTTP
-/// only, issue #226's rationale for why HTTP has no response-size bound), the
-/// stdio path reads through `bounded_response_stream`, but pagination
+/// only, issue #226's rationale for why HTTP's JSON response body has no
+/// size bound), the stdio path reads through `bounded_response_stream`, but pagination
 /// early-bailout happens in `list_tools_bounded` before that bound is ever
 /// relevant — this fixture proves the same early-bailout logic used by the
 /// HTTP tests above also fires via stdio, closing the coverage gap noted in

--- a/specs/BRD-mcp-execution-2026-07-27.md
+++ b/specs/BRD-mcp-execution-2026-07-27.md
@@ -469,7 +469,7 @@ evidenced. See [[NFR-mcp-execution-2026-07-27#5. Usability]].
 - **A response-size bound on the HTTP/SSE introspection transport.**
   Documented as a known, currently-unfixable upstream (`rmcp`) limitation,
   not a deliberate scope decision, and not yet resolved
-  (`specs/introspector/spec.md#Known Gap: HTTP Response Size`).
+  (`specs/introspector/spec.md#Known Gap: HTTP JSON Response Size`).
 
 ## Integrations & Dependencies
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -122,7 +122,7 @@ resolve_server_config() [cli/common.rs]     introspect_server tool [server/servi
                               ▼
       Introspector::discover_server()  (mcp-introspector)
         — bounded stdio response-line decoder (4 MiB, WARN+drop on overflow)
-        — OR Streamable HTTP/SSE transport (rmcp) — NO response-size bound (documented gap)
+        — OR Streamable HTTP/SSE transport (rmcp) — SSE bounded, JSON body unbounded (documented gap)
         — pages tools/list, bails out early past MAX_TOOL_COUNT (1000)
         — per-tool name/description/schema size bounds
                               │

--- a/specs/introspector/spec.md
+++ b/specs/introspector/spec.md
@@ -87,9 +87,10 @@ concurrently-discovered servers' log output be correlated.
      instead of `rmcp`'s default unbounded `AsyncRwTransport`; always kills
      the child afterward regardless of outcome.
    - `Http`/`Sse` → `discover_via_http`: builds a `StreamableHttpClientTransport`
-     with caller headers converted to `http::HeaderValue`/`HeaderName`. **No
-     response-size bound exists on this path** — see
-     [[#Known gap HTTP response size]].
+     with caller headers converted to `http::HeaderValue`/`HeaderName`. **SSE
+     events are bounded** by `rmcp`'s `max_sse_event_size`, set explicitly to
+     match rmcp's own default; **JSON bodies (success and error) are
+     unbounded** — see [[#Known gap HTTP JSON response size]].
 
    Both branches converge on a single private `connect_and_list_tools`
    helper, generic over the connect future each transport builds (issue
@@ -153,18 +154,38 @@ bounds an already-trusted local client's requests).
   during an oversized-line attack can reach ~4x `MAX_RESPONSE_LINE_SIZE`
   before rejection — still strictly bounded, just not 1:1 with the cap.
 
-## 5. Known Gap: HTTP Response Size
+## 5. Known Gap: HTTP JSON Response Size
 
-`rmcp` 2.2.0's Streamable HTTP client transport buffers each JSON response
-body and each SSE event **fully in memory** before this crate's own
-`MAX_TOOL_COUNT`/`MAX_SCHEMA_SIZE_BYTES` checks ever run, with no
-`rmcp`-provided config knob to bound that buffering. The only mitigation is
-`ServerConfig::discover_timeout` (bounds *how long* an unbounded response
-can be read, not *how large* it can grow). This is documented as a known
-upstream limitation, not something fixable without reimplementing a large
-part of `rmcp`'s HTTP transport client-side; `rmcp` 3.0.0-beta.2 adds a
-`max_sse_event_size` knob (SSE only, not JSON bodies) — revisit once a
-3.0.0 stable ships.
+As of `rmcp` 3.1.2, SSE events are bounded: `discover_via_http` sets
+`StreamableHttpClientTransportConfig::max_sse_event_size` explicitly (16 MiB,
+matching `rmcp`'s own default, pinned locally so an upstream default change
+cannot silently loosen this crate's bound) — an oversized SSE event is
+rejected instead of buffered (issue #226, narrowed by #390).
+
+The plain JSON response path remains unbounded: `rmcp` deserializes it via
+`reqwest::Response::json`, buffering the body **fully in memory** before this
+crate's own `MAX_TOOL_COUNT`/`MAX_SCHEMA_SIZE_BYTES` checks ever run, with no
+`rmcp`-provided config knob to bound it. A non-2xx error response is read
+the same unbounded way and folded into the resulting error's message, so a
+hostile server can force a large buffer (plus a copy of it in the error
+value) by answering with an oversized error body — same root cause, no
+separate tracking needed. The only mitigation is
+`ServerConfig::discover_timeout` (bounds *how long* an unbounded body can be
+read, not *how large* it can grow).
+
+This is a known upstream limitation, not something fixable from this crate:
+the unbounded `.json()`/`.text()` calls live inside `rmcp`'s own
+`impl StreamableHttpClient for reqwest::Client`, and the only override point
+(`StreamableHttpClientTransport::with_client`) requires reimplementing
+`post_message`/`get_stream`/`delete_session` against helpers (`bounded_sse_stream`,
+`DEFAULT_MAX_SSE_EVENT_SIZE`, `validate_custom_header`, `RESERVED_HEADERS`)
+that `rmcp` keeps `pub(crate)`. Doing so would trade the JSON bound for the
+loss of the already-working SSE bound and of reserved-header validation — a
+net regression — while adding a direct `reqwest` dependency this crate
+deliberately avoids. A `Content-Length` pre-check is also unsound: the
+header is absent for chunked responses, exactly what an attacker would send.
+There is no version-gated condition left to revisit this under; it stays
+open until `rmcp` exposes a JSON-body size knob.
 
 ## 6. Error Conditions
 


### PR DESCRIPTION
## Summary
- `rmcp` 3.1.2 bounds SSE events by default (16 MiB via `StreamableHttpClientTransportConfig::max_sse_event_size`), closing half of the gap tracked by issue #226. The plain JSON response body and non-2xx error body remain unbounded upstream, with no injection point available below the transport without forfeiting the SSE bound and reserved-header validation (rmcp keeps the required helpers `pub(crate)`).
- Pin the previously-implicit 16 MiB default as an explicit `HTTP_MAX_SSE_EVENT_SIZE` constant in `discover_via_http`, with a drift test asserting it stays in sync with rmcp's actual default.
- Correct six stale doc/spec sites that still described the whole HTTP/SSE path as unbounded against `rmcp` 2.2.0, including two dangling anchor references uncovered during review.

Fixes #390. `specs/decisions/ADR-369-...md` §7 item 3 predicted this exact staleness as an out-of-scope follow-up; no ADR content changed here, this PR is that follow-up.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1149/1149 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`