### PR TITLE
refactor(core): consolidate path-confinement algorithm from server and skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   buffered fully in memory by `rmcp` with no config knob to cap either — a known upstream
   limitation this crate cannot fix without reimplementing `rmcp`'s HTTP transport client-side
   (#390).
+- **`mcp-execution-core`**: added `confinement::{ConfinementError, ConfinementTarget,
+  resolve_confined_path}`, the component-by-component resolve-and-confine filesystem walk
+  previously implemented separately (and identically, apart from the terminal-component check)
+  by `mcp-execution-server::output_dir::resolve_output_dir` and
+  `mcp-execution-skill::resolve_skill_output_path`. Both call sites now delegate to this shared
+  primitive and map its `ConfinementError` onto their own, unchanged `OutputDirError`/
+  `OutputPathError` public error enums via a total `From` impl — no observable change to either
+  crate's error surface, messages, or confinement/symlink-rejection behavior (#395). `mcp-core`
+  gains a direct (previously dev-only) `tokio` dependency (`fs` feature) as a result.
 - **CI**: extracted `cargo build --all-targets --all-features --workspace` out of the `test`
   job into a new, independent `build` job that runs on the same OS/toolchain matrix in
   parallel with `test` (nextest already builds what it needs on its own, so the two no longer

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -19,6 +19,7 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mcp-core/src/confinement.rs
+++ b/crates/mcp-core/src/confinement.rs
@@ -1,0 +1,617 @@
+//! Shared path-confinement algorithm for caller-supplied output paths.
+//!
+//! `mcp-execution-skill`'s `save_skill` and `mcp-execution-server`'s `introspect_server` both
+//! accept an optional caller-supplied relative path (`output_path`, `output_dir`) that must be
+//! confined to a per-server subdirectory of a trusted base directory: without confinement, an
+//! absolute path, a `..`-relative path, or a path that walks through a symlink planted inside
+//! the base directory lets a caller redirect a write anywhere the process can reach (issues
+//! #184, #216, #217). Both crates walked an identical component-by-component resolve-and-confine
+//! loop with their own error types; [`resolve_confined_path`] is that walk, extracted once so
+//! the two copies cannot silently drift apart.
+//!
+//! The absolute-path, `..`-component, and file-name pre-checks stay in each crate's own
+//! `relative_subpath`/`relative_target` helper, since callers disagree on what an *absent* path
+//! means (no subdirectory override, vs. the default `SKILL.md`) and on whether an empty result
+//! is legitimate. Only the shared filesystem walk — segment resolution, the lenient intermediate
+//! walk, and the terminal-component check — lives here.
+
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+use thiserror::Error;
+
+use crate::path::{sanitize_path_for_error, validate_path_segment};
+
+/// The terminal path component a [`resolve_confined_path`] walk resolves and confinement-checks
+/// but deliberately does not create.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::ConfinementTarget;
+/// use std::ffi::OsStr;
+///
+/// let target = ConfinementTarget::File(OsStr::new("SKILL.md"));
+/// assert!(matches!(target, ConfinementTarget::File(_)));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfinementTarget<'a> {
+    /// The caller publishes the directory itself (e.g. via an atomic staged rename), so the
+    /// resolved directory is confinement-checked and canonicalized but not created.
+    Directory(&'a OsStr),
+    /// The caller writes the file itself, so the resolved path is confinement-checked but
+    /// neither created nor canonicalized.
+    File(&'a OsStr),
+}
+
+/// Errors from walking and confining a path to a base directory.
+///
+/// Every variant is publicly constructible only by [`resolve_confined_path`] itself; callers map
+/// this enum into their own crate-specific error type with a total `From` implementation rather
+/// than matching on it directly, since two callers give the same failure different names (e.g.
+/// [`ConfinementError::WrongTargetKind`] means "not a directory" for one caller and "not a file"
+/// for the other).
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::{ConfinementError, resolve_confined_path};
+/// use std::path::Path;
+///
+/// // Segment validation runs before any filesystem access, so this fails synchronously.
+/// let err = tokio::runtime::Builder::new_current_thread()
+///     .build()
+///     .unwrap()
+///     .block_on(resolve_confined_path(Path::new("/base"), "..", Path::new(""), None))
+///     .unwrap_err();
+/// assert!(matches!(err, ConfinementError::InvalidSegment { .. }));
+/// ```
+#[derive(Debug, Error)]
+pub enum ConfinementError {
+    /// The path segment pushed onto the base directory (e.g. a `server_id`) is empty or is not
+    /// a single plain path component.
+    #[error("segment must be a single non-empty path segment: {segment:?}")]
+    InvalidSegment {
+        /// The rejected segment.
+        segment: String,
+    },
+
+    /// The segment's own directory already exists as a symlink, which is rejected outright
+    /// regardless of where it points - including at a sibling directory that still resolves
+    /// inside the base, which would otherwise pass a resolve-and-confine check (issue #217).
+    #[error("segment directory must not be a symlink: {path}")]
+    SegmentIsSymlink {
+        /// Sanitized display form of the offending path.
+        path: String,
+    },
+
+    /// The resolved path escapes the segment directory, typically because a path component
+    /// resolved through (or is itself) a symlink that points outside it.
+    #[error("resolved path escapes the confined directory: {path}")]
+    Escape {
+        /// Sanitized display form of the path that escaped confinement.
+        path: String,
+    },
+
+    /// A path component that must be a directory already exists as something else (e.g. a
+    /// regular file).
+    #[error("path component is not a directory: {path}")]
+    NotADirectory {
+        /// Sanitized display form of the offending component.
+        path: String,
+    },
+
+    /// The terminal component already exists as the kind of entry [`ConfinementTarget`] says it
+    /// isn't (a file where [`ConfinementTarget::Directory`] was expected, or a directory where
+    /// [`ConfinementTarget::File`] was expected).
+    #[error("path exists as the wrong kind of entry: {path}")]
+    WrongTargetKind {
+        /// Sanitized display form of the offending path.
+        path: String,
+    },
+
+    /// Creating a directory needed along the path failed.
+    #[error("failed to create directory {path}: {source}")]
+    CreateDir {
+        /// Sanitized display form of the directory that could not be created.
+        path: String,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// I/O error resolving the base directory or a path component.
+    #[error("failed to resolve confined path: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Resolves `segment`, then `relative_dirs`, then `target` (if any), confining every step to
+/// `base_dir/segment`.
+///
+/// `segment` is validated as a single plain path component (see [`validate_path_segment`]) and
+/// pushed onto `base_dir` (canonicalized once, since `base_dir` itself is trusted, first-party
+/// configuration rather than caller input). It is rejected outright if it already exists as a
+/// symlink, regardless of where it points, since a resolve-and-confine check alone would accept
+/// a symlink from a sibling directory that still resolves under `base_dir` (issue #217).
+///
+/// `relative_dirs` must already be `..`-free and non-absolute — callers reject those shapes in
+/// their own pre-check before calling this function, since what an absent or empty path means
+/// differs by caller. Each of its components is confined to the resolved segment directory (not
+/// merely to `base_dir` as a whole) and created if missing; an existing symlink is followed only
+/// if it still resolves inside the segment directory.
+///
+/// `target`, when supplied, names the walk's terminal component. It is confinement-checked but
+/// deliberately never created: a [`ConfinementTarget::Directory`] is resolved and canonicalized
+/// (the caller typically publishes it itself via an atomic staged rename), while a
+/// [`ConfinementTarget::File`] is checked but left exactly as constructed, uncanonicalized, since
+/// the caller is about to create it. `target: None` returns the walked `relative_dirs` chain
+/// itself. Either way the terminal component is rejected outright if it already exists as a
+/// symlink, dangling or not: a dangling symlink can't be resolved by `canonicalize`, but would
+/// still be followed by a subsequent write, so it is checked with `symlink_metadata` instead.
+///
+/// Each component is created and confinement-checked one at a time (rather than via a single
+/// recursive create-and-canonicalize), so a symlink already present under `base_dir` when this
+/// call starts — whether at `segment` or at any deeper component — is resolved and rejected
+/// *before* this function creates anything under it or descends into it. This is a check against
+/// pre-existing state, not a concurrency guarantee: it does not defend against a symlink planted
+/// by a racing process between this function's checks and the caller's subsequent write.
+///
+/// # Errors
+///
+/// Returns [`ConfinementError`] if `segment` is empty or not a single plain path segment, if
+/// `segment`'s own directory already exists as a symlink, if the resolved path escapes
+/// `base_dir/segment` at any step, if a required directory could not be created, if a path
+/// component that must be a directory already exists as something else, or if `target`'s
+/// terminal component already exists as the wrong kind of entry.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_core::{ConfinementTarget, resolve_confined_path};
+/// use std::ffi::OsStr;
+/// use std::path::Path;
+///
+/// # async fn example() -> Result<(), mcp_execution_core::ConfinementError> {
+/// let path = resolve_confined_path(
+///     Path::new("/home/user/.claude/skills"),
+///     "github",
+///     Path::new(""),
+///     Some(ConfinementTarget::File(OsStr::new("SKILL.md"))),
+/// )
+/// .await?;
+/// println!("Resolved to {}", path.display());
+/// # Ok(())
+/// # }
+/// ```
+pub async fn resolve_confined_path(
+    base_dir: &Path,
+    segment: &str,
+    relative_dirs: &Path,
+    target: Option<ConfinementTarget<'_>>,
+) -> Result<PathBuf, ConfinementError> {
+    let component =
+        validate_path_segment(segment).ok_or_else(|| ConfinementError::InvalidSegment {
+            segment: segment.to_string(),
+        })?;
+
+    tokio::fs::create_dir_all(base_dir)
+        .await
+        .map_err(|source| ConfinementError::CreateDir {
+            path: sanitize_path_for_error(base_dir),
+            source,
+        })?;
+    let canonical_root = tokio::fs::canonicalize(base_dir).await?;
+
+    let segment_dir = resolve_segment_dir(&canonical_root, component).await?;
+
+    let mut current = segment_dir.clone();
+    for dir_component in relative_dirs.components() {
+        current.push(dir_component);
+        resolve_lenient_component(&mut current, &segment_dir).await?;
+    }
+
+    match target {
+        None => Ok(current),
+        Some(target) => resolve_terminal(current, &segment_dir, target).await,
+    }
+}
+
+/// Resolves and confines `segment`'s own directory under `canonical_root`, rejecting it outright
+/// if it already exists as a symlink rather than resolving and re-checking it (see
+/// [`resolve_confined_path`]'s doc comment for why). Creates the directory if it doesn't exist
+/// yet.
+async fn resolve_segment_dir(
+    canonical_root: &Path,
+    component: Component<'_>,
+) -> Result<PathBuf, ConfinementError> {
+    let mut segment_dir = canonical_root.to_path_buf();
+    segment_dir.push(component);
+    if !segment_dir.starts_with(canonical_root) {
+        return Err(ConfinementError::Escape {
+            path: sanitize_path_for_error(&segment_dir),
+        });
+    }
+    if let Ok(meta) = tokio::fs::symlink_metadata(&segment_dir).await {
+        if meta.file_type().is_symlink() {
+            return Err(ConfinementError::SegmentIsSymlink {
+                path: sanitize_path_for_error(&segment_dir),
+            });
+        }
+        if !meta.is_dir() {
+            return Err(ConfinementError::NotADirectory {
+                path: sanitize_path_for_error(&segment_dir),
+            });
+        }
+    } else {
+        tokio::fs::create_dir(&segment_dir)
+            .await
+            .map_err(|source| ConfinementError::CreateDir {
+                path: sanitize_path_for_error(&segment_dir),
+                source,
+            })?;
+    }
+    Ok(segment_dir)
+}
+
+/// Confines `current` to `segment_dir`, resolving (and confirming) an existing symlink rather
+/// than rejecting it outright, or creating the directory if it's missing.
+async fn resolve_lenient_component(
+    current: &mut PathBuf,
+    segment_dir: &Path,
+) -> Result<(), ConfinementError> {
+    if !current.starts_with(segment_dir) {
+        return Err(ConfinementError::Escape {
+            path: sanitize_path_for_error(current),
+        });
+    }
+    match tokio::fs::symlink_metadata(&current).await {
+        Ok(_) => {
+            let resolved = tokio::fs::canonicalize(&current).await?;
+            if !resolved.starts_with(segment_dir) {
+                return Err(ConfinementError::Escape {
+                    path: sanitize_path_for_error(current),
+                });
+            }
+            if !tokio::fs::metadata(&resolved).await?.is_dir() {
+                return Err(ConfinementError::NotADirectory {
+                    path: sanitize_path_for_error(current),
+                });
+            }
+            *current = resolved;
+            Ok(())
+        }
+        Err(_) => {
+            tokio::fs::create_dir(&current)
+                .await
+                .map_err(|source| ConfinementError::CreateDir {
+                    path: sanitize_path_for_error(current),
+                    source,
+                })
+        }
+    }
+}
+
+/// Resolves and confinement-checks the walk's terminal component per `target`, without creating
+/// it. See [`ConfinementTarget`] and [`resolve_confined_path`]'s doc comment for the deliberate
+/// asymmetry between the two variants.
+async fn resolve_terminal(
+    mut current: PathBuf,
+    segment_dir: &Path,
+    target: ConfinementTarget<'_>,
+) -> Result<PathBuf, ConfinementError> {
+    match target {
+        ConfinementTarget::Directory(name) => {
+            current.push(name);
+            if !current.starts_with(segment_dir) {
+                return Err(ConfinementError::Escape {
+                    path: sanitize_path_for_error(&current),
+                });
+            }
+            if let Ok(meta) = tokio::fs::symlink_metadata(&current).await {
+                if meta.file_type().is_symlink() {
+                    return Err(ConfinementError::Escape {
+                        path: sanitize_path_for_error(&current),
+                    });
+                }
+                let resolved = tokio::fs::canonicalize(&current).await?;
+                if !resolved.starts_with(segment_dir) {
+                    return Err(ConfinementError::Escape {
+                        path: sanitize_path_for_error(&current),
+                    });
+                }
+                if !meta.is_dir() {
+                    return Err(ConfinementError::WrongTargetKind {
+                        path: sanitize_path_for_error(&current),
+                    });
+                }
+                current = resolved;
+            }
+            Ok(current)
+        }
+        ConfinementTarget::File(name) => {
+            let final_path = current.join(name);
+            if let Ok(meta) = tokio::fs::symlink_metadata(&final_path).await {
+                if meta.file_type().is_symlink() {
+                    return Err(ConfinementError::Escape {
+                        path: sanitize_path_for_error(&final_path),
+                    });
+                }
+                if meta.is_dir() {
+                    return Err(ConfinementError::WrongTargetKind {
+                        path: sanitize_path_for_error(&final_path),
+                    });
+                }
+            }
+            Ok(final_path)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn target_none_returns_segment_dir_and_creates_nothing_beyond_it() {
+        let base = TempDir::new().unwrap();
+        let resolved = resolve_confined_path(base.path(), "my-server", Path::new(""), None)
+            .await
+            .unwrap();
+        let canonical_base = base.path().canonicalize().unwrap();
+        assert_eq!(resolved, canonical_base.join("my-server"));
+    }
+
+    #[tokio::test]
+    async fn leading_cur_dir_resolves_like_its_normalized_form() {
+        let base = TempDir::new().unwrap();
+        let with_cur_dir = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new("./nested"),
+            Some(ConfinementTarget::File(OsStr::new("out.txt"))),
+        )
+        .await
+        .unwrap();
+        let normalized = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new("nested"),
+            Some(ConfinementTarget::File(OsStr::new("out.txt"))),
+        )
+        .await
+        .unwrap();
+        assert_eq!(with_cur_dir, normalized);
+    }
+
+    #[tokio::test]
+    async fn segment_empty_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::InvalidSegment { .. }));
+    }
+
+    #[tokio::test]
+    async fn segment_with_parent_traversal_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "..", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::InvalidSegment { .. }));
+    }
+
+    #[tokio::test]
+    async fn segment_with_path_separator_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "a/b", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::InvalidSegment { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn segment_dir_symlink_to_outside_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        std::os::unix::fs::symlink(outside.path(), base.path().join("my-server")).unwrap();
+
+        let err = resolve_confined_path(base.path(), "my-server", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::SegmentIsSymlink { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn segment_dir_symlink_to_sibling_is_rejected() {
+        let base = TempDir::new().unwrap();
+        tokio::fs::create_dir_all(base.path().join("server-a"))
+            .await
+            .unwrap();
+        std::os::unix::fs::symlink(base.path().join("server-a"), base.path().join("server-b"))
+            .unwrap();
+
+        let err = resolve_confined_path(base.path(), "server-b", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::SegmentIsSymlink { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn segment_dir_that_is_a_regular_file_is_rejected() {
+        let base = TempDir::new().unwrap();
+        tokio::fs::write(base.path().join("my-server"), "oops")
+            .await
+            .unwrap();
+
+        let err = resolve_confined_path(base.path(), "my-server", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::NotADirectory { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn lenient_walk_symlinked_intermediate_escape_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let server_dir = base.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        std::os::unix::fs::symlink(outside.path(), server_dir.join("escape")).unwrap();
+
+        let err = resolve_confined_path(base.path(), "my-server", Path::new("escape/custom"), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::Escape { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn lenient_walk_regular_file_intermediate_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let server_dir = base.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        tokio::fs::write(server_dir.join("not-a-dir"), "oops")
+            .await
+            .unwrap();
+
+        let err = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new("not-a-dir/custom"),
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ConfinementError::NotADirectory { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn lenient_walk_symlink_loop_surfaces_as_io() {
+        let base = TempDir::new().unwrap();
+        let server_dir = base.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        std::os::unix::fs::symlink("a", server_dir.join("a")).unwrap();
+
+        let err = resolve_confined_path(base.path(), "my-server", Path::new("a/custom"), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::Io(_)));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn dangling_symlink_at_terminal_is_rejected_under_both_targets() {
+        let base = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let dangling_target = outside.path().join("does-not-exist");
+
+        let server_dir = base.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        std::os::unix::fs::symlink(&dangling_target, server_dir.join("custom")).unwrap();
+
+        let dir_err = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new(""),
+            Some(ConfinementTarget::Directory(OsStr::new("custom"))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(dir_err, ConfinementError::Escape { .. }));
+
+        let file_err = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new(""),
+            Some(ConfinementTarget::File(OsStr::new("custom"))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(file_err, ConfinementError::Escape { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn symlink_to_existing_outside_file_at_terminal_is_rejected_under_both_targets() {
+        let base = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("real");
+        tokio::fs::write(&outside_file, "outside").await.unwrap();
+
+        let server_dir = base.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        std::os::unix::fs::symlink(&outside_file, server_dir.join("custom")).unwrap();
+
+        let dir_err = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new(""),
+            Some(ConfinementTarget::Directory(OsStr::new("custom"))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(dir_err, ConfinementError::Escape { .. }));
+
+        let file_err = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new(""),
+            Some(ConfinementTarget::File(OsStr::new("custom"))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(file_err, ConfinementError::Escape { .. }));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn terminal_exists_as_the_other_kind_under_both_targets() {
+        let base = TempDir::new().unwrap();
+        let server_dir = base.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        tokio::fs::write(server_dir.join("custom"), "oops")
+            .await
+            .unwrap();
+
+        // A regular file where a directory was expected.
+        let dir_err = resolve_confined_path(
+            base.path(),
+            "my-server",
+            Path::new(""),
+            Some(ConfinementTarget::Directory(OsStr::new("custom"))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(dir_err, ConfinementError::WrongTargetKind { .. }));
+
+        // A directory where a file was expected.
+        let other_server_dir = base.path().join("other-server");
+        tokio::fs::create_dir_all(other_server_dir.join("custom"))
+            .await
+            .unwrap();
+        let file_err = resolve_confined_path(
+            base.path(),
+            "other-server",
+            Path::new(""),
+            Some(ConfinementTarget::File(OsStr::new("custom"))),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(file_err, ConfinementError::WrongTargetKind { .. }));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_root_relative_intermediate_cannot_escape_base() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "my-server", Path::new(r"\pwn\evil"), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ConfinementError::Escape { .. }));
+    }
+}

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -32,6 +32,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 
 mod command;
+mod confinement;
 mod error;
 mod path;
 mod redact;
@@ -60,6 +61,9 @@ pub use command::{
 
 // Re-export path helpers shared by confinement checks
 pub use path::{contains_parent_dir, sanitize_path_for_error, validate_path_segment};
+
+// Re-export the shared path-confinement walk
+pub use confinement::{ConfinementError, ConfinementTarget, resolve_confined_path};
 
 // Re-export Debug-redaction helpers shared by secret-shaped fields
 pub use redact::{

--- a/crates/mcp-server/src/output_dir.rs
+++ b/crates/mcp-server/src/output_dir.rs
@@ -20,7 +20,10 @@
 //! confinement check that matters runs as close to the actual write as this two-step protocol
 //! allows.
 
-use mcp_execution_core::sanitize_path_for_error;
+use mcp_execution_core::{
+    ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
+    validate_path_segment,
+};
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
@@ -91,23 +94,26 @@ pub enum OutputDirError {
     Io(#[from] std::io::Error),
 }
 
-/// Validates `server_id` is a single plain path segment: non-empty, and with no `..`, path
-/// separator, or root/prefix component.
+/// Maps the shared [`ConfinementError`] onto [`OutputDirError`]'s own, pre-existing variant set.
 ///
-/// `service::introspect_server` already validates `server_id` via `validate_server_id` (a
-/// tighter lowercase-letter/digit/hyphen charset check) before either this function or
-/// [`resolve_output_dir`] ever runs, but this function does not trust that: it delegates to
-/// `mcp_execution_core::validate_path_segment`, shared with `mcp-execution-skill`'s equivalent
-/// check for `save_skill`'s `server_id`, so `resolve_output_dir` is self-defending against a
-/// `server_id` that reaches it some other way (or after a future change loosens the
-/// caller-side check) rather than only being safe today because `introspect_server` happens to
-/// validate first.
-fn validate_server_id_component(server_id: &str) -> Result<Component<'_>, OutputDirError> {
-    mcp_execution_core::validate_path_segment(server_id).ok_or_else(|| {
-        OutputDirError::InvalidServerId {
-            server_id: server_id.to_string(),
+/// This is a 1:1 rename, not a lossy union: [`ConfinementError::WrongTargetKind`] becomes
+/// [`OutputDirError::NotADirectory`] here (the terminal component `resolve_output_dir` walks is
+/// always a directory), which is the only variant this crate names differently than
+/// `mcp-execution-skill`'s equivalent `From` impl.
+impl From<ConfinementError> for OutputDirError {
+    fn from(err: ConfinementError) -> Self {
+        match err {
+            ConfinementError::InvalidSegment { segment } => {
+                Self::InvalidServerId { server_id: segment }
+            }
+            ConfinementError::SegmentIsSymlink { path } => Self::ServerDirIsSymlink { path },
+            ConfinementError::Escape { path } => Self::Escape { path },
+            ConfinementError::NotADirectory { path }
+            | ConfinementError::WrongTargetKind { path } => Self::NotADirectory { path },
+            ConfinementError::CreateDir { path, source } => Self::CreateDir { path, source },
+            ConfinementError::Io(source) => Self::Io(source),
         }
-    })
+    }
 }
 
 /// Validates a caller-supplied `output_dir` and returns it as a safe, base-relative path, or
@@ -147,94 +153,20 @@ pub fn relative_subpath(output_dir: Option<&Path>) -> Result<PathBuf, OutputDirE
     Ok(path.to_path_buf())
 }
 
-/// Confines `current` to `root`, rejecting it outright if it already exists as a symlink -
-/// regardless of where it points - rather than resolving and re-checking it. Creates the
-/// directory if it doesn't exist yet.
-///
-/// Used only for the `server_id` component: a symlink there could point at a sibling server's
-/// own directory, which still resolves under `root` and would therefore pass a resolve-and-
-/// confine check. Rejecting any pre-existing symlink at this exact component closes that gap
-/// (the same one tracked for `save_skill` in issue #217) rather than merely narrowing it.
-async fn resolve_component_strict(current: &Path, root: &Path) -> Result<(), OutputDirError> {
-    if !current.starts_with(root) {
-        return Err(OutputDirError::Escape {
-            path: sanitize_path_for_error(current),
-        });
-    }
-    match tokio::fs::symlink_metadata(current).await {
-        Ok(meta) => {
-            if meta.file_type().is_symlink() {
-                return Err(OutputDirError::ServerDirIsSymlink {
-                    path: sanitize_path_for_error(current),
-                });
-            }
-            if !meta.is_dir() {
-                return Err(OutputDirError::NotADirectory {
-                    path: sanitize_path_for_error(current),
-                });
-            }
-            Ok(())
-        }
-        Err(_) => {
-            tokio::fs::create_dir(current)
-                .await
-                .map_err(|source| OutputDirError::CreateDir {
-                    path: sanitize_path_for_error(current),
-                    source,
-                })
-        }
-    }
-}
-
-/// Confines `current` to `root`, resolving (and confirming) an existing symlink rather than
-/// rejecting it outright, or creating the directory if it's missing.
-///
-/// Used for `output_dir` subdirectory components other than `server_id`, mirroring
-/// `resolve_skill_output_path`'s intermediate-component handling: a symlink already present
-/// here is followed only if it still resolves inside `root`.
-async fn resolve_component_lenient(
-    current: &mut PathBuf,
-    root: &Path,
-) -> Result<(), OutputDirError> {
-    if !current.starts_with(root) {
-        return Err(OutputDirError::Escape {
-            path: sanitize_path_for_error(current),
-        });
-    }
-    match tokio::fs::symlink_metadata(&current).await {
-        Ok(_) => {
-            let resolved = tokio::fs::canonicalize(&current).await?;
-            if !resolved.starts_with(root) {
-                return Err(OutputDirError::Escape {
-                    path: sanitize_path_for_error(current),
-                });
-            }
-            if !tokio::fs::metadata(&resolved).await?.is_dir() {
-                return Err(OutputDirError::NotADirectory {
-                    path: sanitize_path_for_error(current),
-                });
-            }
-            *current = resolved;
-            Ok(())
-        }
-        Err(_) => {
-            tokio::fs::create_dir(&current)
-                .await
-                .map_err(|source| OutputDirError::CreateDir {
-                    path: sanitize_path_for_error(current),
-                    source,
-                })
-        }
-    }
-}
-
 /// Resolves an `introspect_server` output directory, confining it to `base_dir/server_id`.
 ///
-/// `server_id` is validated as a single plain path segment before anything else (defensively -
-/// see [`validate_server_id_component`]) and then pushed onto `base_dir`. `output_dir`, when
-/// supplied, is treated as *relative* to `base_dir/server_id`: an absolute path or a path
-/// containing a `..` component is rejected before any filesystem work happens. `None` resolves
-/// to `base_dir/server_id` itself.
+/// `server_id` is validated as a single plain path segment **before** `output_dir` is checked at
+/// all, matching this crate's pre-#395 error precedence: a caller supplying both an invalid
+/// `server_id` and an invalid `output_dir` sees [`OutputDirError::InvalidServerId`], not a
+/// relative-path error. `server_id` and `output_dir`'s directory components are then walked and
+/// confinement-checked by the shared [`resolve_confined_path`], which defensively re-validates
+/// `server_id` itself as its first step - even though it is already validated twice by the time
+/// it gets there (`service::introspect_server`'s tighter `validate_server_id` charset check, then
+/// the early check this function performs) - so `resolve_confined_path` stays self-defending
+/// against a `server_id` that reaches it some other way. `output_dir`, when supplied, is treated
+/// as *relative* to `base_dir/server_id`: an absolute path or a path containing a `..` component
+/// is rejected by [`relative_subpath`] before any filesystem work happens. `None` resolves to
+/// `base_dir/server_id` itself.
 ///
 /// Every directory component up to (but not including) the final target - `server_id`'s own
 /// directory, plus any but the last directory component of `output_dir` - is confinement-
@@ -273,62 +205,32 @@ pub async fn resolve_output_dir(
     server_id: &str,
     output_dir: Option<&Path>,
 ) -> Result<PathBuf, OutputDirError> {
-    let server_component = validate_server_id_component(server_id)?;
-    let relative = relative_subpath(output_dir)?;
-
-    tokio::fs::create_dir_all(base_dir)
-        .await
-        .map_err(|source| OutputDirError::CreateDir {
-            path: sanitize_path_for_error(base_dir),
-            source,
-        })?;
-    let canonical_root = tokio::fs::canonicalize(base_dir).await?;
-
-    let mut server_dir = canonical_root.clone();
-    server_dir.push(server_component);
-    resolve_component_strict(&server_dir, &canonical_root).await?;
-
-    let sub_components: Vec<Component<'_>> = relative.components().collect();
-    let Some((last, init)) = sub_components.split_last() else {
-        // No output_dir override: the target directory is server_dir itself.
-        return Ok(server_dir);
-    };
-
-    let mut current = server_dir.clone();
-    for component in init {
-        current.push(component);
-        resolve_component_lenient(&mut current, &server_dir).await?;
-    }
-
-    // Final component: the directory `export_to_filesystem` later publishes into via an
-    // atomic staged rename, so it is confinement-checked but deliberately not created here.
-    current.push(last);
-    if !current.starts_with(&server_dir) {
-        return Err(OutputDirError::Escape {
-            path: sanitize_path_for_error(&current),
+    // Validated again, I/O-free, before `relative_subpath` so an invalid `server_id` is reported
+    // even when `output_dir` is also invalid - matching this crate's pre-#395 error precedence
+    // (`resolve_confined_path` re-validates it a second time as part of its own walk).
+    if validate_path_segment(server_id).is_none() {
+        return Err(OutputDirError::InvalidServerId {
+            server_id: server_id.to_string(),
         });
     }
-    if let Ok(meta) = tokio::fs::symlink_metadata(&current).await {
-        if meta.file_type().is_symlink() {
-            return Err(OutputDirError::Escape {
-                path: sanitize_path_for_error(&current),
-            });
-        }
-        let resolved = tokio::fs::canonicalize(&current).await?;
-        if !resolved.starts_with(&server_dir) {
-            return Err(OutputDirError::Escape {
-                path: sanitize_path_for_error(&current),
-            });
-        }
-        if !meta.is_dir() {
-            return Err(OutputDirError::NotADirectory {
-                path: sanitize_path_for_error(&current),
-            });
-        }
-        current = resolved;
-    }
 
-    Ok(current)
+    let relative = relative_subpath(output_dir)?;
+
+    let sub_components: Vec<Component<'_>> = relative.components().collect();
+    let (relative_dirs, target) = match sub_components.split_last() {
+        // No output_dir override: the target directory is server_id's own directory.
+        None => (PathBuf::new(), None),
+        // Final component: the directory `export_to_filesystem` later publishes into via an
+        // atomic staged rename, so it is confinement-checked but deliberately not created.
+        Some((last, init)) => (
+            init.iter().copied().collect::<PathBuf>(),
+            Some(ConfinementTarget::Directory(last.as_os_str())),
+        ),
+    };
+
+    resolve_confined_path(base_dir, server_id, &relative_dirs, target)
+        .await
+        .map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -431,6 +333,22 @@ mod tests {
     async fn empty_server_id_is_rejected() {
         let base = TempDir::new().unwrap();
         let err = resolve_output_dir(base.path(), "", None).await.unwrap_err();
+        assert!(matches!(err, OutputDirError::InvalidServerId { .. }));
+    }
+
+    /// When both `server_id` and `output_dir` are invalid, `InvalidServerId` must win - matching
+    /// the error precedence this function had before the #395 confinement-walk extraction.
+    #[tokio::test]
+    async fn invalid_server_id_takes_precedence_over_invalid_output_dir() {
+        let base = TempDir::new().unwrap();
+        let absolute = if cfg!(windows) {
+            r"C:\Windows\System32\config"
+        } else {
+            "/etc"
+        };
+        let err = resolve_output_dir(base.path(), "", Some(Path::new(absolute)))
+            .await
+            .unwrap_err();
         assert!(matches!(err, OutputDirError::InvalidServerId { .. }));
     }
 

--- a/crates/mcp-skill/src/output_path.rs
+++ b/crates/mcp-skill/src/output_path.rs
@@ -8,8 +8,11 @@
 //! confinement already used by [`crate::scan_tools_directory`], adapted for
 //! a target that may not exist yet.
 
-use mcp_execution_core::sanitize_path_for_error;
-use std::path::{Component, Path, PathBuf};
+use mcp_execution_core::{
+    ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
+    validate_path_segment,
+};
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Errors from resolving and confining a skill output path to its base directory.
@@ -94,31 +97,26 @@ pub enum OutputPathError {
     Io(#[from] std::io::Error),
 }
 
-/// Validates `server_id` is a single plain path segment: non-empty, and
-/// with no `..`, path separator, or root/prefix component.
+/// Maps the shared [`ConfinementError`] onto [`OutputPathError`]'s own, pre-existing variant set.
 ///
-/// `server_id` is walked through the same confinement loop as
-/// `output_path`'s directory components (see [`resolve_skill_output_path`]),
-/// so a `..` or absolute `server_id` would eventually be caught there too —
-/// this check rejects it earlier, before any filesystem work, and gives a
-/// precise error rather than relying on the generic `Escape` path.
-///
-/// Returns the validated [`Component`] itself (borrowed from `server_id`),
-/// rather than just `Ok(())`, so the caller pushes the exact component this
-/// function parsed and approved instead of re-deriving one from the raw
-/// string — which could diverge from this validation on an input like
-/// `"a/."`, where `Path::components()` normalizes away the trailing `.` and
-/// this function sees a single `Normal("a")`, but a fresh
-/// `Component::Normal(OsStr::new("a/."))` would still carry the embedded
-/// separator. Delegates to `mcp_execution_core::validate_path_segment`, shared
-/// with `mcp-execution-server`'s equivalent check for `introspect_server`'s
-/// `output_dir`, so both crates reject the same malformed `server_id` shapes.
-fn validate_server_id_segment(server_id: &str) -> Result<Component<'_>, OutputPathError> {
-    mcp_execution_core::validate_path_segment(server_id).ok_or_else(|| {
-        OutputPathError::InvalidServerId {
-            server_id: server_id.to_string(),
+/// This is a 1:1 rename, not a lossy union: [`ConfinementError::WrongTargetKind`] becomes
+/// [`OutputPathError::NotAFile`] here (the terminal component `resolve_skill_output_path` walks
+/// is always a file), which is the only variant this crate names differently than
+/// `mcp-execution-server`'s equivalent `From` impl.
+impl From<ConfinementError> for OutputPathError {
+    fn from(err: ConfinementError) -> Self {
+        match err {
+            ConfinementError::InvalidSegment { segment } => {
+                Self::InvalidServerId { server_id: segment }
+            }
+            ConfinementError::SegmentIsSymlink { path } => Self::ServerIdIsSymlink { path },
+            ConfinementError::Escape { path } => Self::Escape { path },
+            ConfinementError::NotADirectory { path } => Self::NotADirectory { path },
+            ConfinementError::WrongTargetKind { path } => Self::NotAFile { path },
+            ConfinementError::CreateDir { path, source } => Self::CreateDir { path, source },
+            ConfinementError::Io(source) => Self::Io(source),
         }
-    })
+    }
 }
 
 /// Validates a caller-supplied `output_path` and returns it as a safe,
@@ -149,40 +147,41 @@ fn relative_target(output_path: Option<&Path>) -> Result<PathBuf, OutputPathErro
 
 /// Resolves a `save_skill` output path, confining it to `base_dir/server_id`.
 ///
-/// `server_id` and `output_path` are both attacker-influenced, so both are
-/// walked through the *same* checked component loop, rooted at `base_dir`
-/// (canonicalized once, since `base_dir` itself is trusted, first-party
-/// configuration rather than caller input): `server_id` is pushed as the
-/// first component, followed by `output_path`'s directory components, if
-/// any. `output_path`, when supplied, is treated as *relative* to
-/// `base_dir/server_id`: an absolute path or a path containing a `..`
-/// component is rejected before any filesystem work happens. `None`
-/// resolves to the default `SKILL.md`. Confining to `base_dir/server_id`
-/// (rather than just `base_dir`) matches the documented `save_skill`
-/// contract, in the sense that both the default path and every accepted
+/// `server_id` is validated as a single plain path segment **before** `output_path` is checked
+/// at all, matching this crate's pre-#395 error precedence: a caller supplying both an invalid
+/// `server_id` and an invalid `output_path` sees [`OutputPathError::InvalidServerId`], not a
+/// relative-path error - `mcp_execution_server`'s `save_skill` handler keeps `InvalidServerId` in
+/// its own error-classification arm specifically for external callers of this public function
+/// that skip its own upstream `validate_server_id` check, so masking it behind a relative-path
+/// error would defeat that.
+///
+/// `server_id` and `output_path` are both attacker-influenced, so both are walked and
+/// confinement-checked by the shared [`resolve_confined_path`], rooted at `base_dir`: `server_id`
+/// is resolved as the confined segment, followed by `output_path`'s directory components, if
+/// any. `output_path`, when supplied, is treated as *relative* to `base_dir/server_id`: an
+/// absolute path, a path containing a `..` component, or a path with no file name is rejected by
+/// `relative_target` before any filesystem work happens. `None` resolves to the default
+/// `SKILL.md`. Confining to `base_dir/server_id` (rather than just `base_dir`) matches the
+/// documented `save_skill` contract, in the sense that both the default path and every accepted
 /// `output_path` land under `server_id`'s own directory.
 ///
-/// `server_id`'s own directory is resolved before anything else and is
-/// rejected outright if it already exists as a symlink, regardless of where
-/// it points: a resolve-and-confine check alone would accept a symlink from
-/// `base_dir/server-b` to `base_dir/server-a`, since the target still
-/// resolves under `base_dir` (issue #217). Every subsequent `output_path`
-/// directory component is then confined to that resolved `server_id`
-/// directory specifically, not merely to `base_dir` as a whole, so no
-/// deeper component can reach a different server's directory either.
+/// `server_id`'s own directory is resolved before anything else and is rejected outright if it
+/// already exists as a symlink, regardless of where it points: a resolve-and-confine check alone
+/// would accept a symlink from `base_dir/server-b` to `base_dir/server-a`, since the target still
+/// resolves under `base_dir` (issue #217). Every subsequent `output_path` directory component is
+/// then confined to that resolved `server_id` directory specifically, not merely to `base_dir` as
+/// a whole, so no deeper component can reach a different server's directory either.
 ///
-/// Each component is created and confinement-checked one at a time (rather
-/// than via a single recursive create-and-canonicalize), so that a symlink
-/// already present under `base_dir` when this call starts — whether *at*
-/// `server_id` or at any deeper `output_path` directory component — is
-/// resolved and rejected *before* this function creates anything under it
-/// or descends into it. This is a check against pre-existing state, not a
-/// concurrency guarantee — it does not defend against a symlink planted by
-/// a racing process between this function's checks and the caller's
-/// subsequent write. The final path component is rejected outright if it
-/// already exists as a symlink, dangling or not: a dangling symlink can't
-/// be resolved by `canonicalize`, but would still be followed by a
-/// subsequent write, so it is checked with `symlink_metadata` instead.
+/// Each component is created and confinement-checked one at a time (rather than via a single
+/// recursive create-and-canonicalize), so that a symlink already present under `base_dir` when
+/// this call starts — whether *at* `server_id` or at any deeper `output_path` directory component
+/// — is resolved and rejected *before* this function creates anything under it or descends into
+/// it. This is a check against pre-existing state, not a concurrency guarantee — it does not
+/// defend against a symlink planted by a racing process between this function's checks and the
+/// caller's subsequent write. The final path component is rejected outright if it already exists
+/// as a symlink, dangling or not: a dangling symlink can't be resolved by `canonicalize`, but
+/// would still be followed by a subsequent write, so it is checked with `symlink_metadata`
+/// instead.
 ///
 /// # Errors
 ///
@@ -212,97 +211,16 @@ pub async fn resolve_skill_output_path(
     server_id: &str,
     output_path: Option<&Path>,
 ) -> Result<PathBuf, OutputPathError> {
-    let server_component = validate_server_id_segment(server_id)?;
-    let relative = relative_target(output_path)?;
-
-    tokio::fs::create_dir_all(base_dir)
-        .await
-        .map_err(|source| OutputPathError::CreateDir {
-            path: sanitize_path_for_error(base_dir),
-            source,
-        })?;
-    let canonical_root = tokio::fs::canonicalize(base_dir).await?;
-
-    // Resolve server_id's own directory first, rejecting it outright if it already exists as
-    // a symlink - regardless of where it points - rather than resolving and re-checking it as
-    // the loop below does for deeper components. A symlink here could point at a *sibling*
-    // server's own directory, which still resolves under `canonical_root` and would therefore
-    // pass a resolve-and-confine check; only an unconditional rejection closes that gap
-    // (issue #217). Every subsequent component is then confined to `server_dir` specifically,
-    // not just to `canonical_root` as a whole, so a caller scoped to this `server_id` can never
-    // reach another server's directory through a deeper `output_path` component either.
-    let mut server_dir = canonical_root.clone();
-    server_dir.push(server_component);
-    if !server_dir.starts_with(&canonical_root) {
-        return Err(OutputPathError::Escape {
-            path: sanitize_path_for_error(&server_dir),
+    // Validated again, I/O-free, before `relative_target` so an invalid `server_id` is reported
+    // even when `output_path` is also invalid - matching this crate's pre-#395 error precedence
+    // (`resolve_confined_path` re-validates it a second time as part of its own walk).
+    if validate_path_segment(server_id).is_none() {
+        return Err(OutputPathError::InvalidServerId {
+            server_id: server_id.to_string(),
         });
     }
-    match tokio::fs::symlink_metadata(&server_dir).await {
-        Ok(meta) => {
-            if meta.file_type().is_symlink() {
-                return Err(OutputPathError::ServerIdIsSymlink {
-                    path: sanitize_path_for_error(&server_dir),
-                });
-            }
-            if !meta.is_dir() {
-                return Err(OutputPathError::NotADirectory {
-                    path: sanitize_path_for_error(&server_dir),
-                });
-            }
-        }
-        Err(_) => {
-            tokio::fs::create_dir(&server_dir).await.map_err(|source| {
-                OutputPathError::CreateDir {
-                    path: sanitize_path_for_error(&server_dir),
-                    source,
-                }
-            })?;
-        }
-    }
 
-    let output_dir_components = relative
-        .parent()
-        .map(|parent| parent.components().collect::<Vec<_>>())
-        .unwrap_or_default();
-
-    let mut current = server_dir.clone();
-    for component in output_dir_components {
-        current.push(component);
-        // Cheap for a `..`-free relative path pushed onto an absolute root (a
-        // named component can't leave it), but load-bearing on Windows: a
-        // root-without-prefix component like `\pwn` is not caught by
-        // `Path::is_absolute` and would otherwise reach `create_dir` unconfined.
-        if !current.starts_with(&server_dir) {
-            return Err(OutputPathError::Escape {
-                path: sanitize_path_for_error(&current),
-            });
-        }
-        match tokio::fs::symlink_metadata(&current).await {
-            Ok(_) => {
-                let resolved = tokio::fs::canonicalize(&current).await?;
-                if !resolved.starts_with(&server_dir) {
-                    return Err(OutputPathError::Escape {
-                        path: sanitize_path_for_error(&current),
-                    });
-                }
-                if !tokio::fs::metadata(&resolved).await?.is_dir() {
-                    return Err(OutputPathError::NotADirectory {
-                        path: sanitize_path_for_error(&current),
-                    });
-                }
-                current = resolved;
-            }
-            Err(_) => {
-                tokio::fs::create_dir(&current).await.map_err(|source| {
-                    OutputPathError::CreateDir {
-                        path: sanitize_path_for_error(&current),
-                        source,
-                    }
-                })?;
-            }
-        }
-    }
+    let relative = relative_target(output_path)?;
 
     // `relative_target` already guarantees a file name is present; re-checked
     // here (rather than `.expect`-ed) so this function has no panic surface.
@@ -311,26 +229,16 @@ pub async fn resolve_skill_output_path(
             path: sanitize_path_for_error(&relative),
         });
     };
-    let final_path = current.join(file_name);
+    let relative_dirs = relative.parent().unwrap_or_else(|| Path::new(""));
 
-    if let Ok(meta) = tokio::fs::symlink_metadata(&final_path).await {
-        // Reject unconditionally, independent of whether `canonicalize`
-        // would succeed: a dangling symlink (target does not exist) makes
-        // canonicalize fail, which must not be treated as "safe, doesn't
-        // exist yet" — a subsequent write still follows the link.
-        if meta.file_type().is_symlink() {
-            return Err(OutputPathError::Escape {
-                path: sanitize_path_for_error(&final_path),
-            });
-        }
-        if meta.is_dir() {
-            return Err(OutputPathError::NotAFile {
-                path: sanitize_path_for_error(&final_path),
-            });
-        }
-    }
-
-    Ok(final_path)
+    resolve_confined_path(
+        base_dir,
+        server_id,
+        relative_dirs,
+        Some(ConfinementTarget::File(file_name)),
+    )
+    .await
+    .map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -385,6 +293,24 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    /// When both `server_id` and `output_path` are invalid, `InvalidServerId` must win - matching
+    /// the error precedence this function had before the #395 confinement-walk extraction, and
+    /// the precedence `service.rs`'s `save_skill` handler relies on for external callers that
+    /// skip its own upstream `validate_server_id` check.
+    #[tokio::test]
+    async fn invalid_server_id_takes_precedence_over_invalid_output_path() {
+        let base = TempDir::new().unwrap();
+        let absolute = if cfg!(windows) {
+            r"C:\Windows\System32\config"
+        } else {
+            "/etc/passwd"
+        };
+        let err = resolve_skill_output_path(base.path(), "", Some(Path::new(absolute)))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OutputPathError::InvalidServerId { .. }));
     }
 
     #[tokio::test]

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -46,8 +46,15 @@ related:
      (producer) and `mcp-skill`/`mcp-server` (consumers).
    - `path` — `sanitize_path_for_error` (used by `mcp-skill` and
      `mcp-server` for identical error-message redaction) and
-     `validate_path_segment` (used by both for identical `server_id`
-     path-segment validation).
+     `contains_parent_dir` (used by both, plus `mcp-cli`, for identical
+     `..`-traversal checks); `validate_path_segment` backs `ServerId`/
+     `ToolName` and, since #395, `confinement::resolve_confined_path`
+     internally.
+   - `confinement` — `resolve_confined_path` (issue #395), the shared
+     component-by-component resolve-and-confine filesystem walk used by both
+     `mcp-skill::resolve_skill_output_path` and
+     `mcp-server::output_dir::resolve_output_dir`, previously two independent
+     copies of the same algorithm.
    - `redact` — `Debug`-redaction wrapper types (`RedactedItems`,
      `RedactedMapValues`, `RedactedUrl`) used by `ServerConfig` itself and
      by `mcp-cli`'s CLI-argument types.
@@ -274,15 +281,68 @@ pub fn sanitize_path_for_error(path: &Path) -> String; // redacts home dir to "~
 pub fn validate_path_segment(segment: &str) -> Option<Component<'_>>; // single plain component, no "..", no separator
 pub fn contains_parent_dir(path: &Path) -> bool; // true if any component is `..`
 ```
-`validate_path_segment` is the shared building block for both
-`mcp-skill::resolve_skill_output_path` and
-`mcp-server::output_dir::resolve_output_dir`'s `server_id` confinement — a
-`..` or embedded separator in `server_id` is rejected identically by both;
-it also backs `ServerId::new`/`ToolName::new`'s own invariant (see above).
+`validate_path_segment` backs `ServerId::new`/`ToolName::new`'s own invariant (see above) and,
+since #395, is used internally by `confinement::resolve_confined_path` to validate the `segment`
+(`server_id`) it's given — `mcp-skill` and `mcp-server` no longer call it directly, since the
+confinement walk itself validates `server_id` as part of resolving it.
 `contains_parent_dir` (issue #289) is the shared `..`-only check used by
 `mcp-skill::output_path`, `mcp-server::output_dir`, and
 `mcp-cli::commands::skill::has_path_traversal` for the narrower "is any
 component `..`" question, previously three byte-for-byte-identical copies.
+
+### `confinement` module (`src/confinement.rs`)
+
+```rust
+pub enum ConfinementTarget<'a> { Directory(&'a OsStr), File(&'a OsStr) }
+pub enum ConfinementError {
+    InvalidSegment { segment: String },
+    SegmentIsSymlink { path: String },
+    Escape { path: String },
+    NotADirectory { path: String },
+    WrongTargetKind { path: String },
+    CreateDir { path: String, source: std::io::Error },
+    Io(#[from] std::io::Error),
+}
+pub async fn resolve_confined_path(
+    base_dir: &Path,
+    segment: &str,
+    relative_dirs: &Path,
+    target: Option<ConfinementTarget<'_>>,
+) -> Result<PathBuf, ConfinementError>;
+```
+
+Issue #395: `mcp-skill::resolve_skill_output_path` and
+`mcp-server::output_dir::resolve_output_dir` independently implemented the same
+component-by-component resolve-and-confine walk (validate the `server_id` segment, canonicalize
+`base_dir` once, confine-and-create the segment directory rejecting any pre-existing symlink at
+it outright, then confine-and-create each further directory component leniently — following an
+existing symlink only if it still resolves inside the segment directory — before
+confinement-checking, but deliberately not creating, the terminal component). `resolve_confined_path`
+is that walk extracted once; the two crates differ only in what an *absent* input path means and
+in whether the terminal component is a directory or a file, both of which stay at the call site
+(see [[../server/spec#6. Output Directory Resolution (`output_dir.rs`)]] and
+[[../skill/spec#8. `resolve_skill_output_path` — Path Confinement]]).
+
+`ConfinementTarget` names the walk's terminal component without creating it: `Directory` is
+resolved and canonicalized (the typical caller publishes it itself via an atomic staged rename),
+`File` is confinement-checked but left uncanonicalized (the caller is about to create it) —
+this asymmetry is deliberate and preserved from both crates' pre-consolidation behavior, not
+unified away. `target: None` returns the walked `relative_dirs` chain itself, with nothing beyond
+the segment directory created.
+
+`ConfinementError` is a closed set every caller maps with a **total, 1:1** `From` impl into its
+own pre-existing, byte-identical error enum — `mcp-server::OutputDirError` and
+`mcp-skill::OutputPathError` — rather than matching on `ConfinementError` directly. The single
+`ConfinementError::WrongTargetKind` variant carries two different truthful call-site meanings:
+`OutputDirError::NotADirectory` (the terminal `resolve_output_dir` walks is always a directory)
+and `OutputPathError::NotAFile` (the terminal `resolve_skill_output_path` walks is always a
+file) — one core variant, zero unreachable arms in either `From` impl. `ConfinementError::InvalidSegment`/`SegmentIsSymlink`/`Escape`/`NotADirectory`/`CreateDir`/`Io` map
+1:1 by name to each crate's own variant of the same name (`InvalidSegment` → `InvalidServerId`,
+`SegmentIsSymlink` → `ServerDirIsSymlink`/`ServerIdIsSymlink`). The absolute-path, `..`-component,
+and file-name pre-checks (`relative_subpath`/`relative_target`) are **not** part of this module —
+they stay in each crate, since an absent path means "use the segment directory as-is" for
+`mcp-server` but "use the default `SKILL.md`" for `mcp-skill`, and only a crate-specific helper
+can express that.
 
 ### `redact` module (`src/redact.rs`)
 
@@ -367,8 +427,8 @@ data into text an LLM later reads as instructions — see
 | `mcp-introspector` | `ServerConfig`, `ServerId`, `ToolName`, `Transport`, `validate_server_config`, `Error`/`Result` |
 | `mcp-codegen` | `Error`/`Result`, `metadata::*` (writes `_meta.json`), `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix` (renders them into the generated runtime bridge template) |
 | `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen` |
-| `mcp-skill` | `sanitize_path_for_error`, `validate_path_segment`, `untrusted::*`, `metadata::*` |
-| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `validate_path_segment`, `untrusted::*` |
+| `mcp-skill` | `sanitize_path_for_error`, `contains_parent_dir`, `untrusted::*`, `metadata::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
+| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
 | `mcp-cli` | `cli::{OutputFormat, ExitCode}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |
 
 ## 4. Defense in Depth
@@ -382,6 +442,16 @@ spawning/connecting anyway — not because it's needed to close a gap, but so th
 stays self-defending against a future construction path that forgets to validate, rather than
 relying solely on the invariant holding elsewhere.
 
+`resolve_confined_path` (issue #395) re-validates its `segment` argument via
+`validate_path_segment` on every call rather than trusting a caller's own upstream check (e.g.
+`mcp-server::service::introspect_server`'s tighter `validate_server_id` charset check) to have
+already run — the same self-defending posture: a future call site that reaches this function
+with an unvalidated `segment` is still caught here, not silently trusted. Both `mcp-skill` and
+`mcp-server` keep their own crate-specific `OutputPathError`/`OutputDirError` enums as the public
+error surface rather than exposing `ConfinementError` directly, so a caller matching on either
+enum sees no observable change from before #395 — the `From<ConfinementError>` impls are total
+and byte-preserving of each variant's existing `Display` message.
+
 ## 5. Edge Cases & Notable Behaviors (from tests)
 
 | Scenario | Behavior |
@@ -394,9 +464,14 @@ relying solely on the invariant holding elsewhere.
 | Absolute-path command that exists but lacks the execute bit | Rejected (Unix only) |
 | `sanitize_path_for_error` on a mounted/bind-mounted home directory | Falls back to scrubbing the bare username substring when the leading-prefix match fails |
 | `RedactedUrl` on `https://user:p/w@host/mcp` (unencoded `/` in password) | Whole URL redacted — the authority-terminator ambiguity check fires |
+| `resolve_confined_path` terminal component is a dangling symlink, under either `ConfinementTarget` | Rejected as `Escape` — checked via `symlink_metadata`, not `metadata`/`canonicalize`, so a target that can't be resolved is never mistaken for "doesn't exist yet" |
+| `resolve_confined_path` terminal component exists as the other `ConfinementTarget` kind (file where `Directory` expected, or vice versa) | `WrongTargetKind`, mapped by each caller to its own truthful variant name |
+| `resolve_confined_path` with `target: None` | Returns the walked `relative_dirs` chain itself; nothing beyond the segment directory is created |
+| `resolve_confined_path`'s lenient intermediate walk hits a symlink loop (`ELOOP`) | Surfaces as `Io`, not `Escape` — `canonicalize`'s error propagates via `?` before any confinement comparison runs |
 
 ## 6. See Also
 
 - [[../introspector/spec]] — primary consumer of `ServerConfig`/`validate_server_config`
 - [[../cli/spec]] — consumer of `cli::{OutputFormat,ExitCode}` and the error-classification contract
+- [[../server/spec#6. Output Directory Resolution (`output_dir.rs`)]] / [[../skill/spec#8. `resolve_skill_output_path` — Path Confinement]] — the two `confinement::resolve_confined_path` consumers
 - [[../constitution]] — security principles this crate embodies workspace-wide

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -396,7 +396,11 @@ fields) but not log message text.
 ## 6. Output Directory Resolution (`output_dir.rs`)
 
 Mirrors `mcp-skill`'s `resolve_skill_output_path` for a directory target
-rather than a file:
+rather than a file. Since #395, both share the same filesystem walk —
+`mcp_execution_core::resolve_confined_path` (see
+[[../core/spec#`confinement` module (`src/confinement.rs`)]]) — with the
+absolute-path/`..` pre-check and the terminal-component choice staying local
+to each crate:
 
 - `relative_subpath` (I/O-free) is all `introspect_server` runs — reject
   fast, commit to nothing, create nothing.
@@ -413,11 +417,22 @@ rather than a file:
   already consumed (rather than before, as an earlier version of this fix
   had it) is safe specifically because a failure here now triggers
   `state.restore` (issue #379) exactly like any other post-consume pipeline
-  failure, so it costs nothing in retriability.
+  failure, so it costs nothing in retriability. Internally it calls
+  `resolve_confined_path` with `ConfinementTarget::Directory(name)` as the
+  terminal target and maps `ConfinementError` onto `OutputDirError` via a
+  total `From` impl (see §9) — `ConfinementError::WrongTargetKind` becomes
+  `OutputDirError::NotADirectory`, the only renamed variant.
 - The **final** target directory is confinement-checked but deliberately
   **not created** here — `FileSystem::export_to_filesystem` publishes it
   atomically via a staged rename, and pre-creating it would defeat that
   atomicity on a first-time `generate`.
+
+`resolve_list_base_dir` (`service.rs`) is a **third**, deliberately separate
+implementation of a related but weaker idea — it stays out of scope for #395
+(see [[../core/spec#`confinement` module (`src/confinement.rs`)]] and §11
+below): it is read-only (`read_dir`), constructs `OutputDirError` variants
+directly, and is exhaustively matched at two call sites, so `OutputDirError`
+must stay fully constructible/matchable outside the confinement module.
 
 ## 7. Prompt Injection Defense
 
@@ -481,7 +496,12 @@ environment's fault — I/O failure, task join error, serialization failure).
   `FileSystem`, `mcp-skill::{scan_tools_directory, build_skill_context,
   resolve_skill_output_path, extract_skill_metadata, validate_server_id,
   MAX_TOOL_FILES}`, `mcp-core::{ServerConfig, ServerId,
-  sanitize_path_for_error, validate_path_segment, untrusted::*}`.
+  sanitize_path_for_error, untrusted::*, confinement::{ConfinementError,
+  ConfinementTarget, resolve_confined_path}}` (the last three, since #395,
+  used only by `output_dir::resolve_output_dir`; `resolve_list_base_dir`
+  reuses `output_dir.rs`'s own `relative_subpath` and hand-rolls its own,
+  weaker confinement check rather than calling `resolve_confined_path`,
+  since it is out of scope for the confinement consolidation — see §6).
 - **Schema drift guards**: `service.rs`'s own tests assert the `schemars`-
   derived schema for `CategorizedTool`/`SaveCategorizedToolsParams`/
   `IntrospectServerParams` matches the real runtime constants

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -215,10 +215,16 @@ evaluation this characteristic factored into.
 Confines `save_skill`'s optional `output_path` to `base_dir/server_id`
 (issue #184's fix — without this, an absolute path, `..`, or a
 symlink-planted-inside-`base_dir` path could write anywhere the process can
-reach):
+reach). Since #395, the filesystem walk itself is `mcp_execution_core::resolve_confined_path`
+(see [[../core/spec#`confinement` module (`src/confinement.rs`)]]) — this function is a thin
+call-through: `relative_target` rejects an absolute path, a `..` component, or a missing file
+name before any filesystem work; the rest is delegated with
+`ConfinementTarget::File(file_name)` as the terminal target, and
+`ConfinementError` is mapped onto `OutputPathError` by a total `From` impl (see §9).
 
-- `server_id` and `output_path` walk the **same** checked, one-component-
-  at-a-time loop, rooted at a once-canonicalized `base_dir`.
+- `server_id` and `output_path`'s directory components walk the **same**
+  checked, one-component-at-a-time loop, rooted at a once-canonicalized
+  `base_dir`.
 - `server_id`'s own directory is checked **first** and rejected outright if
   it already exists as a symlink, regardless of where it points — including
   at a *sibling* server's own directory, which would otherwise pass a
@@ -231,7 +237,8 @@ reach):
 - The final path component is rejected outright if it exists as a symlink,
   **dangling or not** — a dangling symlink makes `canonicalize` fail, which
   must not be treated as "safe, doesn't exist yet" (a subsequent write
-  would still follow it).
+  would still follow it). Unlike the directory components, the final file is
+  never canonicalized even when it doesn't yet exist as a symlink.
 - This is a check against **pre-existing** state at call time — not a
   concurrency guarantee against a symlink planted by a racing process
   between this check and the caller's write.
@@ -255,7 +262,9 @@ reach):
 
 - **Consumes** `mcp-core`: `metadata::{METADATA_FILE_NAME,
   METADATA_SCHEMA_VERSION, ServerMetadata}`, `sanitize_path_for_error`,
-  `validate_path_segment`, `untrusted::*`.
+  `untrusted::*`, and (since #395) `confinement::{ConfinementError,
+  ConfinementTarget, resolve_confined_path}` for `resolve_skill_output_path`'s
+  walk.
 - **Used by** `mcp-cli skill` (directly calls `scan_tools_directory` +
   `build_skill_context` + `render_skill_md`, no LLM/prompt step — see
   [[../cli/spec#skill]]).


### PR DESCRIPTION
## Summary

- Extracts the shared base-directory confinement walk (absolute/traversal rejection, symlink-race defense at the `server_id` segment, resolve-and-reconfirm for intermediate segments) that `mcp-execution-server::output_dir` and `mcp-execution-skill::output_path` each reimplemented separately into a single primitive: `mcp_execution_core::confinement::resolve_confined_path`, parameterized over `ConfinementTarget::Directory`/`::File`.
- `OutputDirError` and `OutputPathError` keep their existing public variant sets unchanged, via total `From<ConfinementError>` mappings — no observable change to either crate's error surface or confinement/symlink-rejection behavior.
- `resolve_list_base_dir` in `mcp-server::service` is a third, narrower confinement check left untouched — out of scope for this change (candidate for a follow-up issue).
- `mcp-execution-core` gains a direct `tokio` dependency (`fs` feature, previously dev-only).
- Updates `specs/core/spec.md`, `specs/server/spec.md`, `specs/skill/spec.md`, and `CHANGELOG.md` in the same change.

Closes #395.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1164/1164 passed, +2 regression tests pinning `server_id`-validation precedence)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Existing symlink-race/path-traversal regression tests from #216/#217/#184 in both crates left untouched, verified byte-identical against origin/master