### PR TITLE
refactor(core): consolidate server_id slug validation into mcp-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mcp-execution-core`**: added `validate_server_id_slug`, `ServerIdSlugError`, and
+  `MAX_SERVER_ID_LENGTH` — the authoritative, core-owned invariant for a slug-shaped server id
+  (1-64 lowercase ASCII letters, digits, or hyphens), distinct from `ServerId::new()`'s own
+  looser baseline (single non-empty path segment, no `..`/separator), which is left unchanged.
+  `mcp-execution-skill`'s `validate_server_id` now delegates to it, and `SkillServerIdError` is
+  now a re-export of `ServerIdSlugError` rather than a hand-rolled, structurally identical mirror
+  type — the previous mirror had already let the two crates' error wording drift apart (MCP
+  clients and the CLI disagreed on identical input), which a re-export makes impossible rather
+  than merely fixing once. `mcp-execution-server`'s tool handlers (`introspect_server`,
+  `generate_skill`, `save_skill`) call the core function directly instead of importing
+  `mcp_execution_skill::validate_server_id`. Also fixes a gate/confine mismatch: the
+  output-confinement checks in `mcp-execution-server`'s `output_dir` and `mcp-execution-skill`'s
+  `output_path` previously confined a `server_id` using the looser `validate_path_segment` even
+  though entry validation already gated it with the stricter slug rule; both now confine using
+  the same `validate_server_id_slug` check that gates entry, and their `InvalidServerId` error
+  now carries and reports the specific slug-format violation instead of a hardcoded "must be a
+  single non-empty path segment" message that became inaccurate once the confinement rule
+  tightened (e.g. `"My-Server"` is a valid path segment but not a valid slug) (#401).
+- **`mcp-execution-core`**: `path::components_match`'s `TODO` comment is now accurate about the
+  ASCII-only case-folding gap: it previously claimed `scrub_username`'s fallback mitigates a
+  non-ASCII username differing only by case (e.g. Cyrillic), but that fallback shares the same
+  ASCII-only limitation and does not actually catch this case — the username is not redacted.
+  The comment now states this plainly and tracks the real fix as a new follow-up (#406) rather
+  than closing the loop with an inaccurate mitigation claim. No behavior change (#402).
 - **workspace**: sorted `[dependencies]` alphabetically in `mcp-execution-files` and
   `mcp-execution-skill` (#391).
 - **`mcp-execution-introspector`**: `discover_via_http` now sets

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -47,7 +47,10 @@ pub mod untrusted;
 pub use error::{Error, ResourceKind, Result};
 
 // Re-export domain types
-pub use types::{ServerId, ServerIdError, ToolName, ToolNameError};
+pub use types::{
+    MAX_SERVER_ID_LENGTH, ServerId, ServerIdError, ServerIdSlugError, ToolName, ToolNameError,
+    validate_server_id_slug,
+};
 
 // Re-export server configuration types
 pub use server_config::{ServerConfig, ServerConfigBuilder, Transport};

--- a/crates/mcp-core/src/path.rs
+++ b/crates/mcp-core/src/path.rs
@@ -3,9 +3,10 @@
 //! Confinement checks in `mcp-execution-skill` (`save_skill`'s `output_path`) and
 //! `mcp-execution-server` (`introspect_server`'s `output_dir`) report the offending path back
 //! to the caller. [`sanitize_path_for_error`] is the one place that redaction happens, so both
-//! crates report errors with the same privacy guarantee. [`validate_path_segment`] is the one
-//! place both crates validate a caller-supplied `server_id` as a single plain path component,
-//! so a `..` or path-separator smuggled into it is rejected identically by both.
+//! crates report errors with the same privacy guarantee. [`validate_path_segment`] backs
+//! `ServerId::new`/`ToolName::new`'s own baseline path-segment invariant; the stricter,
+//! filesystem-safe-*slug* rule both crates' `server_id` confinement checks enforce lives in
+//! [`crate::validate_server_id_slug`] instead (see its own doc comment for why).
 
 use std::path::{Component, Path};
 
@@ -93,8 +94,14 @@ fn scrub_username(path: &Path, home: &Path) -> String {
 
 #[cfg(any(windows, target_os = "macos"))]
 fn components_match(home: Component<'_>, path: Component<'_>) -> bool {
-    // TODO(critic): ASCII-only case folding misses non-ASCII usernames (e.g. Cyrillic); the
-    // scrub_username fallback in sanitize_path_for_error covers that gap.
+    // TODO(#406): ASCII-only case folding misses a non-ASCII username that differs only by
+    // case (e.g. Cyrillic "Аня" vs "аня") — NOT mitigated by scrub_username's fallback below:
+    // replace_case_aware's Windows/macOS arm folds case the same ASCII-only way (see its own
+    // doc comment), so a case-differing non-ASCII username is redacted by neither path and
+    // survives verbatim in the sanitized output. Unaffected on other platforms, which compare
+    // path components exactly rather than case-insensitively. Accepted as a known, low-severity
+    // residual gap for now (#406): a correct fix needs Unicode-aware case folding that preserves
+    // replace_case_aware's byte-offset alignment invariant, not a naive `to_lowercase` swap.
     home.as_os_str()
         .to_string_lossy()
         .eq_ignore_ascii_case(&path.as_os_str().to_string_lossy())

--- a/crates/mcp-core/src/types.rs
+++ b/crates/mcp-core/src/types.rs
@@ -57,6 +57,12 @@ pub enum ServerIdError {
 /// since server IDs are ultimately confined into filesystem paths (e.g.
 /// `~/.claude/servers/{server_id}`).
 ///
+/// This baseline invariant is deliberately looser than [`validate_server_id_slug`]'s: a
+/// `ServerId` may contain uppercase letters, underscores, or other path-segment-safe
+/// characters that are not valid in a filesystem-safe *slug*. If you need the id to become a
+/// directory name or generated-code identifier — not just a safe path segment — validate it
+/// with [`validate_server_id_slug`] too, in addition to constructing it here.
+///
 /// # Examples
 ///
 /// ```
