### PR TITLE
Add --log-format/MCP_EXECUTION_LOG_FORMAT JSON logging switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   again immediately before the write. A checkpoint firing after the session was already consumed
   restores it via the existing `StateManager::restore` path, so a cancelled
   `save_categorized_tools` call remains retriable under the same `session_id`.
+- **`mcp-execution-cli`**, **`mcp-execution-server`**: a new `--log-format {text,json}` flag
+  (and its `MCP_EXECUTION_LOG_FORMAT` environment-variable fallback, consulted only when the
+  flag is not passed) selects structured JSON diagnostic logging instead of the previous
+  text-only output, for log shippers/aggregators that expect JSON. `mcp-cli`'s `--format`
+  (command *result* output) is unaffected — the two are independent. Adding this to
+  `mcp-execution-server` required giving that binary a real argv parser
+  (`clap`) for the first time: it now honors `--help`/`--version` and rejects unknown
+  arguments with exit code 2, instead of silently ignoring all argv as before — a low-risk
+  change, since no in-repo `mcp.json` entry passes this server any arguments (#399).
 
 ### Changed
 
@@ -138,6 +147,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on a `categorized_tools` validation failure. A failed validation leaves the session in place,
   at its original expiry, for the caller to retry with the same `session_id` instead of a
   single bad entry (typo'd tool name, duplicate, too many entries) permanently burning it (#371).
+- **`mcp-execution-core`**: `redact_urls_in_text` could produce invalid JSON in structured
+  (`--log-format json`) logging mode when a redacted URL appeared inside a `serde_json`-escaped
+  string (e.g. a quoted URL in error prose): the trailing-punctuation trim applied to the
+  matched token absorbed and deleted the backslash `serde_json` inserts before an escaped `"`,
+  leaving a bare, unescaped quote behind. The trim set now includes `\` so that backslash is
+  left untouched and re-emitted verbatim (#399).
 
 ### Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "dirs",
  "futures-util",
  "mcp-execution-codegen",

--- a/crates/mcp-cli/README.md
+++ b/crates/mcp-cli/README.md
@@ -102,6 +102,8 @@ mcp-execution-cli generate <SERVER> [OPTIONS]
 - `--progressive-output <PATH>`: Custom output directory
 - `--dry-run`: Preview files that would be generated without writing to disk
 - `--format <FORMAT>`: Output format (json, text, pretty)
+- `--log-format <FORMAT>`: Diagnostic log format (text, json); falls back to
+  `MCP_EXECUTION_LOG_FORMAT` when unset
 
 **Examples**:
 
@@ -147,6 +149,8 @@ mcp-execution-cli introspect <SERVER> [OPTIONS]
 - `--env <KEY=VALUE>`: Environment variable (repeatable)
 - `--detailed`: Show full input/output schemas
 - `--format <FORMAT>`: Output format (json, text, pretty)
+- `--log-format <FORMAT>`: Diagnostic log format (text, json); falls back to
+  `MCP_EXECUTION_LOG_FORMAT` when unset
 - `--http <URL>`: Use HTTP transport
 - `--sse <URL>`: Use SSE transport
 

--- a/crates/mcp-cli/src/cli.rs
+++ b/crates/mcp-cli/src/cli.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 use crate::actions::ServerAction;
 use crate::commands::common::{ServerSource, TransportArgs};
-use mcp_execution_core::cli::OutputFormat;
+use mcp_execution_core::cli::{LogFormat, OutputFormat};
 use mcp_execution_core::{Error as CoreError, RedactedItems, RedactedUrl, sanitize_path_for_error};
 
 /// MCP Code Execution - Secure WASM-based MCP tool execution.
@@ -54,6 +54,20 @@ pub struct Cli {
             .map(|s| OutputFormat::from_str(&s).expect("possible values are OutputFormat variants"))
     )]
     pub format: OutputFormat,
+
+    /// Diagnostic log format: `text` (default) or `json`.
+    ///
+    /// Independent of `--format`, which controls command *result* output, not diagnostic
+    /// logging. When unset, falls back to the `MCP_EXECUTION_LOG_FORMAT` environment variable;
+    /// when that is also unset or invalid, defaults to `text`.
+    #[arg(
+        long = "log-format",
+        global = true,
+        ignore_case = true,
+        value_parser = PossibleValuesParser::new(["text", "json"])
+            .map(|s| LogFormat::from_str(&s).expect("possible values are LogFormat variants"))
+    )]
+    pub log_format: Option<LogFormat>,
 }
 
 // Hand-written to redact `Commands::Introspect`'s `env`/`headers`/`http`/`sse`
@@ -73,11 +87,13 @@ impl fmt::Debug for Cli {
             command,
             verbose,
             format,
+            log_format,
         } = self;
         f.debug_struct("Cli")
             .field("command", command)
             .field("verbose", verbose)
             .field("format", format)
+            .field("log_format", log_format)
             .finish()
     }
 }
@@ -849,6 +865,68 @@ mod tests {
     fn test_output_format_parsing_invalid() {
         use mcp_execution_core::cli::OutputFormat;
         assert!("invalid".parse::<OutputFormat>().is_err());
+    }
+
+    #[test]
+    fn test_cli_log_format_default_unset() {
+        let cli = Cli::parse_from(["mcp-cli", "introspect", "github"]);
+        assert_eq!(cli.log_format, None);
+    }
+
+    #[test]
+    fn test_cli_log_format_json() {
+        let cli = Cli::parse_from(["mcp-cli", "--log-format", "json", "introspect", "github"]);
+        assert_eq!(cli.log_format, Some(LogFormat::Json));
+    }
+
+    #[test]
+    fn test_cli_log_format_case_insensitive() {
+        let cli = Cli::parse_from(["mcp-cli", "--log-format", "JSON", "introspect", "github"]);
+        assert_eq!(cli.log_format, Some(LogFormat::Json));
+    }
+
+    #[test]
+    fn test_cli_log_format_invalid_rejected_by_clap() {
+        let result =
+            Cli::try_parse_from(["mcp-cli", "--log-format", "xml", "introspect", "github"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_log_format_global_flag_accepted_after_subcommand() {
+        let cli = Cli::parse_from(["mcp-cli", "introspect", "github", "--log-format", "json"]);
+        assert_eq!(cli.log_format, Some(LogFormat::Json));
+    }
+
+    #[test]
+    fn test_cli_log_format_possible_values_parse_via_from_str() {
+        let cmd = Cli::command();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id() == "log_format")
+            .expect("--log-format argument must exist");
+        let values = arg.get_possible_values();
+        assert!(
+            !values.is_empty(),
+            "--log-format must declare possible values"
+        );
+        for possible_value in values {
+            let name = possible_value.get_name();
+            assert!(
+                LogFormat::from_str(name).is_ok(),
+                "{name} must parse via LogFormat::from_str to match the --log-format value parser"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cli_log_format_help_documents_env_var() {
+        let mut command = Cli::command();
+        let help = command.render_long_help().to_string();
+        assert!(
+            help.contains("MCP_EXECUTION_LOG_FORMAT"),
+            "--help must document the MCP_EXECUTION_LOG_FORMAT environment variable per FR-004"
+        );
     }
 
     #[test]

--- a/crates/mcp-cli/src/main.rs
+++ b/crates/mcp-cli/src/main.rs
@@ -30,11 +30,11 @@ use mcp_execution_cli::runner;
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    runner::init_logging(cli.verbose)?;
+    runner::init_logging(cli.verbose, cli.log_format)?;
 
-    // `--format` is typed as `OutputFormat` directly (clap's `FromStr`-based
-    // auto value parser), so an invalid value (e.g. `--format xml`) is
-    // already rejected by clap itself before this point.
+    // `--format` is typed as `OutputFormat` directly (a `PossibleValuesParser`-based value
+    // parser, see `cli.rs`), so an invalid value (e.g. `--format xml`) is already rejected by
+    // clap itself before this point.
     let exit_code = runner::execute_command(cli.command, cli.format).await?;
 
     std::process::exit(exit_code.as_i32());

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -6,9 +6,9 @@ use std::io::{self, Write};
 
 use anyhow::Result;
 use mcp_execution_core::Error as CoreError;
-use mcp_execution_core::cli::{ExitCode, OutputFormat};
+use mcp_execution_core::cli::{ExitCode, LOG_FORMAT_ENV_VAR, LogFormat, OutputFormat};
 use mcp_execution_files::FilesError;
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{EnvFilter, Layer as _, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::cli::Commands;
 use crate::commands;
@@ -47,6 +47,31 @@ impl<W: Write> Write for RedactingWriter<W> {
     }
 }
 
+/// Resolves the effective log format from `log_format` (the `--log-format` flag value) and the
+/// `MCP_EXECUTION_LOG_FORMAT` environment variable, mirroring `mcp-execution-server`'s
+/// `resolve_log_format`. Kept as its own function (rather than inlined in [`init_logging`]) so a
+/// test can assert the environment variable is actually consulted -- see
+/// `resolve_log_format_reads_env_var_when_flag_unset` -- rather than only exercising the pure
+/// `LogFormat::resolve` this delegates to.
+fn resolve_log_format(log_format: Option<LogFormat>) -> LogFormat {
+    let env_value = std::env::var(LOG_FORMAT_ENV_VAR).ok();
+    LogFormat::resolve(log_format, env_value.as_deref())
+}
+
+/// Whether [`init_logging`] should warn about a rejected `MCP_EXECUTION_LOG_FORMAT` value: the
+/// flag was not passed (matching `LogFormat::resolve`'s own precedence -- a bad env value is not
+/// even inspected once the flag has decided, so it must not warn either) and the environment
+/// variable is set to a non-empty value [`LogFormat::is_invalid_env_value`] rejects. Kept
+/// separate from [`resolve_log_format`] (rather than a second return value there) since
+/// production code needs only a yes/no answer, not the rejected value itself -- see
+/// [`LogFormat::resolve`]'s own doc comment on why that value isn't threaded through.
+fn log_format_env_is_invalid(log_format: Option<LogFormat>) -> bool {
+    log_format.is_none()
+        && std::env::var(LOG_FORMAT_ENV_VAR)
+            .ok()
+            .is_some_and(|raw| LogFormat::is_invalid_env_value(&raw))
+}
+
 /// Initializes logging infrastructure.
 ///
 /// Sets up tracing with appropriate log levels based on verbosity flag.
@@ -56,10 +81,17 @@ impl<W: Write> Write for RedactingWriter<W> {
 /// project's own, since a dependency's `tracing` output cannot go through this crate's
 /// `Debug`/[`escape_error_text`] redaction paths.
 ///
+/// `log_format` selects text or JSON output. When `None` (the flag was not passed),
+/// [`LogFormat::resolve`] consults the `MCP_EXECUTION_LOG_FORMAT` environment variable; an unset
+/// or invalid environment value falls back to text with a `WARN`-level log line (never echoing
+/// the rejected raw value — see the project's log-injection hardening for this switch).
+///
 /// # Arguments
 ///
 /// * `verbose` - If true, sets log level to DEBUG; otherwise uses INFO or
 ///   environment variable override via `RUST_LOG`
+/// * `log_format` - `--log-format` flag value, or `None` to consult
+///   `MCP_EXECUTION_LOG_FORMAT`
 ///
 /// # Errors
 ///
@@ -74,20 +106,37 @@ impl<W: Write> Write for RedactingWriter<W> {
 ///
 /// // `no_run`: this installs a process-global tracing subscriber, which
 /// // panics if called more than once in the same process.
-/// runner::init_logging(false)?;
+/// runner::init_logging(false, None)?;
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub fn init_logging(verbose: bool) -> Result<()> {
+pub fn init_logging(verbose: bool, log_format: Option<LogFormat>) -> Result<()> {
     let filter = if verbose {
         EnvFilter::new("debug")
     } else {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
     };
 
+    let format = resolve_log_format(log_format);
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(|| RedactingWriter(io::stderr()));
+    let layer = match format {
+        LogFormat::Json => fmt_layer.json().boxed(),
+        LogFormat::Text => fmt_layer.boxed(),
+    };
+
     tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer().with_writer(|| RedactingWriter(io::stderr())))
+        .with(layer)
         .init();
+
+    // No raw value interpolation: the rejected value already comes from an external environment
+    // variable, and echoing it into a log line — even truncated — would open a log-injection
+    // vector for whoever controls the process environment.
+    if log_format_env_is_invalid(log_format) {
+        tracing::warn!(
+            "invalid value for {LOG_FORMAT_ENV_VAR} (expected 'text' or 'json'), falling back to text"
+        );
+    }
 
     Ok(())
 }
@@ -818,5 +867,217 @@ mod tests {
         );
         assert!(written.contains("https://api.example.invalid/mcp?<redacted>"));
         assert!(written.contains("when send initialize request"));
+    }
+
+    /// JSON-mode counterpart to `test_redacting_writer_wired_into_real_fmt_layer_redacts_full_event`:
+    /// wires `RedactingWriter` through a real `fmt::layer().json()` (the `.boxed()` branch
+    /// `init_logging` takes for `LogFormat::Json`) and asserts (a) the secret never reaches the
+    /// sink, (b) the redaction marker is present, and (c) every emitted line parses as JSON via
+    /// `serde_json` -- the assertion that would have caught the C1 regression (an unescaped `"`
+    /// left behind when a redacted URL sits inside a JSON-escaped string).
+    #[test]
+    fn test_redacting_writer_wired_into_real_json_layer_emits_valid_json() {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().write(buf)
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                self.0.lock().unwrap().flush()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = {
+            let buf = buf.clone();
+            move || RedactingWriter(SharedBuf(buf.clone()))
+        };
+
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(make_writer)
+                .with_ansi(false),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::error!(
+                "failed to connect to \"https://api.example.invalid/mcp?token=hunter2secret\" after 3 tries"
+            );
+        });
+
+        let written = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            !written.contains("hunter2secret"),
+            "secret leaked: {written}"
+        );
+        assert!(written.contains("<redacted>"));
+
+        for line in written.lines().filter(|line| !line.is_empty()) {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|e| panic!("invalid JSON line: {e}\n{line}"));
+        }
+    }
+
+    /// Serializes tests in this module that mutate `MCP_EXECUTION_LOG_FORMAT`, mirroring
+    /// `BACKTRACE_ENV_LOCK` above and `mcp-execution-server`'s own `LOG_FORMAT_ENV_LOCK`: a
+    /// safety net for plain `cargo test` (which shares one process across a crate's tests), not
+    /// required by the mandated `cargo nextest run` (which isolates every test in its own
+    /// process).
+    static LOG_FORMAT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Proves `resolve_log_format` -- the function `init_logging` actually calls -- reads the
+    /// real `MCP_EXECUTION_LOG_FORMAT` environment variable itself, not just that the pure
+    /// `LogFormat::resolve` it delegates to works given a hand-built `Option<&str>`. A version of
+    /// `resolve_log_format` that dropped the `std::env::var` call entirely would still pass every
+    /// other test in this module.
+    #[test]
+    fn resolve_log_format_reads_env_var_when_flag_unset() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "json");
+        }
+
+        let format = resolve_log_format(None);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert_eq!(format, LogFormat::Json);
+    }
+
+    #[test]
+    fn resolve_log_format_flag_wins_over_bad_env() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "xml");
+        }
+
+        let format = resolve_log_format(Some(LogFormat::Json));
+        let is_invalid = log_format_env_is_invalid(Some(LogFormat::Json));
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert_eq!(format, LogFormat::Json);
+        assert!(
+            !is_invalid,
+            "a bad env value must not be reported once the flag has already decided"
+        );
+    }
+
+    #[test]
+    fn resolve_log_format_bad_env_value_falls_back_to_text() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "xml");
+        }
+
+        let format = resolve_log_format(None);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert_eq!(format, LogFormat::Text);
+    }
+
+    /// Proves `log_format_env_is_invalid` -- the function that actually gates `init_logging`'s
+    /// warning -- reads the real environment variable itself, not just that
+    /// `LogFormat::is_invalid_env_value` works given a hand-built `&str`.
+    #[test]
+    fn log_format_env_is_invalid_true_for_bad_value_when_flag_unset() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "xml");
+        }
+
+        let is_invalid = log_format_env_is_invalid(None);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert!(is_invalid);
+    }
+
+    #[test]
+    fn log_format_env_is_invalid_false_for_valid_value() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "json");
+        }
+
+        let is_invalid = log_format_env_is_invalid(None);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert!(!is_invalid);
+    }
+
+    #[test]
+    fn log_format_env_is_invalid_false_when_unset() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::remove_var(LOG_FORMAT_ENV_VAR);
+        }
+
+        let is_invalid = log_format_env_is_invalid(None);
+
+        // SAFETY: see above.
+        unsafe {
+            if let Some(v) = &original {
+                std::env::set_var(LOG_FORMAT_ENV_VAR, v);
+            }
+        }
+
+        assert!(!is_invalid);
     }
 }

