### PR TITLE
fix(core): redact non-ASCII usernames that differ from $HOME only by case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
       - name: Check formatting (nightly)
         run: cargo +nightly fmt --all -- --check
 
+      - name: Install cargo-sort
+        uses: taiki-e/install-action@v2.85.10
+        with:
+          tool: cargo-sort
+
+      - name: Check Cargo.toml dependency order
+        run: cargo sort --check --workspace --order package,lints,workspace,lib,bin,features,dependencies,build-dependencies,dev-dependencies
+
       - name: Clippy (all targets, all features)
         run: cargo +stable clippy --all-targets --all-features --workspace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   need to run sequentially). `ci-success` now also gates on `build`'s result.
 - **CI**: the `release` job now only runs on pushes to `master`, instead of on every PR and
   branch push covered by the workflow's triggers.
+- **workspace**: swapped the out-of-alphabetical-order `mcp-execution-introspector`/
+  `mcp-execution-files` dependency lines in `mcp-execution-cli`'s `Cargo.toml`, and moved the
+  `[lints]` table in `mcp-execution-server`/`mcp-execution-skill` and the `[features]`/
+  `[[bench]]`/`[[example]]` tables in `mcp-execution-files` to the position `cargo-sort` expects,
+  so the new CI gate below is clean from its first run. Purely mechanical; no semantic change
+  (#396).
+- **CI**: the `check` job now runs `cargo sort --check --workspace` after the formatting check,
+  failing the build if any crate's `Cargo.toml` has an out-of-alphabetical-order
+  `[dependencies]`/`[dev-dependencies]`/`[build-dependencies]` table, or a top-level table in
+  the wrong position (#397).
 - **`mcp-execution-cli`**: extracted `formatters::emit`, a shared helper that formats a value,
   prints it, and returns the given `ExitCode`, collapsing the repeated
   format/print/return-exit-code sequence duplicated across `server.rs`, `setup.rs`,
@@ -137,6 +147,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   side effect, a generated SKILL.md's `description:` line is no longer always double-quoted — it
   may now be plain, single-quoted, or a block literal depending on content, which changes the
   byte size of a frontmatter block near the existing `MAX_FRONTMATTER_SIZE` (8 KiB) cap.
+- **`mcp-execution-core`**: `sanitize_path_for_error`'s home-directory redaction on Windows/macOS
+  missed non-ASCII usernames (e.g. Cyrillic, Greek) that differed only by case: `components_match`
+  compared components with `eq_ignore_ascii_case`, and `replace_case_aware`'s username-scrubbing
+  fallback lowercased with `to_ascii_lowercase`, both of which only fold ASCII bytes, so a
+  same-username-different-case path silently skipped redaction and leaked the username verbatim
+  in error messages. Both now case-fold with full Unicode semantics via `str::to_lowercase`, kept
+  consistent between the two functions so they agree on Unicode's context-sensitive folding rules
+  (e.g. Greek final sigma: `"ΣΑΣ".to_lowercase() == "σας"`); `replace_case_aware` was rewritten
+  around a windowed comparison that only ever slices at `haystack`'s own (unmodified) char
+  boundaries, rather than lowering a copy and reusing its byte offsets, so it stays correct when
+  `str::to_lowercase()` changes a character's encoded byte length, e.g. Turkish "İ" (#406).
 - **`mcp-execution-skill`**: `HANDLEBARS` now enables `set_strict_mode(true)`, matching
   `mcp-execution-codegen`'s `TemplateEngine`. Without it, a template referencing a typo'd or
   removed field silently rendered an empty string instead of failing at render time.

--- a/crates/mcp-cli/Cargo.toml
+++ b/crates/mcp-cli/Cargo.toml
@@ -28,8 +28,8 @@ dirs = { workspace = true }
 futures-util = { workspace = true }
 mcp-execution-codegen = { workspace = true }
 mcp-execution-core = { workspace = true }
-mcp-execution-introspector = { workspace = true }
 mcp-execution-files = { workspace = true }
+mcp-execution-introspector = { workspace = true }
 mcp-execution-skill = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/mcp-core/src/path.rs
+++ b/crates/mcp-core/src/path.rs
@@ -20,8 +20,9 @@ use std::path::{Component, Path};
 /// The comparison walks path components rather than matching raw strings, so a `/`-separated
 /// input matches a backslash-separated home directory (and vice versa) on platforms where both
 /// separators are valid. On Windows and macOS, components are also compared
-/// ASCII-case-insensitively, matching those platforms' case-insensitive-but-case-preserving
-/// filesystem semantics; elsewhere the comparison stays case-sensitive.
+/// Unicode-case-insensitively (via [`str::to_lowercase`]), matching those platforms'
+/// case-insensitive-but-case-preserving filesystem semantics; elsewhere the comparison stays
+/// case-sensitive.
 ///
 /// When `path` does not begin with `home` — e.g. it reaches this function through a different
 /// mount point, or (on Windows) as a `\\?\`-verbatim canonicalized path whose prefix shape the
@@ -94,17 +95,11 @@ fn scrub_username(path: &Path, home: &Path) -> String {
 
 #[cfg(any(windows, target_os = "macos"))]
 fn components_match(home: Component<'_>, path: Component<'_>) -> bool {
-    // TODO(#406): ASCII-only case folding misses a non-ASCII username that differs only by
-    // case (e.g. Cyrillic "Аня" vs "аня") — NOT mitigated by scrub_username's fallback below:
-    // replace_case_aware's Windows/macOS arm folds case the same ASCII-only way (see its own
-    // doc comment), so a case-differing non-ASCII username is redacted by neither path and
-    // survives verbatim in the sanitized output. Unaffected on other platforms, which compare
-    // path components exactly rather than case-insensitively. Accepted as a known, low-severity
-    // residual gap for now (#406): a correct fix needs Unicode-aware case folding that preserves
-    // replace_case_aware's byte-offset alignment invariant, not a naive `to_lowercase` swap.
-    home.as_os_str()
-        .to_string_lossy()
-        .eq_ignore_ascii_case(&path.as_os_str().to_string_lossy())
+    // Unicode-aware case folding (not `eq_ignore_ascii_case`, which only folds ASCII bytes and
+    // misses non-ASCII usernames such as Cyrillic). This compares whole components, so there is
+    // no byte-offset slicing to keep valid across the fold, unlike `replace_case_aware` below.
+    home.as_os_str().to_string_lossy().to_lowercase()
+        == path.as_os_str().to_string_lossy().to_lowercase()
 }
 
 #[cfg(not(any(windows, target_os = "macos")))]
@@ -114,18 +109,41 @@ fn components_match(home: Component<'_>, path: Component<'_>) -> bool {
 
 #[cfg(any(windows, target_os = "macos"))]
 fn replace_case_aware(haystack: &str, needle: &str, replacement: &str) -> String {
-    // `to_ascii_lowercase` only remaps bytes in the ASCII range and never changes a string's
-    // byte length, so every byte offset found in the lowered copies below is also a valid slice
-    // point into the original `haystack`/`needle`. This invariant breaks if the case-folding
-    // strategy is ever changed to something Unicode-aware (e.g. `to_lowercase`).
-    let haystack_lower = haystack.to_ascii_lowercase();
-    let needle_lower = needle.to_ascii_lowercase();
+    // Case-folds each candidate window with whole-string `str::to_lowercase` (not a per-char
+    // fold), so this agrees with `components_match`'s folding on Unicode's context-sensitive
+    // rules — e.g. Greek final sigma: "ΣΑΣ".to_lowercase() == "σας", which a char-by-char fold
+    // would render "σασ" and so fail to match. `str::to_lowercase` can also change a character's
+    // encoded length (Turkish "İ" folds to two chars: "i" + a combining dot above), so byte
+    // offsets found by searching a fully-lowered copy of `haystack` are not valid slice points
+    // back into the original. Instead, this walks `haystack`'s own (never-lowered) char
+    // boundaries and, at each candidate start, lowers only that `needle`-char-count-long window
+    // to compare against the lowered needle — only `haystack`'s own char boundaries are ever
+    // used as slice points, so byte-length drift introduced by folding never invalidates a slice.
+    if needle.is_empty() {
+        return haystack.to_owned();
+    }
+    let needle_len = needle.chars().count();
+    let needle_lower = needle.to_lowercase();
+    let boundaries: Vec<usize> = haystack
+        .char_indices()
+        .map(|(i, _)| i)
+        .chain(std::iter::once(haystack.len()))
+        .collect();
+
     let mut result = String::with_capacity(haystack.len());
     let mut last_end = 0;
-    for (start, _) in haystack_lower.match_indices(needle_lower.as_str()) {
-        result.push_str(&haystack[last_end..start]);
-        result.push_str(replacement);
-        last_end = start + needle.len();
+    let mut i = 0;
+    while i + needle_len < boundaries.len() {
+        let start = boundaries[i];
+        let end = boundaries[i + needle_len];
+        if haystack[start..end].to_lowercase() == needle_lower {
+            result.push_str(&haystack[last_end..start]);
+            result.push_str(replacement);
+            last_end = end;
+            i += needle_len;
+        } else {
+            i += 1;
+        }
     }
     result.push_str(&haystack[last_end..]);
     result
@@ -285,6 +303,80 @@ mod tests {
         assert_eq!(
             sanitize_path_for_error(Path::new(&under_home)),
             format!("~{}secret-file.md", std::path::MAIN_SEPARATOR),
+        );
+    }
+
+    // Regression test for a non-ASCII username case leak: `eq_ignore_ascii_case` only folds
+    // ASCII bytes, so a Cyrillic username differing only by case was never recognized as a
+    // match, silently defeating the case-insensitive redaction on Windows/macOS.
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn components_match_is_unicode_case_insensitive() {
+        let home_path = Path::new("Аня");
+        let path_path = Path::new("аня");
+        let home = home_path.components().next().unwrap();
+        let path = path_path.components().next().unwrap();
+        assert!(components_match(home, path));
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn replace_case_aware_matches_non_ascii_case_variants() {
+        assert_eq!(
+            replace_case_aware("Аня/secret.md", "аня", "~"),
+            "~/secret.md"
+        );
+    }
+
+    // `str::to_lowercase()` can change a character's encoded length: Turkish "İ" folds to two
+    // chars, "i" + a combining dot above (verified: `"İ".to_lowercase().chars().count()` is 2).
+    // A naive port of the old byte-offset/`match_indices` approach to `to_lowercase` would slice
+    // a lowered buffer using needle-derived byte offsets that no longer line up with the
+    // original string once folding expands a character. This test proves the windowed
+    // comparison — which only ever slices at `haystack`'s own char boundaries — matches and
+    // replaces correctly instead of panicking or corrupting output, even though the window's
+    // folded form is longer than its raw form.
+    //
+    // Known limitation, not exercised here: because the window is sized to `needle`'s *raw* char
+    // count, this can't match a needle/haystack pair whose folded forms only line up at a
+    // different raw char count (e.g. German "ß" needle against a haystack spelled "ss" — 1 raw
+    // char vs 2). Accepted per the original design: the fallback's over-redaction bias makes a
+    // missed match here a false negative, not an information leak on its own, since the primary
+    // `strip_home_prefix`/`components_match` path (whole-component comparison, not a windowed
+    // substring search) still catches the common case.
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn replace_case_aware_preserves_byte_offsets_when_fold_changes_length() {
+        assert_eq!(replace_case_aware("aİb", "İ", "~"), "a~b");
+        // A plain ASCII "i" is not a case variant of "İ" under this fold, so no match — the
+        // differing fold length must not cause a panic or a false match.
+        assert_eq!(replace_case_aware("aİb", "i", "~"), "aİb");
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn replace_case_aware_replaces_multiple_occurrences() {
+        assert_eq!(
+            replace_case_aware("Alice/Alice/notes.md", "alice", "~"),
+            "~/~/notes.md"
+        );
+    }
+
+    // Regression test for the Greek final-sigma inconsistency the critic caught: whole-string
+    // `str::to_lowercase()` applies Unicode's context-sensitive rule ("ΣΑΣ".to_lowercase() ==
+    // "σας", using final sigma "ς"), which a naive per-char fold (`char::to_lowercase` on each
+    // char independently) would render "σασ" — disagreeing with `components_match`, which folds
+    // the same way `replace_case_aware` does here. Proves both functions now agree.
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn replace_case_aware_matches_greek_final_sigma_case_variant() {
+        assert_eq!(
+            replace_case_aware("/home/ΣΑΣ/secret.md", "σας", "~"),
+            "/home/~/secret.md"
+        );
+        assert_eq!(
+            replace_case_aware("/home/σας/secret.md", "ΣΑΣ", "~"),
+            "/home/~/secret.md"
         );
     }
 

--- a/crates/mcp-files/Cargo.toml
+++ b/crates/mcp-files/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["development-tools", "filesystem"]
 [lints]
 workspace = true
 
+[features]
+dhat-heap = ["dhat"]
+parallel = ["dep:rayon"]
+
 [dependencies]
 dhat = { workspace = true, optional = true }
 dirs.workspace = true
@@ -24,10 +28,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
-
-[features]
-dhat-heap = ["dhat"]
-parallel = ["dep:rayon"]
 
 [[bench]]
 name = "vfs_benchmarks"

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -11,6 +11,9 @@ description = "MCP server for progressive loading TypeScript code generation"
 keywords = ["mcp", "server", "codegen", "progressive-loading"]
 categories = ["development-tools"]
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "mcp-execution"
 path = "src/main.rs"
@@ -46,6 +49,3 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
-
-[lints]
-workspace = true

--- a/crates/mcp-skill/Cargo.toml
+++ b/crates/mcp-skill/Cargo.toml
@@ -11,6 +11,9 @@ description = "SKILL.md generation for Claude Code integration with MCP tools"
 keywords = ["mcp", "skill", "claude-code", "codegen"]
 categories = ["development-tools"]
 
+[lints]
+workspace = true
+
 [dependencies]
 handlebars = { workspace = true }
 mcp-execution-core = { workspace = true }
@@ -26,6 +29,3 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
-
-[lints]
-workspace = true


### PR DESCRIPTION
## Summary
- `sanitize_path_for_error`'s home-directory redaction on Windows/macOS missed non-ASCII usernames (e.g. Cyrillic, Greek) that differed from `$HOME` only by case: `components_match` folded with `eq_ignore_ascii_case` and `replace_case_aware`'s fallback folded with `to_ascii_lowercase`, both ASCII-only, so the username survived unredacted in sanitized error output. Both now fold with `str::to_lowercase`, kept consistent between the two functions so they agree on Unicode's context-sensitive rules (e.g. Greek final sigma). `replace_case_aware` was rewritten around a windowed comparison over `haystack`'s own char boundaries instead of byte offsets from a pre-lowered copy, since folding can change a character's encoded length (closes #406).
- Swapped `mcp-cli`'s out-of-order `Cargo.toml` dependency lines (closes #396).
- Added a `cargo-sort` CI gate so `[dependencies]`/`[dev-dependencies]`/`[build-dependencies]` ordering can't silently drift again; mechanical, zero-semantic-change table-position moves in `mcp-server`, `mcp-skill`, and `mcp-files` make the new gate pass cleanly from its first run (closes #397).

## Follow-up
- Filed #416: `components_match`/`replace_case_aware` still miss a username that differs from `$HOME` only by Unicode normalization form (NFC vs NFD) — same class of bug, out of scope here, tracked separately.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1239 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo sort --check --workspace --order package,lints,workspace,lib,bin,features,dependencies,build-dependencies,dev-dependencies`
- [x] New regression tests for Cyrillic/Greek/length-changing-fold case variants and multi-occurrence replacement in `crates/mcp-core/src/path.rs`