@@ -151,6 +157,85 @@ impl fmt::Display for ServerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// Maximum length, in bytes, of a slug-shaped server id (see [`validate_server_id_slug`]).
+pub const MAX_SERVER_ID_LENGTH: usize = 64;
+
+/// Errors returned by [`validate_server_id_slug`].
+///
+/// Every message names the parameter as `server_id` (matching the MCP tool JSON field and this
+/// crate's other `server_id`-named APIs) rather than "server id" — callers surface these
+/// messages verbatim to end users/MCP clients, so wording here must stay actionable and
+/// consistent with every other layer that reports the same rejection.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ServerIdSlugError {
+    /// The candidate was empty.
+    #[error("server_id must not be empty")]
+    Empty,
+
+    /// The candidate exceeded [`MAX_SERVER_ID_LENGTH`].
+    #[error("server_id too long: {len} chars exceeds {limit} limit")]
+    TooLong {
+        /// Actual length of the rejected id, in bytes (`str::len`, not `chars().count()`).
+        len: usize,
+        /// Maximum allowed length ([`MAX_SERVER_ID_LENGTH`]).
+        limit: usize,
+    },
+
+    /// The candidate contained a character other than a lowercase ASCII letter, digit, or
+    /// hyphen.
+    #[error("server_id must contain only lowercase letters, digits, and hyphens")]
+    InvalidCharacters,
+}
+
+/// Validates that `id` is a filesystem-safe server id *slug*: 1-64 lowercase ASCII letters,
+/// digits, or hyphens (`^[a-z0-9-]+$`).
+///
+/// This is a stricter, opt-in invariant layered on top of [`ServerId::new`]'s own baseline
+/// (single non-empty path segment, no `..` or path separator): every slug-shaped id is
+/// automatically a valid [`ServerId`], but not every valid `ServerId` is slug-shaped — e.g. a
+/// raw `mcp.json` key like `claude_ai_Gmail` (mixed case, underscore) is a legitimate
+/// `ServerId` but not a valid slug. [`ServerId::new`] deliberately does not enforce this
+/// tighter rule itself, since callers that only need a safe path segment (e.g. looking up an
+/// existing `mcp.json` entry) must keep accepting non-slug-shaped ids. Callers that need the id
+/// to become a directory name or generated-code identifier — where entry validation and
+/// filesystem confinement must agree on the exact same rule — should call this function too,
+/// in addition to [`ServerId::new`].
+///
+/// # Errors
+///
+/// Returns [`ServerIdSlugError`] if `id` is empty, exceeds [`MAX_SERVER_ID_LENGTH`] bytes, or
+/// contains a character other than a lowercase ASCII letter, digit, or hyphen.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::validate_server_id_slug;
+///
+/// assert!(validate_server_id_slug("github").is_ok());
+/// assert!(validate_server_id_slug("my-server-123").is_ok());
+/// assert!(validate_server_id_slug("").is_err());
+/// assert!(validate_server_id_slug("GitHub").is_err());
+/// assert!(validate_server_id_slug("my_server").is_err());
+/// ```
+pub fn validate_server_id_slug(id: &str) -> Result<(), ServerIdSlugError> {
+    if id.is_empty() {
+        return Err(ServerIdSlugError::Empty);
+    }
+    if id.len() > MAX_SERVER_ID_LENGTH {
+        return Err(ServerIdSlugError::TooLong {
+            len: id.len(),
+            limit: MAX_SERVER_ID_LENGTH,
+        });
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(ServerIdSlugError::InvalidCharacters);
+    }
+    Ok(())
 }
 
 /// Error returned when a candidate string fails the invariant [`ToolName::new`] enforces.