--- a/crates/mcp-core/src/cli.rs
+++ b/crates/mcp-core/src/cli.rs
@@ -262,6 +262,173 @@ impl fmt::Display for ExitCode {
     }
 }
 
+/// Diagnostic log output format.
+///
+/// Selects whether `mcp-execution-cli` and `mcp-execution-server` emit human-readable text logs
+/// or structured JSON logs. Independent of [`OutputFormat`], which controls command *result*
+/// output, not diagnostic logging.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::cli::LogFormat;
+///
+/// let format = LogFormat::Json;
+/// assert_eq!(format.as_str(), "json");
+///
+/// let format: LogFormat = "TEXT".parse().unwrap();
+/// assert_eq!(format, LogFormat::Text);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum LogFormat {
+    /// Human-readable text logs.
+    #[default]
+    Text,
+    /// Structured JSON logs, one object per line.
+    Json,
+}
+
+impl LogFormat {
+    /// Returns the string representation of the format.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::cli::LogFormat;
+    ///
+    /// assert_eq!(LogFormat::Text.as_str(), "text");
+    /// assert_eq!(LogFormat::Json.as_str(), "json");
+    /// ```
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Json => "json",
+        }
+    }
+
+    /// Resolves the effective log format from an optional CLI flag value and an optional raw
+    /// environment variable value.
+    ///
+    /// Precedence: `flag` wins unconditionally when set — `env_value` is not even inspected, so a
+    /// malformed environment value has no effect on the result once the flag has already resolved
+    /// the format. Otherwise the env value is parsed via [`LogFormat::parse_env`], which treats
+    /// an empty/whitespace-only or unrecognized value alike as "no override" and falls back to
+    /// [`LogFormat::default`].
+    ///
+    /// Returns only the resolved format, not the rejected raw value: neither production caller
+    /// logs it (a raw `MCP_EXECUTION_LOG_FORMAT` value is untrusted external input, and echoing
+    /// it — even truncated — would open a log-injection vector), so carrying it through this
+    /// return type would be a capability with no real consumer. A caller that needs to know
+    /// *whether* the env value was invalid specifically (as opposed to merely absent), e.g. to
+    /// decide whether to log a warning, calls [`LogFormat::is_invalid_env_value`] separately.
+    ///
+    /// Deliberately free of `std::env` access itself: callers pass
+    /// `std::env::var(LOG_FORMAT_ENV_VAR).ok()` in, which keeps precedence and fallback behavior
+    /// testable without mutating process environment state. One accepted consequence of that
+    /// call shape: a non-UTF-8 `MCP_EXECUTION_LOG_FORMAT` value folds to `Err(VarError::NotUnicode(_))`,
+    /// hence `None` here, so it is silently treated as *unset* rather than *invalid* — unlike a
+    /// valid-UTF-8 but unrecognized value (e.g. `"xml"`), which [`LogFormat::is_invalid_env_value`]
+    /// does flag for a caller to warn about. Not worth switching callers to `std::env::var_os` to
+    /// close this gap: a non-UTF-8 value is exceedingly unlikely for a variable whose only valid
+    /// values are ASCII, and the failure mode (no warning, falls back to the same default a bad
+    /// value would) is identical either way.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::cli::LogFormat;
+    ///
+    /// // The flag wins even over a valid env value.
+    /// assert_eq!(LogFormat::resolve(Some(LogFormat::Json), Some("text")), LogFormat::Json);
+    ///
+    /// // No flag: a valid env value is used, case-insensitively.
+    /// assert_eq!(LogFormat::resolve(None, Some("JSON")), LogFormat::Json);
+    ///
+    /// // No flag, unrecognized env value: falls back to the default (`Text`).
+    /// assert_eq!(LogFormat::resolve(None, Some("xml")), LogFormat::Text);
+    /// ```
+    #[must_use]
+    pub fn resolve(flag: Option<Self>, env_value: Option<&str>) -> Self {
+        flag.or_else(|| env_value.and_then(Self::parse_env))
+            .unwrap_or_default()
+    }
+
+    /// Parses a raw `MCP_EXECUTION_LOG_FORMAT` environment-variable value.
+    ///
+    /// Returns `None` uniformly for an empty/whitespace-only value and for one that doesn't
+    /// match `text`/`json` (case-insensitive) — both are "no override" as far as [`resolve`]
+    /// is concerned. Use [`LogFormat::is_invalid_env_value`] when the two `None` cases need to
+    /// be told apart (e.g. to decide whether a caller should warn about a rejected value).
+    ///
+    /// [`resolve`]: LogFormat::resolve
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::cli::LogFormat;
+    ///
+    /// assert_eq!(LogFormat::parse_env("json"), Some(LogFormat::Json));
+    /// assert_eq!(LogFormat::parse_env("JSON"), Some(LogFormat::Json));
+    /// assert_eq!(LogFormat::parse_env(""), None);
+    /// assert_eq!(LogFormat::parse_env("   "), None);
+    /// assert_eq!(LogFormat::parse_env("xml"), None);
+    /// ```
+    #[must_use]
+    pub fn parse_env(raw: &str) -> Option<Self> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        trimmed.parse().ok()
+    }
+
+    /// True when `raw` is a genuinely invalid `MCP_EXECUTION_LOG_FORMAT` value — non-empty and
+    /// not parseable via [`LogFormat::parse_env`] — as opposed to an empty/whitespace-only value,
+    /// which is merely "unset" and not worth warning about. Lets a caller decide whether to emit
+    /// a warning without re-implementing [`parse_env`](LogFormat::parse_env)'s own emptiness
+    /// check.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::cli::LogFormat;
+    ///
+    /// assert!(LogFormat::is_invalid_env_value("xml"));
+    /// assert!(!LogFormat::is_invalid_env_value("json"));
+    /// assert!(!LogFormat::is_invalid_env_value(""));
+    /// assert!(!LogFormat::is_invalid_env_value("   "));
+    /// ```
+    #[must_use]
+    pub fn is_invalid_env_value(raw: &str) -> bool {
+        !raw.trim().is_empty() && Self::parse_env(raw).is_none()
+    }
+}
+
+impl fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for LogFormat {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            _ => Err(crate::Error::InvalidArgument(format!(
+                "invalid log format: '{s}' (expected: text or json)"
+            ))),
+        }
+    }
+}
+
+/// Environment variable consulted for the default [`LogFormat`] when `--log-format` is not
+/// passed. See [`LogFormat::resolve`].
+pub const LOG_FORMAT_ENV_VAR: &str = "MCP_EXECUTION_LOG_FORMAT";
+
 /// Validated MCP server connection string.
 ///
 /// Ensures server identifiers are non-empty and contain only valid characters.