@@ -405,6 +490,113 @@ mod tests {
         assert_sync::<ServerId>();
         assert_send::<ServerIdError>();
         assert_sync::<ServerIdError>();
+    }
+
+    // validate_server_id_slug tests
+    #[test]
+    fn test_validate_server_id_slug_valid() {
+        assert!(validate_server_id_slug("github").is_ok());
+        assert!(validate_server_id_slug("my-server").is_ok());
+        assert!(validate_server_id_slug("server123").is_ok());
+        assert!(validate_server_id_slug("my-server-123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_server_id_slug_empty() {
+        assert_eq!(validate_server_id_slug(""), Err(ServerIdSlugError::Empty));
+    }
+
+    #[test]
+    fn test_validate_server_id_slug_uppercase() {
+        assert_eq!(
+            validate_server_id_slug("GitHub"),
+            Err(ServerIdSlugError::InvalidCharacters)
+        );
+    }
+
+    #[test]
+    fn test_validate_server_id_slug_underscore() {
+        assert_eq!(
+            validate_server_id_slug("my_server"),
+            Err(ServerIdSlugError::InvalidCharacters)
+        );
+    }
+
+    #[test]
+    fn test_validate_server_id_slug_special_chars() {
+        assert_eq!(
+            validate_server_id_slug("my@server"),
+            Err(ServerIdSlugError::InvalidCharacters)
+        );
+    }
+
+    #[test]
+    fn test_validate_server_id_slug_too_long() {
+        let long_id = "a".repeat(65);
+        assert_eq!(
+            validate_server_id_slug(&long_id),
+            Err(ServerIdSlugError::TooLong {
+                len: 65,
+                limit: MAX_SERVER_ID_LENGTH
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_server_id_slug_max_length() {
+        let max_id = "a".repeat(64);
+        assert!(validate_server_id_slug(&max_id).is_ok());
+    }
+
+    /// A slug-shaped id must always also satisfy `ServerId::new`'s own (looser) baseline
+    /// invariant — the slug charset is a strict subset of what a plain path segment allows.
+    #[test]
+    fn test_valid_slug_is_always_a_valid_server_id() {
+        // Every single character in the slug charset, individually — not just a handful of
+        // hand-picked compositions, so a future charset change to `validate_server_id_slug`
+        // that quietly adds a character `ServerId::new` would reject (e.g. a path separator)
+        // is caught here rather than only in a hand-picked example.
+        const CHARSET: &str = "abcdefghijklmnopqrstuvwxyz0123456789-";
+        for c in CHARSET.chars() {
+            let single = c.to_string();
+            assert!(validate_server_id_slug(&single).is_ok(), "{single:?}");
+            assert!(ServerId::new(&single).is_ok(), "{single:?}");
+        }
+        for candidate in [
+            "github",
+            "my-server",
+            "server123",
+            "my-server-123",
+            "-leading-hyphen",
+            "trailing-hyphen-",
+            "0123456789",
+            &"a".repeat(MAX_SERVER_ID_LENGTH),
+        ] {
+            assert!(validate_server_id_slug(candidate).is_ok(), "{candidate:?}");
+            assert!(ServerId::new(candidate).is_ok(), "{candidate:?}");
+        }
+    }
+
+    /// The converse of the test above: `ServerId::new`'s baseline is strictly looser than
+    /// `validate_server_id_slug`'s charset, not merely equal to it in practice. Mixed case and
+    /// underscores are legitimate path segments (e.g. a raw `mcp.json` key like
+    /// `claude_ai_Gmail`, issue #311) even though they fail the slug charset — this must keep
+    /// holding after #401, which deliberately left `ServerId::new` untouched rather than
+    /// tightening it to the slug rule.
+    #[test]
+    fn test_server_id_new_accepts_non_slug_shaped_baseline() {
+        for candidate in ["GitHub", "my_server", "claude_ai_Gmail"] {
+            assert!(validate_server_id_slug(candidate).is_err());
+            assert!(ServerId::new(candidate).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_server_id_slug_error_is_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<ServerIdSlugError>();
+        assert_sync::<ServerIdSlugError>();
     }
 
     #[test]

--- a/crates/mcp-core/tests/send_sync_tests.rs
+++ b/crates/mcp-core/tests/send_sync_tests.rs
@@ -9,6 +9,7 @@ fn test_domain_types_are_send_sync() {
     // All domain types must be Send + Sync
     assert_send_sync::<ServerId>();
     assert_send_sync::<ServerIdError>();
+    assert_send_sync::<ServerIdSlugError>();
     assert_send_sync::<ToolName>();
     assert_send_sync::<ToolNameError>();
 }

--- a/crates/mcp-server/src/output_dir.rs
+++ b/crates/mcp-server/src/output_dir.rs
@@ -22,7 +22,7 @@
 
 use mcp_execution_core::{
     ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
-    validate_path_segment,
+    validate_server_id_slug,
 };
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
@@ -30,12 +30,18 @@ use thiserror::Error;
 /// Errors from resolving and confining an `introspect_server` output directory.
 #[derive(Debug, Error)]
 pub enum OutputDirError {
-    /// `server_id` is empty or is not a single plain path segment (e.g. it contains a `..`,
-    /// `/`, or is otherwise not a bare directory name).
-    #[error("server_id must be a single non-empty path segment: {server_id:?}")]
+    /// `server_id` failed [`mcp_execution_core::validate_server_id_slug`]'s slug-format check
+    /// (e.g. it is empty, too long, or contains a character other than a lowercase ASCII
+    /// letter, digit, or hyphen). `source` carries the precise reason; the message is derived
+    /// from it rather than hardcoded, so it can't independently drift from the actual rule
+    /// enforced.
+    #[error("invalid server_id {server_id:?}: {source}")]
     InvalidServerId {
         /// The rejected server id.
         server_id: String,
+        /// The specific slug-format violation.
+        #[source]
+        source: mcp_execution_core::ServerIdSlugError,
     },
 
     /// The caller supplied an absolute `output_dir`, which would override the base directory
@@ -100,11 +106,26 @@ pub enum OutputDirError {
 /// [`OutputDirError::NotADirectory`] here (the terminal component `resolve_output_dir` walks is
 /// always a directory), which is the only variant this crate names differently than
 /// `mcp-execution-skill`'s equivalent `From` impl.
+///
+/// [`ConfinementError::InvalidSegment`] doesn't carry a [`mcp_execution_core::ServerIdSlugError`]
+/// (the underlying walk only knows the looser [`mcp_execution_core::validate_path_segment`]
+/// rule), so this re-derives one by re-running [`validate_server_id_slug`] on the rejected
+/// segment. `resolve_output_dir` already validates with `validate_server_id_slug` before this
+/// path can be reached, so in practice that second call always fails the same way the first one
+/// did — `unwrap_or` never actually falls back — but doing it this way keeps this `From` impl
+/// itself panic-free instead of `expect`-ing an invariant that only holds because of a check made
+/// somewhere else.
 impl From<ConfinementError> for OutputDirError {
     fn from(err: ConfinementError) -> Self {
         match err {
             ConfinementError::InvalidSegment { segment } => {
-                Self::InvalidServerId { server_id: segment }
+                let source = validate_server_id_slug(&segment)
+                    .err()
+                    .unwrap_or(mcp_execution_core::ServerIdSlugError::InvalidCharacters);
+                Self::InvalidServerId {
+                    server_id: segment,
+                    source,
+                }
             }
             ConfinementError::SegmentIsSymlink { path } => Self::ServerDirIsSymlink { path },
             ConfinementError::Escape { path } => Self::Escape { path },
@@ -155,15 +176,18 @@ pub fn relative_subpath(output_dir: Option<&Path>) -> Result<PathBuf, OutputDirE
 
 /// Resolves an `introspect_server` output directory, confining it to `base_dir/server_id`.
 ///
-/// `server_id` is validated as a single plain path segment **before** `output_dir` is checked at
-/// all, matching this crate's pre-#395 error precedence: a caller supplying both an invalid
-/// `server_id` and an invalid `output_dir` sees [`OutputDirError::InvalidServerId`], not a
-/// relative-path error. `server_id` and `output_dir`'s directory components are then walked and
-/// confinement-checked by the shared [`resolve_confined_path`], which defensively re-validates
-/// `server_id` itself as its first step - even though it is already validated twice by the time
-/// it gets there (`service::introspect_server`'s tighter `validate_server_id` charset check, then
-/// the early check this function performs) - so `resolve_confined_path` stays self-defending
-/// against a `server_id` that reaches it some other way. `output_dir`, when supplied, is treated
+/// `server_id` is validated against the same slug rule entry validation gates with
+/// ([`validate_server_id_slug`]) **before** `output_dir` is checked at all, matching this crate's
+/// pre-#395 error precedence: a caller supplying both an invalid `server_id` and an invalid
+/// `output_dir` sees [`OutputDirError::InvalidServerId`], not a relative-path error. `server_id`
+/// and `output_dir`'s directory components are then walked and confinement-checked by the shared
+/// [`resolve_confined_path`], which defensively re-validates `server_id` itself as its first step
+/// (against the looser structural [`mcp_execution_core::validate_path_segment`] rule) - even
+/// though it is already validated twice by the time it gets there
+/// (`service::introspect_server`'s `validate_server_id_slug` charset check, then the early check
+/// this function performs) - so `resolve_confined_path` stays self-defending against a
+/// `server_id` that reaches it some other way, or after a future change loosens one of the
+/// caller-side checks. `output_dir`, when supplied, is treated
 /// as *relative* to `base_dir/server_id`: an absolute path or a path containing a `..` component
 /// is rejected by [`relative_subpath`] before any filesystem work happens. `None` resolves to
 /// `base_dir/server_id` itself.
@@ -195,11 +219,11 @@ pub fn relative_subpath(output_dir: Option<&Path>) -> Result<PathBuf, OutputDirE
 ///
 /// # Errors
 ///
-/// Returns [`OutputDirError`] if `server_id` is empty or not a single plain path segment, if
-/// `output_dir` is absolute or contains a `..` component, if `server_id`'s own directory already
-/// exists as a symlink, if the resolved path escapes `base_dir`, if a required directory could
-/// not be created, or if a path component that must be a directory already exists as the wrong
-/// kind of entry.
+/// Returns [`OutputDirError`] if `server_id` fails [`validate_server_id_slug`], if `output_dir`
+/// is absolute or contains a `..` component, if `server_id`'s own directory already exists as a
+/// symlink, if the resolved path escapes `base_dir`, if a required directory could not be
+/// created, or if a path component that must be a directory already exists as the wrong kind of
+/// entry.
 pub async fn resolve_output_dir(
     base_dir: &Path,
     server_id: &str,
@@ -207,12 +231,12 @@ pub async fn resolve_output_dir(
 ) -> Result<PathBuf, OutputDirError> {
     // Validated again, I/O-free, before `relative_subpath` so an invalid `server_id` is reported
     // even when `output_dir` is also invalid - matching this crate's pre-#395 error precedence
-    // (`resolve_confined_path` re-validates it a second time as part of its own walk).
-    if validate_path_segment(server_id).is_none() {
-        return Err(OutputDirError::InvalidServerId {
-            server_id: server_id.to_string(),
-        });
-    }
+    // (`resolve_confined_path` re-validates it a second time, against the looser structural rule,
+    // as part of its own walk).
+    validate_server_id_slug(server_id).map_err(|source| OutputDirError::InvalidServerId {
+        server_id: server_id.to_string(),
+        source,
+    })?;
 
     let relative = relative_subpath(output_dir)?;
 
@@ -372,6 +396,44 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, OutputDirError::InvalidServerId { .. }));
+    }
+
+    /// #401 regression: a `server_id` that is a valid, path-segment-safe `ServerId` but not
+    /// slug-shaped (uppercase letters) must be rejected here too, not just at
+    /// `service::introspect_server`'s entry gate — entry validation and confinement must agree
+    /// on the exact same rule.
+    #[tokio::test]
+    async fn server_id_with_uppercase_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_output_dir(base.path(), "My-Server", None)
+            .await
+            .unwrap_err();
+        // Asserts on the specific reason, not just the outer variant, so a regression that
+        // rejects "My-Server" for the wrong cause (or with stale wording) is still caught.
+        assert!(matches!(
+            err,
+            OutputDirError::InvalidServerId {
+                source: mcp_execution_core::ServerIdSlugError::InvalidCharacters,
+                ..
+            }
+        ));
+    }
+
+    /// #401 regression: same as above, for an underscore (also a valid `ServerId` character but
+    /// not a valid slug character).
+    #[tokio::test]
+    async fn server_id_with_underscore_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_output_dir(base.path(), "my_server", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OutputDirError::InvalidServerId {
+                source: mcp_execution_core::ServerIdSlugError::InvalidCharacters,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -1079,12 +1079,12 @@ impl GeneratorService {
         )
         .await
         .map_err(|e| match e {
-            // `server_id` was already validated above via `validate_server_id_slug`, which
-            // `resolve_skill_output_path`'s internal check now also delegates to (see
-            // `output_path::validate_server_id_segment`), so this arm is unreachable from this
-            // call site — kept distinct (rather than folded into the `output_path` arm below)
-            // because `resolve_skill_output_path` is public API other callers may reach without
-            // that upstream validation.
+            // `server_id` was already validated above via `validate_server_id_slug`, and
+            // `resolve_skill_output_path` itself gates `server_id` with the same
+            // `validate_server_id_slug` check at its own entry, so this arm is unreachable from
+            // this call site — kept distinct (rather than folded into the `output_path` arm
+            // below) because `resolve_skill_output_path` is public API other callers may reach
+            // without that upstream validation.
             OutputPathError::InvalidServerId { .. } => {
                 McpError::invalid_params(format!("Invalid server_id: {e}"), None)
             }

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -17,13 +17,15 @@ use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::untrusted::{
     MAX_UNTRUSTED_FIELD_LEN, sanitize_untrusted_text, wrap_untrusted_block,
 };
-use mcp_execution_core::{ServerConfig, ServerId, sanitize_path_for_error};
+use mcp_execution_core::{
+    ServerConfig, ServerId, sanitize_path_for_error, validate_server_id_slug,
+};
 use mcp_execution_files::FilesBuilder;
 use mcp_execution_introspector::{Introspector, ToolInfo};
 use mcp_execution_skill::{
     GenerateSkillParams, MAX_TOOL_FILES, OutputPathError, SaveSkillParams, SaveSkillResult,
     ScanError, build_skill_context, extract_skill_metadata, resolve_skill_output_path,
-    scan_tools_directory, validate_server_id,
+    scan_tools_directory,
 };
 use rmcp::handler::server::ServerHandler;
 use rmcp::handler::server::tool::ToolRouter;
@@ -393,7 +395,7 @@ impl GeneratorService {
         // an attacker-controlled string into a structured field before it's validated risks
         // log injection, so an empty field on this path is accepted as a trade-off, not an
         // oversight.
-        validate_server_id(&params.server_id)
+        validate_server_id_slug(&params.server_id)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
         // Extract server_id before consuming params
@@ -891,7 +893,7 @@ impl GeneratorService {
     ) -> Result<CallToolResult, McpError> {
         // Validate server_id format and length. As in `introspect_server`, the span
         // field is only recorded once validation succeeds (see the comment there).
-        validate_server_id(&params.server_id)
+        validate_server_id_slug(&params.server_id)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
         tracing::Span::current().record("server_id", tracing::field::display(&params.server_id));
 
@@ -1040,7 +1042,7 @@ impl GeneratorService {
 
         // Validate server_id format and length. As in `introspect_server`, the span
         // field is only recorded once validation succeeds (see the comment there).
-        validate_server_id(&params.server_id)
+        validate_server_id_slug(&params.server_id)
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
         tracing::Span::current().record("server_id", tracing::field::display(&params.server_id));
 
@@ -1077,11 +1079,12 @@ impl GeneratorService {
         )
         .await
         .map_err(|e| match e {
-            // `server_id` was already validated above by `validate_server_id`, which is
-            // strictly tighter than `resolve_skill_output_path`'s internal check, so this
-            // arm is unreachable from this call site — kept distinct (rather than folded
-            // into the `output_path` arm below) because `resolve_skill_output_path` is
-            // public API other callers may reach without that upstream validation.
+            // `server_id` was already validated above via `validate_server_id_slug`, which
+            // `resolve_skill_output_path`'s internal check now also delegates to (see
+            // `output_path::validate_server_id_segment`), so this arm is unreachable from this
+            // call site — kept distinct (rather than folded into the `output_path` arm below)
+            // because `resolve_skill_output_path` is public API other callers may reach without
+            // that upstream validation.
             OutputPathError::InvalidServerId { .. } => {
                 McpError::invalid_params(format!("Invalid server_id: {e}"), None)
             }
@@ -2205,7 +2208,7 @@ mod tests {
 
     /// A zero timeout is a client input error, not a server-side connection
     /// failure — it must surface as `INVALID_PARAMS`, matching the sibling
-    /// `validate_server_id` behavior, not `internal_error`.
+    /// `validate_server_id_slug` behavior, not `internal_error`.
     #[tokio::test]
     async fn test_introspect_server_zero_connect_timeout_is_invalid_params() {
         use tempfile::TempDir;

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -52,7 +52,7 @@ use uuid::Uuid;
 pub struct IntrospectServerParams {
     /// Unique identifier for the server (e.g., "github", "filesystem").
     ///
-    /// Must be 1-64 lowercase letters, digits, or hyphens (see `validate_server_id`'s
+    /// Must be 1-64 lowercase letters, digits, or hyphens (see `validate_server_id_slug`'s
     /// `MAX_SERVER_ID_LENGTH`, mirrored here as a literal since schemars attributes cannot
     /// reference a `const`).
     #[schemars(length(max = 64), regex(pattern = r"^[a-z0-9-]+$"))]

--- a/crates/mcp-skill/src/output_path.rs
+++ b/crates/mcp-skill/src/output_path.rs
@@ -10,7 +10,7 @@
 
 use mcp_execution_core::{
     ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
-    validate_path_segment,
+    validate_server_id_slug,
 };
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -18,12 +18,18 @@ use thiserror::Error;
 /// Errors from resolving and confining a skill output path to its base directory.
 #[derive(Debug, Error)]
 pub enum OutputPathError {
-    /// `server_id` is empty or is not a single plain path segment (e.g. it
-    /// contains a `..`, `/`, or is otherwise not a bare directory name).
-    #[error("server_id must be a single non-empty path segment: {server_id:?}")]
+    /// `server_id` failed [`mcp_execution_core::validate_server_id_slug`]'s slug-format check
+    /// (e.g. it is empty, too long, or contains a character other than a lowercase ASCII
+    /// letter, digit, or hyphen). `source` carries the precise reason; the message is derived
+    /// from it rather than hardcoded, so it can't independently drift from the actual rule
+    /// enforced.
+    #[error("invalid server_id {server_id:?}: {source}")]
     InvalidServerId {
         /// The rejected server id.
         server_id: String,
+        /// The specific slug-format violation.
+        #[source]
+        source: mcp_execution_core::ServerIdSlugError,
     },
 
     /// The caller supplied an absolute `output_path`, which would override
@@ -103,11 +109,26 @@ pub enum OutputPathError {
 /// [`OutputPathError::NotAFile`] here (the terminal component `resolve_skill_output_path` walks
 /// is always a file), which is the only variant this crate names differently than
 /// `mcp-execution-server`'s equivalent `From` impl.
+///
+/// [`ConfinementError::InvalidSegment`] doesn't carry a [`mcp_execution_core::ServerIdSlugError`]
+/// (the underlying walk only knows the looser [`mcp_execution_core::validate_path_segment`]
+/// rule), so this re-derives one by re-running [`validate_server_id_slug`] on the rejected
+/// segment. `resolve_skill_output_path` already validates with `validate_server_id_slug` before
+/// this path can be reached, so in practice that second call always fails the same way the first
+/// one did — `unwrap_or` never actually falls back — but doing it this way keeps this `From` impl
+/// itself panic-free instead of `expect`-ing an invariant that only holds because of a check made
+/// somewhere else.
 impl From<ConfinementError> for OutputPathError {
     fn from(err: ConfinementError) -> Self {
         match err {
             ConfinementError::InvalidSegment { segment } => {
-                Self::InvalidServerId { server_id: segment }
+                let source = validate_server_id_slug(&segment)
+                    .err()
+                    .unwrap_or(mcp_execution_core::ServerIdSlugError::InvalidCharacters);
+                Self::InvalidServerId {
+                    server_id: segment,
+                    source,
+                }
             }
             ConfinementError::SegmentIsSymlink { path } => Self::ServerIdIsSymlink { path },
             ConfinementError::Escape { path } => Self::Escape { path },
@@ -147,13 +168,14 @@ fn relative_target(output_path: Option<&Path>) -> Result<PathBuf, OutputPathErro
 
 /// Resolves a `save_skill` output path, confining it to `base_dir/server_id`.
 ///
-/// `server_id` is validated as a single plain path segment **before** `output_path` is checked
-/// at all, matching this crate's pre-#395 error precedence: a caller supplying both an invalid
-/// `server_id` and an invalid `output_path` sees [`OutputPathError::InvalidServerId`], not a
-/// relative-path error - `mcp_execution_server`'s `save_skill` handler keeps `InvalidServerId` in
-/// its own error-classification arm specifically for external callers of this public function
-/// that skip its own upstream `validate_server_id` check, so masking it behind a relative-path
-/// error would defeat that.
+/// `server_id` is validated against the same slug rule entry validation gates with
+/// ([`validate_server_id_slug`]) **before** `output_path` is checked at all, matching this
+/// crate's pre-#395 error precedence: a caller supplying both an invalid `server_id` and an
+/// invalid `output_path` sees [`OutputPathError::InvalidServerId`], not a relative-path error -
+/// `mcp_execution_server`'s `save_skill` handler keeps `InvalidServerId` in its own
+/// error-classification arm specifically for external callers of this public function that skip
+/// its own upstream `validate_server_id_slug` check, so masking it behind a relative-path error
+/// would defeat that.
 ///
 /// `server_id` and `output_path` are both attacker-influenced, so both are walked and
 /// confinement-checked by the shared [`resolve_confined_path`], rooted at `base_dir`: `server_id`
@@ -185,13 +207,11 @@ fn relative_target(output_path: Option<&Path>) -> Result<PathBuf, OutputPathErro
 ///
 /// # Errors
 ///
-/// Returns [`OutputPathError`] if `server_id` is empty or not a single
-/// plain path segment, if `output_path` is absolute, contains a `..`
-/// component, or has no file name, if the resolved path escapes `base_dir`
-/// (including via a symlink at `server_id` itself or any deeper
-/// component), if a required directory could not be created, or if a path
-/// component that must be a directory (or must hold the output file)
-/// already exists as the wrong kind of entry.
+/// Returns [`OutputPathError`] if `server_id` fails [`validate_server_id_slug`], if `output_path`
+/// is absolute, contains a `..` component, or has no file name, if the resolved path escapes
+/// `base_dir` (including via a symlink at `server_id` itself or any deeper component), if a
+/// required directory could not be created, or if a path component that must be a directory (or
+/// must hold the output file) already exists as the wrong kind of entry.
 ///
 /// # Examples
 ///
@@ -213,12 +233,12 @@ pub async fn resolve_skill_output_path(
 ) -> Result<PathBuf, OutputPathError> {
     // Validated again, I/O-free, before `relative_target` so an invalid `server_id` is reported
     // even when `output_path` is also invalid - matching this crate's pre-#395 error precedence
-    // (`resolve_confined_path` re-validates it a second time as part of its own walk).
-    if validate_path_segment(server_id).is_none() {
-        return Err(OutputPathError::InvalidServerId {
-            server_id: server_id.to_string(),
-        });
-    }
+    // (`resolve_confined_path` re-validates it a second time, against the looser structural rule,
+    // as part of its own walk).
+    validate_server_id_slug(server_id).map_err(|source| OutputPathError::InvalidServerId {
+        server_id: server_id.to_string(),
+        source,
+    })?;
 
     let relative = relative_target(output_path)?;
 
@@ -333,6 +353,44 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, OutputPathError::InvalidServerId { .. }));
+    }
+
+    /// #401 regression: a `server_id` that is a valid, path-segment-safe `ServerId` but not
+    /// slug-shaped (uppercase letters) must be rejected here too, not just at
+    /// `service::save_skill`'s entry gate — entry validation and confinement must agree on the
+    /// exact same rule.
+    #[tokio::test]
+    async fn server_id_with_uppercase_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(base.path(), "My-Server", None)
+            .await
+            .unwrap_err();
+        // Asserts on the specific reason, not just the outer variant, so a regression that
+        // rejects "My-Server" for the wrong cause (or with stale wording) is still caught.
+        assert!(matches!(
+            err,
+            OutputPathError::InvalidServerId {
+                source: mcp_execution_core::ServerIdSlugError::InvalidCharacters,
+                ..
+            }
+        ));
+    }
+
+    /// #401 regression: same as above, for an underscore (also a valid `ServerId` character but
+    /// not a valid slug character).
+    #[tokio::test]
+    async fn server_id_with_underscore_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(base.path(), "my_server", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OutputPathError::InvalidServerId {
+                source: mcp_execution_core::ServerIdSlugError::InvalidCharacters,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/mcp-skill/src/types.rs
+++ b/crates/mcp-skill/src/types.rs
@@ -9,14 +9,15 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use thiserror::Error;
 
 /// Maximum `server_id` length (denial-of-service protection).
 ///
-/// `pub` (rather than private) so downstream crates' schemars drift-guard tests — e.g.
-/// `mcp-execution-server`'s, for `IntrospectServerParams::server_id` — can assert the declared
-/// schema length against this real constant instead of a hardcoded literal (issue #198 S3).
-pub const MAX_SERVER_ID_LENGTH: usize = 64;
+/// Re-exported from `mcp_execution_core`, the authoritative owner of the server id slug
+/// invariant (see [`validate_server_id`]). `pub` (rather than private) so downstream crates'
+/// schemars drift-guard tests — e.g. `mcp-execution-server`'s, for
+/// `IntrospectServerParams::server_id` — can assert the declared schema length against this
+/// real constant instead of a hardcoded literal (issue #198 S3).
+pub use mcp_execution_core::MAX_SERVER_ID_LENGTH;
 
 // ============================================================================
 // generate_skill types
@@ -238,34 +239,21 @@ pub struct SkillMetadata {
 // ============================================================================
 
 /// Errors returned by [`validate_server_id`].
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum SkillServerIdError {
-    /// `server_id` was empty.
-    ///
-    /// An empty `server_id` would collapse a per-server confinement
-    /// directory back to its shared parent, so it is rejected explicitly
-    /// rather than falling through the (vacuously true) character-class
-    /// check below.
-    #[error("server_id must not be empty")]
-    Empty,
-
-    /// `server_id` exceeded the maximum allowed length.
-    #[error("server_id too long: {len} chars exceeds {limit} limit")]
-    TooLong {
-        /// Actual length of the rejected `server_id`, in bytes (`str::len`,
-        /// not `chars().count()`).
-        len: usize,
-        /// Maximum allowed length (`MAX_SERVER_ID_LENGTH`).
-        limit: usize,
-    },
-
-    /// `server_id` contained a character other than a lowercase letter,
-    /// digit, or hyphen.
-    #[error("server_id must contain only lowercase letters, digits, and hyphens")]
-    InvalidCharacters,
-}
+///
+/// A re-export of [`mcp_execution_core::ServerIdSlugError`] — the authoritative error type for
+/// this invariant — under this crate's own name, so existing callers of
+/// `mcp_execution_skill::SkillServerIdError` are unaffected. This crate previously hand-rolled a
+/// structurally identical enum plus a manual `From` conversion; that let this crate's error
+/// wording drift from `mcp_execution_core`'s (the MCP tool handlers in `mcp-execution-server`
+/// surface the core wording directly, so the two had visibly disagreed on identical input). A
+/// re-export makes that drift structurally impossible: there is only one type, and therefore
+/// only one `Display` wording, to keep in sync.
+pub use mcp_execution_core::ServerIdSlugError as SkillServerIdError;
 
 /// Validate `server_id` format and length.
+///
+/// Delegates to [`mcp_execution_core::validate_server_id_slug`], the authoritative owner of
+/// this invariant.
 ///
 /// # Arguments
 ///
@@ -300,30 +288,7 @@ pub enum SkillServerIdError {
 /// assert!(validate_server_id("my_server").is_err()); // underscore
 /// ```
 pub fn validate_server_id(server_id: &str) -> Result<(), SkillServerIdError> {
-    // Check emptiness (the character-class check below is vacuously true for
-    // an empty string, and an empty server_id would collapse a per-server
-    // confinement directory back to its shared parent)
-    if server_id.is_empty() {
-        return Err(SkillServerIdError::Empty);
-    }
-
-    // Check length
-    if server_id.len() > MAX_SERVER_ID_LENGTH {
-        return Err(SkillServerIdError::TooLong {
-            len: server_id.len(),
-            limit: MAX_SERVER_ID_LENGTH,
-        });
-    }
-
-    // Check format
-    if !server_id
-        .chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-    {
-        return Err(SkillServerIdError::InvalidCharacters);
-    }
-
-    Ok(())
+    mcp_execution_core::validate_server_id_slug(server_id)
 }
 
 #[cfg(test)]

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -48,8 +48,13 @@ related:
      `mcp-server` for identical error-message redaction) and
      `contains_parent_dir` (used by both, plus `mcp-cli`, for identical
      `..`-traversal checks); `validate_path_segment` backs `ServerId`/
-     `ToolName` and, since #395, `confinement::resolve_confined_path`
-     internally.
+     `ToolName`'s own baseline path-segment invariant and, since #395, is
+     also used internally by `confinement::resolve_confined_path` as its
+     generic (looser) segment check. `types::validate_server_id_slug`
+     (issue #401) is the separate, stricter charset check both crates'
+     `server_id` confinement now additionally enforces *before* calling
+     into `resolve_confined_path` (see below) — `resolve_confined_path`
+     itself stays generic and does not know about the slug rule.
    - `confinement` — `resolve_confined_path` (issue #395), the shared
      component-by-component resolve-and-confine filesystem walk used by both
      `mcp-skill::resolve_skill_output_path` and
@@ -86,9 +91,33 @@ bypassed by an infallible conversion or a direct-derive deserialize. Without
 `Self(raw_string)` directly since the derived impl lives in this same module and privacy
 doesn't block it — this is exactly the gap that made `mcp_execution_introspector::ServerInfo`/
 `ToolInfo` (which derive `Deserialize` and hold a `ServerId`/`ToolName` field) deserializable
-with an unvalidated id/name before this was added. `mcp-skill::validate_server_id`
-layers a stricter `[a-z0-9-]`-charset + length check on top of this baseline for its own
-contract; it does not replace it.
+with an unvalidated id/name before this was added.
+
+### `validate_server_id_slug` / `ServerIdSlugError` (`src/types.rs`, issue #401)
+
+```rust
+pub const MAX_SERVER_ID_LENGTH: usize = 64;
+pub enum ServerIdSlugError { Empty, TooLong { len: usize, limit: usize }, InvalidCharacters }
+pub fn validate_server_id_slug(id: &str) -> Result<(), ServerIdSlugError>;
+// Rules: 1-64 bytes, only `[a-z0-9-]` (ASCII lowercase letters, digits, hyphen)
+```
+A stricter, opt-in invariant layered *on top of* `ServerId::new`'s baseline — not a replacement
+for it, and not enforced by `ServerId::new`/`Deserialize` itself. `ServerId::new` deliberately
+stays permissive (issue #311: a raw `mcp.json` key like `claude_ai_Gmail` is a valid `ServerId`
+but not a valid slug — callers that only need a safe path segment, e.g. `mcp-cli`'s config-key
+lookup, must keep accepting non-slug-shaped ids). Callers that need the id to become a directory
+name or generated-code identifier — where entry validation and filesystem confinement must
+agree on the exact same rule — call this function in addition to `ServerId::new`.
+
+This is the single, authoritative home for the rule previously hand-rolled independently in
+`mcp-execution-skill::validate_server_id`/`SkillServerIdError` (which now delegates to it —
+`SkillServerIdError` is a re-export of `ServerIdSlugError`, not a separate mirror type, so the
+two crates' error wording cannot drift apart) and imported piecemeal by
+`mcp-execution-server`'s tool handlers. It also now backs both crates' `server_id`
+output-confinement checks (`mcp-server::output_dir`, `mcp-skill::output_path`), which previously
+confined using the looser `validate_path_segment` even though entry validation already gated
+with the stricter rule — see [[../server/spec#Output directory resolution]] and
+[[../skill/spec]].
 
 ### `Error` / `Result<T>` (`src/error.rs`)
 
@@ -281,10 +310,22 @@ pub fn sanitize_path_for_error(path: &Path) -> String; // redacts home dir to "~
 pub fn validate_path_segment(segment: &str) -> Option<Component<'_>>; // single plain component, no "..", no separator
 pub fn contains_parent_dir(path: &Path) -> bool; // true if any component is `..`
 ```
-`validate_path_segment` backs `ServerId::new`/`ToolName::new`'s own invariant (see above) and,
-since #395, is used internally by `confinement::resolve_confined_path` to validate the `segment`
-(`server_id`) it's given — `mcp-skill` and `mcp-server` no longer call it directly, since the
-confinement walk itself validates `server_id` as part of resolving it.
+`validate_path_segment` backs `ServerId::new`/`ToolName::new`'s own baseline invariant (see
+above) and, since #395, is used internally by `confinement::resolve_confined_path` as its own
+generic, looser structural check on the `segment` (`server_id`) it's given —
+`resolve_confined_path` stays a generic reusable primitive, not coupled to the `server_id`
+domain concept specifically. It is *no longer* the primary rule
+`mcp-skill::resolve_skill_output_path` and `mcp-server::output_dir::resolve_output_dir` gate
+`server_id` confinement with directly — since issue #401, both call `types::validate_server_id_slug`
+up front, before calling into `resolve_confined_path` at all (the same rule their respective
+entry-point handlers already validate with), so the domain-specific slug rule and the generic
+structural rule both apply, in that order. Neither confinement helper calls
+`validate_path_segment` directly anymore; `resolve_confined_path`'s internal re-check (and, on
+its `ConfinementError::InvalidSegment` path, each crate's `From<ConfinementError>` impl
+re-deriving a `ServerIdSlugError` by calling `validate_server_id_slug` again) exist purely as
+defense-in-depth against a `server_id` that reaches the walk some other way, or after a future
+change loosens the caller-side check — not because either helper still leans on
+`validate_path_segment` as its primary gate.
 `contains_parent_dir` (issue #289) is the shared `..`-only check used by
 `mcp-skill::output_path`, `mcp-server::output_dir`, and
 `mcp-cli::commands::skill::has_path_traversal` for the narrower "is any
@@ -427,8 +468,8 @@ data into text an LLM later reads as instructions — see
 | `mcp-introspector` | `ServerConfig`, `ServerId`, `ToolName`, `Transport`, `validate_server_config`, `Error`/`Result` |
 | `mcp-codegen` | `Error`/`Result`, `metadata::*` (writes `_meta.json`), `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix` (renders them into the generated runtime bridge template) |
 | `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen` |
-| `mcp-skill` | `sanitize_path_for_error`, `contains_parent_dir`, `untrusted::*`, `metadata::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
-| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
+| `mcp-skill` | `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `MAX_SERVER_ID_LENGTH`, `untrusted::*`, `metadata::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
+| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
 | `mcp-cli` | `cli::{OutputFormat, ExitCode}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |
 
 ## 4. Defense in Depth

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -135,10 +135,12 @@ issue #381).
   guard against reintroducing SSRF risk, since `ServerConfig`'s own docs
   note this crate is exactly the kind of server-context embedder expected
   to add SSRF allowlisting before ever setting Http/Sse transport.
-- `server_id` validated via `mcp_execution_skill::validate_server_id`
-  before anything else; the tracing span's `server_id` field is left empty
-  on early validation failure (never logging unvalidated attacker input
-  into a structured field).
+- `server_id` validated via `mcp_execution_core::validate_server_id_slug`
+  (issue #401 — previously imported from `mcp_execution_skill::validate_server_id`,
+  which now delegates to the same core function) before anything else; the
+  tracing span's `server_id` field is left empty on early validation
+  failure (never logging unvalidated attacker input into a structured
+  field).
 - `output_dir`, if given, is checked with the cheap, I/O-free
   `relative_subpath` (rejects absolute/`..`) — **not** the full
   filesystem-touching confinement walk, which is deliberately deferred to
@@ -481,8 +483,10 @@ warns.
 
 `StateError`: `AtCapacity { limit }`, `MemoryBudgetExceeded { limit }`.
 
-`OutputDirError`: `InvalidServerId`, `AbsolutePath`, `ParentTraversal`,
-`ServerDirIsSymlink`, `Escape`, `NotADirectory`, `CreateDir`, `Io`.
+`OutputDirError`: `InvalidServerId { server_id, source: ServerIdSlugError }` (issue #401 —
+`source` carries the precise slug-format violation, so the message can't independently drift
+from the actual rule `mcp_execution_core::validate_server_id_slug` enforces), `AbsolutePath`,
+`ParentTraversal`, `ServerDirIsSymlink`, `Escape`, `NotADirectory`, `CreateDir`, `Io`.
 
 Every tool method maps its internal errors to `rmcp::ErrorData` via either
 `McpError::invalid_params` (caller's fault — bad input, missing session,
@@ -494,14 +498,21 @@ environment's fault — I/O failure, task join error, serialization failure).
 - **Consumes**: `mcp-introspector::Introspector`/`ServerInfo`,
   `mcp-codegen::ProgressiveGenerator`, `mcp-files::FilesBuilder`/
   `FileSystem`, `mcp-skill::{scan_tools_directory, build_skill_context,
-  resolve_skill_output_path, extract_skill_metadata, validate_server_id,
+  resolve_skill_output_path, extract_skill_metadata,
   MAX_TOOL_FILES}`, `mcp-core::{ServerConfig, ServerId,
-  sanitize_path_for_error, untrusted::*, confinement::{ConfinementError,
-  ConfinementTarget, resolve_confined_path}}` (the last three, since #395,
-  used only by `output_dir::resolve_output_dir`; `resolve_list_base_dir`
-  reuses `output_dir.rs`'s own `relative_subpath` and hand-rolls its own,
-  weaker confinement check rather than calling `resolve_confined_path`,
-  since it is out of scope for the confinement consolidation — see §6).
+  sanitize_path_for_error, validate_server_id_slug, ServerIdSlugError,
+  untrusted::*, confinement::{ConfinementError, ConfinementTarget,
+  resolve_confined_path}}` (the `confinement::*` items, since #395, used only
+  by `output_dir::resolve_output_dir`; `resolve_list_base_dir` reuses
+  `output_dir.rs`'s own `relative_subpath` and hand-rolls its own, weaker
+  confinement check rather than calling `resolve_confined_path`, since it is
+  out of scope for the confinement consolidation — see §6).
+  `validate_server_id` is no longer imported from `mcp-skill` (issue #401) —
+  the three tool handlers (`introspect_server`, `generate_skill`,
+  `save_skill`) now validate `server_id` via
+  `mcp_execution_core::validate_server_id_slug` directly, and
+  `output_dir::resolve_output_dir` gates `server_id` with the same function
+  before delegating the filesystem walk itself to `resolve_confined_path`.
 - **Schema drift guards**: `service.rs`'s own tests assert the `schemars`-
   derived schema for `CategorizedTool`/`SaveCategorizedToolsParams`/
   `IntrospectServerParams` matches the real runtime constants

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -55,9 +55,11 @@ pub use types::{GenerateSkillParams, GenerateSkillResult, MAX_SERVER_ID_LENGTH,
     SaveSkillParams, SaveSkillResult, SkillCategory, SkillMetadata, SkillServerIdError,
     SkillTool, ToolExample, validate_server_id};
 
-pub const MAX_SERVER_ID_LENGTH: usize = 64;
+pub use mcp_execution_core::MAX_SERVER_ID_LENGTH; // = 64, re-exported (issue #401)
+pub use mcp_execution_core::ServerIdSlugError as SkillServerIdError; // re-exported, not a separate mirror type
 pub fn validate_server_id(server_id: &str) -> Result<(), SkillServerIdError>;
-// Rules: non-empty, <= 64 bytes, only [a-z0-9-]
+// Rules: non-empty, <= 64 bytes, only [a-z0-9-]. Delegates to
+// mcp_execution_core::validate_server_id_slug — the authoritative owner of this invariant.
 
 pub const MAX_TOOL_FILES: usize = 500;
 pub const MAX_FILE_SIZE: u64 = 1024 * 1024;       // 1 MiB, _meta.json size cap
@@ -252,19 +254,29 @@ name before any filesystem work; the rest is delegated with
 `SkillMetadataError`: `MissingFrontmatter`, `FrontmatterTooLarge`,
 `InvalidYaml`, `MissingField`.
 
-`OutputPathError`: `InvalidServerId`, `AbsolutePath`, `ParentTraversal`,
+`OutputPathError`: `InvalidServerId { server_id, source: ServerIdSlugError }` (issue #401 —
+confinement now validates `server_id` via `mcp_execution_core::validate_server_id_slug`, the
+same rule `mcp-server`'s tool handlers gate entry with, rather than the looser
+`validate_path_segment`; `source` carries the precise violation so the message can't drift from
+the actual rule enforced), `AbsolutePath`, `ParentTraversal`,
 `InvalidPath`, `ServerIdIsSymlink`, `Escape`, `NotADirectory`, `NotAFile`,
 `CreateDir`, `Io`.
 
-`SkillServerIdError`: `Empty`, `TooLong { len, limit }`, `InvalidCharacters`.
+`SkillServerIdError`: re-export of `mcp_execution_core::ServerIdSlugError` — `Empty`,
+`TooLong { len, limit }`, `InvalidCharacters` (issue #401; previously a hand-rolled,
+structurally identical mirror type with its own `#[error(...)]` wording, which had let this
+crate's error messages drift from `mcp-core`'s/`mcp-server`'s for identical input).
 
 ## 10. Cross-Crate Contracts
 
 - **Consumes** `mcp-core`: `metadata::{METADATA_FILE_NAME,
   METADATA_SCHEMA_VERSION, ServerMetadata}`, `sanitize_path_for_error`,
+  `validate_server_id_slug`, `ServerIdSlugError`, `MAX_SERVER_ID_LENGTH`,
   `untrusted::*`, and (since #395) `confinement::{ConfinementError,
   ConfinementTarget, resolve_confined_path}` for `resolve_skill_output_path`'s
-  walk.
+  walk — `validate_server_id_slug` gates `server_id` before that walk starts
+  (issue #401); `validate_path_segment` is no longer called directly by this
+  crate.
 - **Used by** `mcp-cli skill` (directly calls `scan_tools_directory` +
   `build_skill_context` + `render_skill_md`, no LLM/prompt step — see
   [[../cli/spec#skill]]).


### PR DESCRIPTION
## Summary

- Adds `mcp_execution_core::validate_server_id_slug`/`ServerIdSlugError`/`MAX_SERVER_ID_LENGTH` as the single, core-owned strict-format invariant for a slug-shaped `server_id` (1-64 lowercase letters/digits/hyphens), kept separate from `ServerId::new()`'s own looser baseline. `ServerId::new()` is deliberately left unchanged to preserve #311's non-slug-shaped `mcp.json` config-key lookups (e.g. `claude_ai_Gmail`).
- `mcp-execution-skill`'s `validate_server_id`/`SkillServerIdError` now delegate to the core function (`SkillServerIdError` is a re-export, not a hand-rolled mirror), and `mcp-execution-server`'s tool handlers call it directly instead of importing from `mcp-execution-skill`.
- Fixes the gate/confine mismatch reported in #401: `mcp-execution-server`'s `output_dir` and `mcp-execution-skill`'s `output_path` now confine a `server_id` using the same strict rule that gates entry, instead of the looser `validate_path_segment`.
- Closes the loop on #402's untracked `TODO(critic)` marker in `path::components_match`, correcting a mitigation claim that turned out to be false (`scrub_username`'s fallback shares the same ASCII-only limitation). Real Unicode-aware fix tracked separately in #406.
- Updates `specs/core`, `specs/server`, `specs/skill`, and `CHANGELOG.md`.

## Scope note

Issue #401's body originally asked to tighten `ServerId::new()`'s own invariant directly. Mid-implementation this was found to conflict with #311's deliberately permissive `ServerId::new()` contract (guarded by a regression test for non-slug-shaped config keys). Scope was narrowed to add a separate, core-owned strict validator instead of changing `ServerId::new()` itself — confirmed with the team lead before implementation, verified independently, and adversarially critiqued (two rounds) before this PR.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1167 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests for the gate/confine mismatch (uppercase/underscore rejected at confinement, not just entry)
- [x] Existing #311 regression test (`test_get_mcp_server_accepts_non_slug_shaped_config_key`) confirmed untouched and passing

Closes #401, #402