@@ -496,6 +663,116 @@ mod tests {
     fn test_exit_code_display() {
         assert_eq!(ExitCode::SUCCESS.to_string(), "0");
         assert_eq!(ExitCode::ERROR.to_string(), "1");
+    }
+
+    // LogFormat tests
+    #[test]
+    fn test_log_format_as_str() {
+        assert_eq!(LogFormat::Text.as_str(), "text");
+        assert_eq!(LogFormat::Json.as_str(), "json");
+    }
+
+    #[test]
+    fn test_log_format_default() {
+        assert_eq!(LogFormat::default(), LogFormat::Text);
+    }
+
+    #[test]
+    fn test_log_format_from_str_valid_case_insensitive() {
+        assert_eq!("text".parse::<LogFormat>().unwrap(), LogFormat::Text);
+        assert_eq!("JSON".parse::<LogFormat>().unwrap(), LogFormat::Json);
+        assert_eq!("Json".parse::<LogFormat>().unwrap(), LogFormat::Json);
+    }
+
+    #[test]
+    fn test_log_format_from_str_invalid() {
+        assert!("xml".parse::<LogFormat>().is_err());
+        assert!("".parse::<LogFormat>().is_err());
+    }
+
+    #[test]
+    fn test_log_format_display() {
+        assert_eq!(LogFormat::Text.to_string(), "text");
+        assert_eq!(LogFormat::Json.to_string(), "json");
+    }
+
+    #[test]
+    fn test_log_format_resolve_flag_wins_over_valid_env() {
+        assert_eq!(
+            LogFormat::resolve(Some(LogFormat::Json), Some("text")),
+            LogFormat::Json
+        );
+    }
+
+    #[test]
+    fn test_log_format_resolve_flag_wins_over_bad_env() {
+        assert_eq!(
+            LogFormat::resolve(Some(LogFormat::Text), Some("xml")),
+            LogFormat::Text
+        );
+    }
+
+    #[test]
+    fn test_log_format_resolve_env_used_when_flag_none() {
+        assert_eq!(LogFormat::resolve(None, Some("json")), LogFormat::Json);
+    }
+
+    #[test]
+    fn test_log_format_resolve_env_case_insensitive() {
+        assert_eq!(LogFormat::resolve(None, Some("JSON")), LogFormat::Json);
+    }
+
+    #[test]
+    fn test_log_format_resolve_no_flag_no_env_defaults_to_text() {
+        assert_eq!(LogFormat::resolve(None, None), LogFormat::Text);
+    }
+
+    #[test]
+    fn test_log_format_resolve_empty_or_whitespace_env_treated_as_unset() {
+        assert_eq!(LogFormat::resolve(None, Some("")), LogFormat::Text);
+        assert_eq!(LogFormat::resolve(None, Some("   ")), LogFormat::Text);
+    }
+
+    #[test]
+    fn test_log_format_resolve_unknown_env_falls_back_to_default() {
+        assert_eq!(LogFormat::resolve(None, Some("xml")), LogFormat::Text);
+    }
+
+    // LogFormat::parse_env tests
+    #[test]
+    fn test_log_format_parse_env_valid_case_insensitive() {
+        assert_eq!(LogFormat::parse_env("text"), Some(LogFormat::Text));
+        assert_eq!(LogFormat::parse_env("JSON"), Some(LogFormat::Json));
+        assert_eq!(LogFormat::parse_env("Json"), Some(LogFormat::Json));
+    }
+
+    #[test]
+    fn test_log_format_parse_env_empty_or_whitespace_is_none() {
+        assert_eq!(LogFormat::parse_env(""), None);
+        assert_eq!(LogFormat::parse_env("   "), None);
+    }
+
+    #[test]
+    fn test_log_format_parse_env_invalid_is_none() {
+        assert_eq!(LogFormat::parse_env("xml"), None);
+    }
+
+    // LogFormat::is_invalid_env_value tests
+    #[test]
+    fn test_log_format_is_invalid_env_value_true_for_unparseable_non_empty_value() {
+        assert!(LogFormat::is_invalid_env_value("xml"));
+    }
+
+    #[test]
+    fn test_log_format_is_invalid_env_value_false_for_valid_value() {
+        assert!(!LogFormat::is_invalid_env_value("json"));
+        assert!(!LogFormat::is_invalid_env_value("TEXT"));
+    }
+
+    #[test]
+    fn test_log_format_is_invalid_env_value_false_for_empty_or_whitespace() {
+        assert!(!LogFormat::is_invalid_env_value(""));
+        assert!(!LogFormat::is_invalid_env_value("   "));
     }
 
     // ServerConnectionString tests

--- a/crates/mcp-core/src/redact.rs
+++ b/crates/mcp-core/src/redact.rs
@@ -223,8 +223,12 @@ fn is_token_terminator(c: char) -> bool {
 /// scheme-legal characters, then walking right to the first whitespace,
 /// control character, or wrapping-punctuation character (quote, backtick,
 /// paren — or the end of `text`), then trimming trailing sentence
-/// punctuation (`,` `.` `;` `:`) that a log message or `Display` impl
-/// commonly appends after a URL. That terminator set is deliberately
+/// punctuation (`,` `.` `;` `:` `\`) that a log message or `Display` impl
+/// commonly appends after a URL — the backslash covers the escaping
+/// backslash a JSON string serializer inserts before a `"` that closes a
+/// quoted URL, which the token walk otherwise absorbs as part of the URL
+/// and then deletes, leaving the quote unescaped and the JSON invalid.
+/// That terminator set is deliberately
 /// narrower than "every character invalid in a URL" — RFC 3986 IP-literal
 /// delimiters (`[`/`]`, needed verbatim for an IPv6 authority like
 /// `http://[::1]:1/path`) and every other RFC 3986 "unsafe" character are
@@ -236,6 +240,16 @@ fn is_token_terminator(c: char) -> bool {
 /// wrap one", so a token capturing a few extra characters of trailing
 /// prose is the accepted cost of never capturing too few and truncating a
 /// secret.
+///
+/// The `\` addition to the trim set (above) has its own over-capture corollary in JSON mode: a
+/// raw control character (e.g. a literal newline) immediately after a URL, once JSON-escaped to
+/// a printable two-character sequence like `\n`, is no longer a `is_token_terminator` match —
+/// neither `\` nor the following letter is whitespace, control, or wrapping punctuation — so the
+/// token walk continues past it and swallows whatever prose follows, right up to the next real
+/// terminator, into the redaction. This is the same "over-capture is the safe failure mode"
+/// contract already documented above, not a new class of gap: no secret leaks and the output
+/// stays valid JSON, the same guarantee the `\"`-preserving fix targets — it just means slightly
+/// more trailing prose than usual is swallowed on this specific input shape.
 ///
 /// The one residual gap from this heuristic: a raw, un-percent-encoded
 /// instance of *any* terminator character — whitespace and control
@@ -375,7 +389,7 @@ pub fn redact_urls_in_text(text: &str) -> String {
             }
         }
 
-        let token = text[start..end].trim_end_matches([',', '.', ';', ':']);
+        let token = text[start..end].trim_end_matches([',', '.', ';', ':', '\\']);
 
         out.push_str(&text[cursor..start]);
         // Infallible: `String`'s `fmt::Write` impl never returns `Err`.
@@ -686,5 +700,37 @@ mod tests {
         let line = "url http://127.0.0.1:1/mcp?<redacted> failed";
         let redacted = redact_urls_in_text(line);
         assert_eq!(redacted, line);
+    }
+
+    /// Regression test for the JSON-mode logging bug (`MCP_EXECUTION_LOG_FORMAT=json`): when
+    /// `redact_urls_in_text` runs on text that is itself a `serde_json`-escaped JSON string value
+    /// -- the shape `RedactingWriter` sees when it wraps a `tracing_subscriber` JSON formatter's
+    /// already-serialized output -- the backslash `serde_json` inserts before an escaped `"` must
+    /// survive redaction. Before the `'\\'` trim-set fix, the token walk absorbed that backslash
+    /// into the URL token and deleted it on replacement, leaving a bare unescaped `"` and invalid
+    /// JSON. Covers the quoted-URL shape (the one that reproduced the bug) plus four related
+    /// shapes that must keep working.
+    #[test]
+    fn redact_urls_in_text_output_stays_valid_json_after_escaping() {
+        let raw_lines = [
+            r#"failed to connect to "https://api.example.invalid/mcp?token=hunter2secret" after 3 tries"#,
+            "failed to connect to https://api.example.invalid/mcp?token=hunter2secret after 3 tries",
+            "failed to connect to (https://api.example.invalid/mcp?token=hunter2secret) after 3 tries",
+            "failed to connect to https://user:hunter2secret@api.example.invalid/mcp?x=1 after 3 tries",
+            "failed to connect to https://api.example.invalid/mcp?token=hunter2secret\\ after 3 tries",
+        ];
+
+        for raw in raw_lines {
+            let json_field = serde_json::to_string(raw).expect("string always encodes");
+            let redacted = redact_urls_in_text(&json_field);
+            assert!(
+                !redacted.contains("hunter2secret"),
+                "secret leaked for {raw:?}: {redacted}"
+            );
+
+            let json_line = format!(r#"{{"message":{redacted}}}"#);
+            serde_json::from_str::<serde_json::Value>(&json_line)
+                .unwrap_or_else(|e| panic!("invalid JSON for {raw:?}: {e}\n{json_line}"));
+        }
     }
 }

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["derive"] }
 dirs = { workspace = true }
 futures-util = { workspace = true }
 mcp-execution-codegen = { workspace = true }
@@ -39,7 +40,7 @@ tokio = { workspace = true, features = [
 ] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/crates/mcp-server/README.md
+++ b/crates/mcp-server/README.md
@@ -32,6 +32,14 @@ mcp-execution
 cargo run -p mcp-execution-server
 ```
 
+> [!NOTE]
+> The `mcp-execution` binary parses its command-line arguments: `--help`/`--version` are
+> supported, and unknown arguments now exit with code 2 instead of being silently ignored.
+> `--log-format {text,json}` selects the diagnostic log format written to stderr (default
+> `text`); it falls back to the `MCP_EXECUTION_LOG_FORMAT` environment variable when the flag
+> isn't passed. No existing `mcp.json` entry needs to change — this server takes no arguments
+> by default.
+
 ### Claude Code Configuration
 
 Add to `~/.claude/mcp.json`:

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -9,7 +9,7 @@
 //! Run the server via stdio transport:
 //!
 //! ```bash
-//! mcp-execution-server
+//! mcp-execution
 //! ```
 //!
 //! Or configure in `~/.config/claude/mcp.json`:
@@ -18,15 +18,18 @@
 //! {
 //!   "mcpServers": {
 //!     "mcp-execution": {
-//!       "command": "mcp-execution-server"
+//!       "command": "mcp-execution"
 //!     }
 //!   }
 //! }
 //! ```
 
 use anyhow::Result;
+use clap::Parser;
+use clap::builder::{PossibleValuesParser, TypedValueParser as _};
 use futures_util::StreamExt;
 use futures_util::stream::{self, Stream};
+use mcp_execution_core::cli::{LOG_FORMAT_ENV_VAR, LogFormat};
 use mcp_execution_server::service::GeneratorService;
 use rmcp::RoleServer;
 use rmcp::ServiceExt;
@@ -35,6 +38,7 @@ use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::async_rw::{JsonRpcMessageCodec, JsonRpcMessageCodecError};
 use rmcp::transport::stdio;
 use std::collections::VecDeque;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
 use tokio::io::AsyncRead;
@@ -42,7 +46,77 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::bytes::BytesMut;
 use tokio_util::codec::{Decoder, FramedRead, FramedWrite};
 use tokio_util::sync::PollSemaphore;
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{EnvFilter, Layer as _, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Command-line arguments for the `mcp-execution` server binary.
+///
+/// Minimal by design: today, no in-repo `mcp.json` entry passes arguments to this server (see
+/// `examples/README.md`, `crates/mcp-server/README.md`), so adding `clap` here to gain
+/// `--log-format` is a deliberate, low-risk behavior change -- the binary now parses argv
+/// (gaining `--help`/`--version`, both written to stdout, harmless since the process exits
+/// immediately after) and rejects unknown arguments with exit code 2, rather than silently
+/// ignoring them as before.
+#[derive(Parser)]
+#[command(
+    name = "mcp-execution",
+    version,
+    about = "MCP server for progressive loading TypeScript code generation"
+)]
+struct ServerArgs {
+    /// Diagnostic log format: `text` (default) or `json`.
+    ///
+    /// Independent of the MCP protocol's own JSON-RPC framing on stdout; this only affects the
+    /// diagnostic logs this process writes to stderr. When unset, falls back to the
+    /// `MCP_EXECUTION_LOG_FORMAT` environment variable; when that is also unset or invalid,
+    /// defaults to `text`.
+    #[arg(
+        long = "log-format",
+        ignore_case = true,
+        value_parser = PossibleValuesParser::new(["text", "json"])
+            .map(|s| LogFormat::from_str(&s).expect("possible values are LogFormat variants"))
+    )]
+    log_format: Option<LogFormat>,
+}
+
+/// Resolves the effective log format from the parsed `--log-format` flag and the
+/// `MCP_EXECUTION_LOG_FORMAT` environment variable, mirroring `mcp-execution-cli`'s
+/// `runner::init_logging`. Kept as its own function (rather than inlined in `main`) so tests can
+/// assert the environment variable is actually consulted -- see
+/// `resolve_log_format_reads_env_var_when_flag_unset` -- rather than only exercising the pure
+/// `LogFormat::resolve` this delegates to.
+fn resolve_log_format(args: &ServerArgs) -> LogFormat {
+    let env_value = std::env::var(LOG_FORMAT_ENV_VAR).ok();
+    LogFormat::resolve(args.log_format, env_value.as_deref())
+}
+
+/// Whether `main` should warn about a rejected `MCP_EXECUTION_LOG_FORMAT` value: the flag was
+/// not passed (matching `LogFormat::resolve`'s own precedence -- a bad env value is not even
+/// inspected once the flag has decided, so it must not warn either) and the environment variable
+/// is set to a non-empty value [`LogFormat::is_invalid_env_value`] rejects. A separate function
+/// from [`resolve_log_format`] (rather than a second return value there) since production code
+/// needs only a yes/no answer, not the rejected value itself -- see [`LogFormat::resolve`]'s own
+/// doc comment on why that value isn't threaded through.
+fn log_format_env_is_invalid(args: &ServerArgs) -> bool {
+    args.log_format.is_none()
+        && std::env::var(LOG_FORMAT_ENV_VAR)
+            .ok()
+            .is_some_and(|raw| LogFormat::is_invalid_env_value(&raw))
+}
+
+/// Emits the fixed-message `WARN` log line for a rejected `MCP_EXECUTION_LOG_FORMAT` value.
+/// Deliberately takes no reference to the rejected value itself: interpolating external
+/// environment input into this line -- even truncated -- would open a log-injection vector,
+/// since this process has no `RedactingWriter` guarding its logs (see `main`'s comment on the
+/// `tracing_subscriber::registry()` setup). Extracted so a test can assert this actually fires
+/// on a rejected value, using the same `WarnCounter` subscriber pattern already established
+/// below for [`bounded_request_stream`]'s own warnings.
+fn warn_on_rejected_log_format(rejected: bool) {
+    if rejected {
+        tracing::warn!(
+            "invalid value for {LOG_FORMAT_ENV_VAR} (expected 'text' or 'json'), falling back to text"
+        );
+    }
+}
 
 /// Maximum size, in bytes, of a single newline-delimited JSON-RPC request read from
 /// stdin. Requests exceeding this are discarded rather than buffered without bound.
@@ -427,7 +501,18 @@ where
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = ServerArgs::parse();
+    let log_format = resolve_log_format(&args);
+
     // Initialize logging to stderr (stdout is for MCP protocol)
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_target(true);
+    let layer = match log_format {
+        LogFormat::Json => fmt_layer.json().boxed(),
+        LogFormat::Text => fmt_layer.boxed(),
+    };
+
     tracing_subscriber::registry()
         .with(
             EnvFilter::try_from_default_env()
@@ -441,16 +526,18 @@ async fn main() -> Result<()> {
             // error whose `Display` could embed a secret-bearing URL for this writer to reach. The
             // #209 regression test (`service.rs`) guards that invariant; if a future change adds
             // an http/sse client path to this crate, wire the same writer in at that point.
-            tracing_subscriber::fmt::layer()
-                .with_writer(std::io::stderr)
-                .with_target(true),
+            //
+            // `MCP_EXECUTION_LOG_FORMAT` (see `resolve_log_format`) is a second,
+            // narrower untrusted-text-into-log path this process does have, but the warning
+            // logged below never echoes its rejected raw value -- only a fixed diagnostic string
+            // naming the environment variable is logged -- so it does not need this writer either.
+            layer,
         )
         .init();
 
-    tracing::info!(
-        "Starting mcp-execution-server v{}",
-        env!("CARGO_PKG_VERSION")
-    );
+    warn_on_rejected_log_format(log_format_env_is_invalid(&args));
+
+    tracing::info!("Starting mcp-execution v{}", env!("CARGO_PKG_VERSION"));
 
     // Wire stdio through a size-bounded codec instead of `stdio()` directly: the
     // default transport's read path bypasses the codec's max-length check entirely.
@@ -475,10 +562,12 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AsyncRead, GetExtensions, JsonRpcMessage, MAX_CONCURRENT_REQUESTS, MAX_REQUEST_LINE_SIZE,
-        OwnedSemaphorePermit, RoleServer, RxJsonRpcMessage, Semaphore, Stream, StreamExt,
-        bounded_request_stream,
+        AsyncRead, GetExtensions, JsonRpcMessage, LOG_FORMAT_ENV_VAR, LogFormat,
+        MAX_CONCURRENT_REQUESTS, MAX_REQUEST_LINE_SIZE, OwnedSemaphorePermit, RoleServer,
+        RxJsonRpcMessage, Semaphore, ServerArgs, Stream, StreamExt, bounded_request_stream,
+        log_format_env_is_invalid, resolve_log_format, warn_on_rejected_log_format,
     };
+    use clap::Parser as _;
     use mcp_execution_server::service::GeneratorService;
     use rmcp::ServiceExt;
     use rmcp::model::NumberOrString;
@@ -492,6 +581,7 @@ mod tests {
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, ReadBuf};
     use tokio_util::codec::FramedWrite;
+    use tracing_subscriber::layer::SubscriberExt;
 
     const TEST_MAX: usize = 64;
     const TEST_CONCURRENCY: usize = 8;
@@ -1285,5 +1375,291 @@ mod tests {
         drop(client_write);
         drop(client_reader);
         let _ = tokio::time::timeout(Duration::from_secs(5), service_task).await;
+    }
+
+    // ── #399: `--log-format`/`MCP_EXECUTION_LOG_FORMAT` wiring ──
+
+    #[test]
+    fn test_server_args_log_format_default_unset() {
+        let args = ServerArgs::parse_from(["mcp-execution"]);
+        assert_eq!(args.log_format, None);
+    }
+
+    #[test]
+    fn test_server_args_log_format_json_parses() {
+        let args = ServerArgs::parse_from(["mcp-execution", "--log-format", "json"]);
+        assert_eq!(args.log_format, Some(LogFormat::Json));
+    }
+
+    #[test]
+    fn test_server_args_log_format_case_insensitive() {
+        let args = ServerArgs::parse_from(["mcp-execution", "--log-format", "JSON"]);
+        assert_eq!(args.log_format, Some(LogFormat::Json));
+    }
+
+    #[test]
+    fn test_server_args_log_format_invalid_rejected_by_clap() {
+        let result = ServerArgs::try_parse_from(["mcp-execution", "--log-format", "xml"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_server_args_help_documents_env_var() {
+        use clap::CommandFactory;
+
+        let mut command = ServerArgs::command();
+        let help = command.render_long_help().to_string();
+        assert!(
+            help.contains(LOG_FORMAT_ENV_VAR),
+            "--help must document {LOG_FORMAT_ENV_VAR} per FR-004"
+        );
+    }
+
+    #[test]
+    fn test_server_args_command_name_matches_installed_binary() {
+        use clap::CommandFactory;
+
+        // `CARGO_PKG_NAME` is `mcp-execution-server`, but the installed binary (see
+        // `crates/mcp-server/Cargo.toml`'s `[[bin]]`) is `mcp-execution` -- `#[command(name =
+        // ...)]` on `ServerArgs` must override clap's default so `--help`/error output names
+        // the binary users actually run.
+        assert_eq!(ServerArgs::command().get_name(), "mcp-execution");
+    }
+
+    /// Serializes tests in this module that mutate `MCP_EXECUTION_LOG_FORMAT`, mirroring the
+    /// `HOME_ENV_LOCK`/`BACKTRACE_ENV_LOCK` pattern `mcp-cli`'s tests already use for
+    /// env-var mutation: a safety net for plain `cargo test` (which shares one process across a
+    /// crate's tests), not required by the mandated `cargo nextest run` (which isolates every
+    /// test in its own process).
+    static LOG_FORMAT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn resolve_log_format_flag_wins_over_bad_env() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "xml");
+        }
+
+        let args = ServerArgs {
+            log_format: Some(LogFormat::Json),
+        };
+        let format = resolve_log_format(&args);
+        let is_invalid = log_format_env_is_invalid(&args);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert_eq!(format, LogFormat::Json);
+        assert!(
+            !is_invalid,
+            "a bad env value must not be reported once the flag has already decided"
+        );
+    }
+
+    /// Proves the environment variable is actually consulted end to end -- not just that
+    /// `LogFormat::resolve` itself works in isolation: a `resolve_log_format` that forgot to
+    /// call `std::env::var(LOG_FORMAT_ENV_VAR)` would still pass every test that only exercises
+    /// the pure resolver directly with a hand-built `Option<&str>`.
+    #[test]
+    fn resolve_log_format_reads_env_var_when_flag_unset() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "json");
+        }
+
+        let args = ServerArgs { log_format: None };
+        let format = resolve_log_format(&args);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert_eq!(format, LogFormat::Json);
+    }
+
+    #[test]
+    fn resolve_log_format_bad_env_value_falls_back_to_text() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "xml");
+        }
+
+        let args = ServerArgs { log_format: None };
+        let format = resolve_log_format(&args);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert_eq!(format, LogFormat::Text);
+    }
+
+    /// Proves `log_format_env_is_invalid` -- the function that actually gates
+    /// `warn_on_rejected_log_format` in `main` -- reads the real environment variable itself,
+    /// not just that `LogFormat::is_invalid_env_value` works given a hand-built `&str`.
+    #[test]
+    fn log_format_env_is_invalid_true_for_bad_value_when_flag_unset() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "xml");
+        }
+
+        let args = ServerArgs { log_format: None };
+        let is_invalid = log_format_env_is_invalid(&args);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert!(is_invalid);
+    }
+
+    #[test]
+    fn log_format_env_is_invalid_false_for_valid_value() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::set_var(LOG_FORMAT_ENV_VAR, "json");
+        }
+
+        let args = ServerArgs { log_format: None };
+        let is_invalid = log_format_env_is_invalid(&args);
+
+        // SAFETY: see above.
+        unsafe {
+            match &original {
+                Some(v) => std::env::set_var(LOG_FORMAT_ENV_VAR, v),
+                None => std::env::remove_var(LOG_FORMAT_ENV_VAR),
+            }
+        }
+
+        assert!(!is_invalid);
+    }
+
+    #[test]
+    fn log_format_env_is_invalid_false_when_unset() {
+        let _guard = LOG_FORMAT_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os(LOG_FORMAT_ENV_VAR);
+        // SAFETY: guarded by `LOG_FORMAT_ENV_LOCK`; no other test in this process reads or
+        // writes `MCP_EXECUTION_LOG_FORMAT` while the guard is held.
+        unsafe {
+            std::env::remove_var(LOG_FORMAT_ENV_VAR);
+        }
+
+        let args = ServerArgs { log_format: None };
+        let is_invalid = log_format_env_is_invalid(&args);
+
+        // SAFETY: see above.
+        unsafe {
+            if let Some(v) = &original {
+                std::env::set_var(LOG_FORMAT_ENV_VAR, v);
+            }
+        }
+
+        assert!(!is_invalid);
+    }
+
+    #[test]
+    fn warn_on_rejected_log_format_fires_for_a_rejected_value() {
+        let warn_count = Arc::new(AtomicUsize::new(0));
+        let _tracing_guard = tracing::subscriber::set_default(WarnCounter(Arc::clone(&warn_count)));
+
+        warn_on_rejected_log_format(true);
+
+        assert_eq!(warn_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn warn_on_rejected_log_format_silent_when_nothing_was_rejected() {
+        let warn_count = Arc::new(AtomicUsize::new(0));
+        let _tracing_guard = tracing::subscriber::set_default(WarnCounter(Arc::clone(&warn_count)));
+
+        warn_on_rejected_log_format(false);
+
+        assert_eq!(warn_count.load(Ordering::SeqCst), 0);
+    }
+
+    /// JSON-mode coverage for the `.boxed()` branch `main` takes when `LogFormat::Json` is
+    /// selected: wires a real `fmt::layer().json()` into a scoped subscriber and asserts every
+    /// emitted line parses via `serde_json` -- the assertion that would have caught the C1
+    /// regression (an unescaped `"` left behind when a redacted URL sits inside a
+    /// JSON-escaped string; not exercised directly here since this binary has no
+    /// `RedactingWriter`, but the JSON-validity property must hold regardless).
+    #[test]
+    fn json_log_format_emits_serde_json_parseable_lines() {
+        use std::sync::Mutex;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl std::io::Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                std::io::Write::write(&mut *self.0.lock().unwrap(), buf)
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                std::io::Write::flush(&mut *self.0.lock().unwrap())
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = {
+            let buf = buf.clone();
+            move || SharedBuf(buf.clone())
+        };
+
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(make_writer)
+                .with_target(true)
+                .with_ansi(false),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("Starting mcp-execution v0.0.0-test");
+            tracing::warn!(
+                "invalid value for MCP_EXECUTION_LOG_FORMAT (expected 'text' or 'json'), falling back to text"
+            );
+        });
+
+        let written = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        let lines: Vec<&str> = written.lines().filter(|line| !line.is_empty()).collect();
+        assert_eq!(lines.len(), 2, "expected two emitted lines, got: {written}");
+        for line in lines {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|e| panic!("invalid JSON line: {e}\n{line}"));
+        }
     }
 }

--- a/specs/NFR-mcp-execution-2026-07-27.md
+++ b/specs/NFR-mcp-execution-2026-07-27.md
@@ -314,7 +314,7 @@ project controls); `MAX_CONCURRENT_REQUESTS` (8, server binary);
 | ID | Requirement | Details |
 |----|------------|---------|
 | NFR-POR-010 | Installation methods | `cargo install mcp-execution-cli` (crates.io, recommended); pre-built release binaries (GitHub Releases, per-platform archives); build from source (`cargo install --path crates/mcp-cli`); individual library crates via `cargo add` |
-| NFR-POR-011 | Configuration management | A single JSON file, `~/.claude/mcp.json`, read directly from the filesystem; no environment-variable-based or secrets-manager-based configuration path exists for this project's *own* configuration (as opposed to the *target* MCP servers it introspects, whose env vars it explicitly validates — see [[#4.1 Confidentiality]]) |
+| NFR-POR-011 | Configuration management | A single JSON file, `~/.claude/mcp.json`, read directly from the filesystem, plus one narrow environment-variable exception: `MCP_EXECUTION_LOG_FORMAT` (issue #399) selects diagnostic log format (`text`/`json`) for `mcp-execution-cli` and the `mcp-execution` server binary — an operational logging-output switch, not a secrets-manager-style configuration path, with no secret-shaped value ever accepted or echoed. No other environment-variable-based or secrets-manager-based configuration path exists for this project's *own* configuration (as opposed to the *target* MCP servers it introspects, whose env vars it explicitly validates — see [[#4.1 Confidentiality]]) |
 | NFR-POR-012 | MSRV policy | Rust 1.91 minimum, enforced by a dedicated CI job (`msrv`); README states MSRV increases are treated as minor version bumps |
 
 ## 9. Verification Matrix

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -69,6 +69,21 @@ handler-level failure — see [[#5. runner.rs]]), and
 `completions`-generated shell scripts complete `--format` from the same
 three values (issue #206).
 
+`--log-format {text,json}` (issue #399) is a second, independent global
+flag: it selects the *diagnostic log* format (text vs. structured JSON,
+written to stderr via `runner::init_logging`), not the command *result*
+format `--format` controls. Typed as `Option<mcp_execution_core::cli::LogFormat>`
+via the same `PossibleValuesParser`/`ignore_case = true` pattern as
+`--format` (so `--help` lists both possible values and case-insensitivity
+comes from clap, not a manual `to_lowercase`), deliberately with **no**
+`default_value` — `None` means "flag not passed, consult the
+`MCP_EXECUTION_LOG_FORMAT` environment variable" (see
+[[#5. runner.rs|init_logging]]). An invalid `--log-format` value is
+rejected by clap itself, exactly like `--format`; an invalid
+`MCP_EXECUTION_LOG_FORMAT` value is handled leniently (falls back to text
+with a `WARN` log line) since it is consulted only after the flag, deep
+inside `init_logging`, not at clap-parse time.
+
 `introspect`/`generate` flatten a shared `ServerFlags` (`#[derive(Args)]`,
 private fields, `cli.rs`) holding `from_config`/`server`/`args`/`env`/`cwd`/
 `http`/`sse`/`headers`/`connect_timeout_secs`/`discover_timeout_secs`.
@@ -202,10 +217,73 @@ future.
 ## 5. `runner.rs` — Dispatch and Exit-Code Classification
 
 ```rust
-pub fn init_logging(verbose: bool) -> Result<()>;
+pub fn init_logging(verbose: bool, log_format: Option<LogFormat>) -> Result<()>;
 pub async fn execute_command(command: Commands, output_format: OutputFormat) -> Result<ExitCode>;
 pub fn report_and_classify(err: &anyhow::Error) -> ExitCode;
 ```
+
+`init_logging`'s `log_format` parameter (issue #399) is `cli.log_format`
+verbatim — `None` when `--log-format` was not passed. Two private
+module-level functions (mirroring `mcp-execution-server`'s
+`resolve_log_format`/`log_format_env_is_invalid`) are extracted out of
+`init_logging` rather than inlined, specifically so a test can assert
+`MCP_EXECUTION_LOG_FORMAT` is actually consulted — see
+`resolve_log_format_reads_env_var_when_flag_unset` — not only that the pure
+resolvers they delegate to work given a hand-built input:
+- `resolve_log_format(log_format: Option<LogFormat>) -> LogFormat` reads
+  `MCP_EXECUTION_LOG_FORMAT` itself (`std::env::var(LOG_FORMAT_ENV_VAR).ok()`)
+  and resolves the effective format via the pure, unit-tested
+  `mcp_execution_core::cli::LogFormat::resolve(log_format, env_value)`: the
+  flag wins unconditionally when set (the environment variable is not even
+  inspected in that case); otherwise an empty/whitespace env value is
+  treated as unset, a valid one (case-insensitive) is used, and an
+  unrecognized one falls back to `LogFormat::Text`. `resolve` returns only
+  the resolved format — no caller logs the rejected raw value (an earlier
+  design threading it through `resolve`'s return type as `(LogFormat,
+  Option<String>)` was reworked away: neither production call site
+  consumed it, exactly the "capability designed, caller never wired"
+  pattern issue #399 itself targets).
+- `log_format_env_is_invalid(log_format: Option<LogFormat>) -> bool`
+  independently reads the same environment variable and answers "should
+  `init_logging` warn about it", via
+  `mcp_execution_core::cli::LogFormat::is_invalid_env_value(raw)`: `false`
+  whenever the flag was passed (matching `resolve`'s own precedence — a
+  bad env value must not warn once the flag has already decided) or the
+  env value is unset/valid, `true` only for a non-empty rejected value.
+
+`init_logging` calls both, then emits a fixed-message `tracing::warn!`
+*after* subscriber init (a warn before init would go nowhere) when
+`log_format_env_is_invalid` returns `true` — the rejected raw value is
+never interpolated into that log line, to avoid a log-injection vector
+from external process environment input.
+
+Building the layer itself: `fmt::layer()` and `fmt::layer().json()` are
+different types (`Format<Full>` vs. `Format<Json>`), so they cannot share
+one binding across an `if`/`match`. `init_logging` instead builds the
+writer-configured layer once — `fmt::layer().with_writer(|| RedactingWriter(io::stderr()))`
+— then branches only on the terminal `.json()`/no-op call, `.boxed()`-ing
+each arm to a common `Box<dyn Layer<_> + Send + Sync>`:
+
+```rust
+let fmt_layer = tracing_subscriber::fmt::layer().with_writer(|| RedactingWriter(io::stderr()));
+let layer = match format {
+    LogFormat::Json => fmt_layer.json().boxed(),
+    LogFormat::Text => fmt_layer.boxed(),
+};
+tracing_subscriber::registry().with(filter).with(layer).init();
+```
+
+This proves `RedactingWriter` is present in both arms by construction — the
+writer is configured once, before the format branch, so no copy-paste
+divergence between two full `registry()...init()` calls can silently drop
+it from one arm. `RedactingWriter` itself is formatter-independent (it
+wraps the byte sink, not the event formatter), so it applies identically to
+text and JSON output — with one caveat: `redact_urls_in_text`'s trailing-
+punctuation trim set includes `\` (backslash) specifically so a redacted
+URL sitting inside a JSON-escaped string (`serde_json` escaping `"` to
+`\"`) does not absorb and delete that escaping backslash, which would
+otherwise leave an unescaped `"` and invalid JSON — see
+[[../core/spec#redact module|redact_urls_in_text]].
 
 `execute_command` **never propagates a handler failure as `Err`** — it
 always resolves to `Ok(classified_exit_code)` (issue #195's fix, so `main`

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -272,6 +272,22 @@ header name/value) — this is enforced by tests, not just convention.
 
 ```rust
 pub enum OutputFormat { Json, Text, #[default] Pretty } // FromStr, Display
+pub enum LogFormat { #[default] Text, Json } // FromStr, Display; mirrors OutputFormat's shape
+pub const LOG_FORMAT_ENV_VAR: &str = "MCP_EXECUTION_LOG_FORMAT";
+// LogFormat::resolve(flag: Option<LogFormat>, env_value: Option<&str>) -> LogFormat: flag wins
+// unconditionally (env not even inspected on Some); empty/whitespace env is treated as unset;
+// an unrecognized env value falls back to Text. Returns only the resolved format -- no rejected
+// raw value threaded through, since no production caller logs it (see below). Pure and
+// process-env-free by design: callers pass `std::env::var(LOG_FORMAT_ENV_VAR).ok()` in
+// themselves, which keeps this testable without mutating process env.
+// LogFormat::parse_env(raw: &str) -> Option<LogFormat>: `resolve`'s env-parsing step, exposed
+// separately -- None for both an empty/whitespace value and an unrecognized one.
+// LogFormat::is_invalid_env_value(raw: &str) -> bool: true only for a non-empty value
+// `parse_env` rejects, i.e. the "should a caller warn about this" question `resolve` itself
+// doesn't answer. Lets a caller (both `mcp-cli`'s `init_logging` and `mcp-server`'s
+// `resolve_log_format`/`log_format_env_is_invalid`) decide whether to warn without `resolve`
+// carrying a second, production-dead return value -- an earlier `(LogFormat, Option<String>)`
+// shape was reworked away for exactly that reason.
 pub struct ExitCode(i32); // SUCCESS=0, ERROR=1, INVALID_INPUT=2, SERVER_ERROR=3, TIMEOUT=4
 // ExitCode::from_i32(code: i32) -> Option<ExitCode>: None outside 0..=255 (std::process::exit's
 // actual valid range), instead of accepting any i32 unchecked.
@@ -282,6 +298,18 @@ pub struct ServerConnectionString(String); // charset [A-Za-z0-9-_./:], <=256 ch
 `mcp-cli` actually uses for `--from-config`/`server` values today (those
 flow through `ServerId`/`ServerConfig` instead) — it exists as reusable,
 tested infrastructure in this crate's public surface.
+
+`LogFormat` (issue #399) lives here rather than in `mcp-cli` specifically
+because `mcp-server` needs it too and does not depend on `mcp-cli`: putting
+it here means `mcp-core` gains a second CLI-adjacent enum but no new
+dependency (it's a plain enum), and the two binaries' `--log-format`
+flag/`MCP_EXECUTION_LOG_FORMAT` fallback logic can never drift apart the
+way two independently hand-rolled copies could. Both
+`mcp-cli::runner::init_logging` and `mcp-server`'s `resolve_log_format`
+call `LogFormat::resolve` and then build the same `.boxed()`-branched
+`fmt::layer()`/`fmt::layer().json()` pair — see
+[[../cli/spec#5. runner.rs|cli spec §5]] and
+[[../server/spec#Logging & CLI Surface|server spec §9]].
 
 ### `metadata` module (`src/metadata.rs`)
 
@@ -408,7 +436,10 @@ sentence. It locates each `scheme://…` token by walking left over
 scheme-legal characters from `://`, walking right to the first whitespace,
 control character, or wrapping-punctuation character (quote, backtick,
 paren — or text's end), and trimming trailing sentence punctuation (`,` `.`
-`;` `:`); the resulting token is redacted by handing it to `RedactedUrl`'s
+`;` `:` `\`) — the backslash covers a JSON string serializer's escaping
+backslash before a closing `"` around a quoted URL, which would otherwise be
+absorbed into the token and deleted, leaving unescaped, invalid JSON; the
+resulting token is redacted by handing it to `RedactedUrl`'s
 own `Debug` impl, so the *masking* decision — what counts as
 authority/query, what gets hidden — can never drift between the two.
 
@@ -469,8 +500,8 @@ data into text an LLM later reads as instructions — see
 | `mcp-codegen` | `Error`/`Result`, `metadata::*` (writes `_meta.json`), `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix` (renders them into the generated runtime bridge template) |
 | `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen` |
 | `mcp-skill` | `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `MAX_SERVER_ID_LENGTH`, `untrusted::*`, `metadata::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
-| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
-| `mcp-cli` | `cli::{OutputFormat, ExitCode}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |
+| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}`, `cli::{LogFormat, LOG_FORMAT_ENV_VAR}` |
+| `mcp-cli` | `cli::{OutputFormat, ExitCode, LogFormat, LOG_FORMAT_ENV_VAR}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |
 
 ## 4. Defense in Depth
 

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -479,7 +479,59 @@ log-volume-amplification class already fixed for the introspector's
 symmetric decoder (#275/#282); a genuinely malformed non-blank line still
 warns.
 
-## 9. Error Conditions
+## 9. Logging & CLI Surface (`main.rs`, binary only)
+
+Issue #399: the `mcp-execution` binary parses argv via a minimal
+`#[derive(Parser)]` struct (`ServerArgs`), where before it ignored argv
+entirely. `#[command(name = "mcp-execution")]` overrides clap's
+`CARGO_PKG_NAME`-derived default (`mcp-execution-server`, the crate name,
+not the installed binary — see `crates/mcp-server/Cargo.toml`'s `[[bin]]`),
+so `--help`/error output names the binary users actually run. This is a
+deliberate, low-risk behavior change: no in-repo `mcp.json` entry passes
+this server any arguments today, but the binary now honors `--help`/
+`--version` (both written to stdout, harmless since the process exits
+immediately after) and rejects unknown arguments with exit code 2, rather
+than silently ignoring them.
+
+`ServerArgs` carries one flag, `--log-format {text,json}` — typed as
+`Option<mcp_execution_core::cli::LogFormat>` via the same
+`PossibleValuesParser`/`ignore_case = true` pattern `mcp-cli`'s `--format`
+uses (`--help` lists both possible values; case-insensitivity comes from
+clap, not manual lowercasing). `None` means "flag not passed, consult
+`MCP_EXECUTION_LOG_FORMAT`". Two functions extracted out of `main` (rather
+than inlined) so tests can assert the environment variable is actually
+consulted, not only that the pure `mcp-core` helpers work given a
+hand-built input:
+- `resolve_log_format(&ServerArgs) -> LogFormat` reads
+  `MCP_EXECUTION_LOG_FORMAT` itself (`std::env::var(LOG_FORMAT_ENV_VAR).ok()`)
+  and delegates precedence/fallback to the same pure `LogFormat::resolve`
+  `mcp-core`'s `cli` module exposes to `mcp-cli`.
+- `log_format_env_is_invalid(&ServerArgs) -> bool` independently reads the
+  same environment variable and answers "should `main` warn about it" —
+  `false` whenever the flag was passed (matching `resolve`'s own
+  precedence) or the env value is unset/valid, `true` only for a non-empty
+  value `LogFormat::is_invalid_env_value` rejects. Kept separate from
+  `resolve_log_format`'s return value rather than folded into a tuple,
+  since an earlier `(LogFormat, Option<String>)` shape carried a value no
+  production caller ever logged.
+
+Logging setup mirrors `mcp-cli`'s `runner::init_logging` `.boxed()`
+pattern: the writer-configured `fmt::layer().with_writer(std::io::stderr).with_target(true)`
+is built once, then branched only on `.json()` vs. no-op, `.boxed()`-ing
+both arms to a common `Box<dyn Layer<_> + Send + Sync>` so no copy-paste
+divergence between two full `registry()...init()` calls can drop the
+writer configuration from one arm. Unlike `mcp-cli`, this binary's fmt
+layer is **not** wrapped in a `RedactingWriter` — see `main.rs`'s own
+comment on why (no path here ever constructs an http/sse client config, so
+there is no `reqwest`/`rmcp` transport error whose `Display` could embed a
+secret-bearing URL for one to reach). `MCP_EXECUTION_LOG_FORMAT` is a
+second, narrower untrusted-text-into-log path this binary does have, but
+`warn_on_rejected_log_format` never echoes the rejected raw environment
+value into its `WARN` line — only a fixed diagnostic string naming the
+environment variable is logged — so it does not need a redacting writer
+either.
+
+## 10. Error Conditions
 
 `StateError`: `AtCapacity { limit }`, `MemoryBudgetExceeded { limit }`.
 
@@ -493,7 +545,7 @@ Every tool method maps its internal errors to `rmcp::ErrorData` via either
 confinement violation) or `McpError::internal_error` (this project's/the
 environment's fault — I/O failure, task join error, serialization failure).
 
-## 10. Cross-Crate Contracts
+## 11. Cross-Crate Contracts
 
 - **Consumes**: `mcp-introspector::Introspector`/`ServerInfo`,
   `mcp-codegen::ProgressiveGenerator`, `mcp-files::FilesBuilder`/
@@ -519,7 +571,7 @@ environment's fault — I/O failure, task join error, serialization failure).
   (`MAX_CATEGORIZED_TOOL_NAME_LEN` etc., `mcp_execution_skill::MAX_TOOL_FILES`,
   `mcp_execution_core::MAX_ARG_COUNT`/`MAX_ARG_LEN`) byte-for-byte.
 
-## 11. Edge Cases & Notable Behaviors
+## 12. Edge Cases & Notable Behaviors
 
 - `test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id`
   guards a subtle interaction between rmcp's async-fn span-instrumentation
@@ -533,7 +585,7 @@ environment's fault — I/O failure, task join error, serialization failure).
   confinement check in this crate rather than being the one path that
   skips it.
 
-## 12. See Also
+## 13. See Also
 
 - [[../introspector/spec]] — wrapped by `introspect_server`
 - [[../codegen/spec]] / [[../files/spec]] — wrapped by `save_categorized_tools`


### PR DESCRIPTION
## Summary

- Adds an opt-in structured JSON logging mode to `mcp-execution-server` and `mcp-execution-cli`, selectable via `--log-format {text,json}` or the `MCP_EXECUTION_LOG_FORMAT` env var (flag takes precedence when both are set). Default output stays plain text, unchanged.
- `mcp-execution-server` gains a minimal `clap`-based argv parser (it previously parsed no arguments at all) to carry the flag; it now honors `--help`/`--version` and rejects unknown args with exit code 2. Low risk: no in-repo `mcp.json` entry passes this server any arguments.
- Fixes a real correctness bug found during review: `redact_urls_in_text`'s trailing-trim set didn't include a backslash, so a redacted secret sitting inside a JSON-escaped string (closing quote escaped to `\"`) lost its escaping backslash and produced invalid JSON. Verified with a differential fuzz harness (400k cases) that the fix introduces no new under-redaction.
- `LogFormat` lives in `mcp_execution_core::cli` (shared by both binaries, mirrors the existing `OutputFormat`) to avoid duplicating the enum/resolver/env-var name across two crates that don't depend on each other.
- `RedactingWriter` (secret-URL redaction) is structurally guaranteed to wrap both the text and JSON formatter branches — a single writer-configured layer is built once, then only the formatter is branched via `.boxed()`, so the two paths can't diverge by copy-paste.

Closes #399

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1231 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo audit` / `cargo deny check` clean for the new `clap` dependency on `mcp-execution-server`
- [x] Differential fuzz (400k cases) confirming the redaction fix introduces no new secret leaks
- [x] New regression tests proving `MCP_EXECUTION_LOG_FORMAT` is actually read by both binaries (not just that the pure resolver logic works), and that every emitted JSON-mode log line parses via `serde_json`