### PR TITLE
fix: bound skill_name length and cap rmcp debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `data` carries a machine-checkable `session_restore_failure_reason` field so a programmatic
   client doesn't have to substring-match prose (#387).
 
+### Breaking
+
+- **`mcp-execution-skill`**: `SkillMetadataError` gained a new `NameTooLong { len, limit }`
+  variant, returned by `extract_skill_metadata` when the frontmatter `name` exceeds
+  `MAX_SKILL_NAME_LENGTH` (see the `### Fixed` entry below). Source-breaking for any downstream
+  consumer exhaustively matching `SkillMetadataError` without a wildcard arm (#419).
+
 ### Fixed
 
 - **`mcp-execution-skill`**: `render_skill_md`'s YAML frontmatter (`name`, `description`) is
@@ -215,6 +222,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matched token absorbed and deleted the backslash `serde_json` inserts before an escaped `"`,
   leaving a bare, unescaped quote behind. The trim set now includes `\` so that backslash is
   left untouched and re-emitted verbatim (#399).
+- **`mcp-execution-skill`**: `extract_skill_metadata` now enforces `MAX_SKILL_NAME_LENGTH` (200
+  chars) on the frontmatter `name` it parses, via `validate_skill_name`. The two `generate` call
+  sites (`mcp-cli`'s `skill` command, `mcp-server`'s `generate_skill` tool) already bounded a
+  custom `skill_name` this way before rendering, but `save_skill` writes caller-supplied
+  `SKILL.md` content straight through to `extract_skill_metadata` without ever calling
+  `validate_skill_name` — so `name` was bounded only by `MAX_FRONTMATTER_SIZE` (8 KiB) on that
+  path, letting an oversized name reach the always-loaded skill index (#419).
+- **`mcp-execution-skill`**: `context.rs`'s "### Categories and Tools" heading was emitted twice
+  in `build_generation_prompt` — once in the trusted preamble, once inside the
+  `wrap_untrusted_block`-wrapped section. Dropped the preamble copy; the wrapped one is the
+  correct placement, since the content it heads is untrusted (#419).
 
 ### Testing
 
@@ -246,6 +264,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   event is actually recorded, matching the laziness the surrounding code already relied on.
   `--log-format json` is unaffected either way, since `serde_json` already escapes whatever
   string ends up in the field (#415).
+- **`mcp-execution-server`**: `main`'s `EnvFilter` construction now caps `rmcp`'s own `tracing`
+  targets at `info` via a private `cap_rmcp_log_level` helper, closing the *debug-level, raw-line*
+  logging path. `rmcp` 3.1.2's transport layer logs raw, unsanitized peer input at `debug` (e.g. a
+  parse-failure line embeds the offending line verbatim), which previously fired inside this
+  binary's decode path *before* the #415 `SanitizedCodecError` mitigation could sanitize it — so a
+  broad `RUST_LOG=debug` streamed untrusted peer text into the log unfiltered. The cap is applied
+  to the *result* of `try_from_default_env().unwrap_or_else(...)`, not folded only into the
+  fallback string, which would have been dead code whenever `RUST_LOG` parsed successfully. An
+  operator who explicitly needs `rmcp` transport debug output can still get it via a target more
+  specific than the bare `rmcp` this cap sets, e.g. `RUST_LOG=rmcp::transport=debug` — directives
+  order by target specificity, so that survives the cap; an equally-specific `RUST_LOG=rmcp=debug`
+  does not; it is replaced by this cap's `rmcp=info`, not merged with it. This cap is level-based
+  only: `rmcp` also logs a `Debug`-formatted peer notification at `info`
+  (`tracing::info!(?notification, ...)`), which it does not and cannot suppress; that site is
+  mitigated by `Debug`-escaping control characters, not eliminated, and fires under the server's
+  default filter with no `RUST_LOG` at all (#421).
+- **`mcp-execution-cli`**: `runner::init_logging` now applies the same `cap_rmcp_log_level`
+  treatment to both the non-verbose (`RUST_LOG`-driven) and `--verbose` branches. The `--verbose`
+  branch previously set a bare `EnvFilter::new("debug")` with no `RUST_LOG` involved at all —
+  since this crate is a *client* of third-party MCP servers, `--verbose` alone streamed an
+  untrusted server's raw stdout lines into stderr; `RedactingWriter` only rewrites embedded URLs
+  and does not neutralize this. Both branches now add an `rmcp=info` directive on top of their
+  base filter; the same `RUST_LOG=rmcp::transport=debug` escape hatch and `rmcp=debug`
+  replace-not-merge caveat noted above apply here too (#421).
 
 ### Removed
 

--- a/crates/mcp-cli/src/runner.rs
+++ b/crates/mcp-cli/src/runner.rs
@@ -72,6 +72,42 @@ fn log_format_env_is_invalid(log_format: Option<LogFormat>) -> bool {
             .is_some_and(|raw| LogFormat::is_invalid_env_value(&raw))
 }
 
+/// Caps `rmcp`'s own `tracing` targets at `info`, on top of whatever base filter is already in
+/// effect.
+///
+/// `rmcp` 3.1.2's transport layer logs raw, unsanitized peer input at `debug` level. This crate is
+/// a *client* of third-party MCP servers (see `mcp_execution_introspector::Introspector`), so
+/// without this cap, `--verbose` alone -- with no `RUST_LOG` involved -- streams an untrusted
+/// server's raw stdout lines into stderr; [`RedactingWriter`] only rewrites embedded URLs, it does
+/// not neutralize this (issue #421). This closes the *debug-level, raw-line* logging specifically
+/// -- `rmcp` also logs a `Debug`-formatted peer notification at `info`, which this cap does not
+/// and cannot suppress (`rmcp=info` still allows `info`); that site is mitigated by
+/// `Debug`-escaping control characters, not eliminated.
+///
+/// Applied via [`EnvFilter::add_directive`] to the filter already selected by [`init_logging`]'s
+/// verbose/non-verbose branches, not folded into only one of them: a directive added solely to
+/// the non-verbose fallback string would never apply to `--verbose`'s `EnvFilter::new("debug")`,
+/// which does not consult `RUST_LOG` at all.
+///
+/// Directive sets order by target specificity, so this `rmcp=info` directive (more specific than
+/// a bare global `debug`) wins over it. An operator who explicitly sets a *more specific*
+/// directive, e.g. `RUST_LOG=rmcp::transport=debug`, still wins over this one -- that is
+/// intentional: this cap closes the accidental broad-`debug` case, not an operator's deliberate
+/// request for `rmcp` transport debug logs -- **this is the escape hatch**: a target under
+/// `rmcp::` (not the bare `rmcp` target this cap sets) survives the cap and can be raised back to
+/// `debug` explicitly. Note this is target *specificity*, not level: an equally-specific
+/// `RUST_LOG=rmcp=debug` (same target as this cap, different level) is *replaced* by this cap's
+/// `rmcp=info`, not merged with it -- `tracing_subscriber`'s `Directive` ordering does not compare
+/// level, so a same-target `add_directive` call overwrites the existing entry. Both behaviors are
+/// pinned by tests below rather than assumed.
+fn cap_rmcp_log_level(filter: EnvFilter) -> EnvFilter {
+    filter.add_directive(
+        "rmcp=info"
+            .parse()
+            .expect("static \"rmcp=info\" directive string is always valid"),
+    )
+}
+
 /// Initializes logging infrastructure.
 ///
 /// Sets up tracing with appropriate log levels based on verbosity flag.
@@ -85,6 +121,9 @@ fn log_format_env_is_invalid(log_format: Option<LogFormat>) -> bool {
 /// [`LogFormat::resolve`] consults the `MCP_EXECUTION_LOG_FORMAT` environment variable; an unset
 /// or invalid environment value falls back to text with a `WARN`-level log line (never echoing
 /// the rejected raw value — see the project's log-injection hardening for this switch).
+///
+/// Both branches are passed through `cap_rmcp_log_level`, which caps `rmcp`'s own `tracing`
+/// targets at `info` regardless of the base filter -- see that function's doc comment for why.
 ///
 /// # Arguments
 ///
@@ -110,11 +149,11 @@ fn log_format_env_is_invalid(log_format: Option<LogFormat>) -> bool {
 /// # Ok::<(), anyhow::Error>(())
 /// ```
 pub fn init_logging(verbose: bool, log_format: Option<LogFormat>) -> Result<()> {
-    let filter = if verbose {
+    let filter = cap_rmcp_log_level(if verbose {
         EnvFilter::new("debug")
     } else {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
-    };
+    });
 
     let format = resolve_log_format(log_format);
 
@@ -922,6 +961,109 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(line)
                 .unwrap_or_else(|e| panic!("invalid JSON line: {e}\n{line}"));
         }
+    }
+
+    /// Shared harness for the `cap_rmcp_log_level` regression tests below: builds
+    /// `cap_rmcp_log_level(EnvFilter::new(base_filter))`, wires it into a real `fmt::layer()`
+    /// over a scoped subscriber (mirroring
+    /// `test_redacting_writer_wired_into_real_fmt_layer_redacts_full_event` above), emits one
+    /// `rmcp::transport::async_rw`-targeted `debug!` (standing in for `rmcp`'s own raw-peer-line
+    /// logging) and one `mcp_execution_cli`-targeted `debug!` (standing in for this crate's own
+    /// diagnostics), and returns `(rmcp_line_visible, own_line_visible)`. Does not mutate
+    /// `RUST_LOG` (parallel test threads share one process) -- `base_filter` plays the same role
+    /// a real `RUST_LOG` value would, but only ever reaches `EnvFilter::new` directly.
+    fn rmcp_capped_filter_captures(base_filter: &str) -> (bool, bool) {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().write(buf)
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                self.0.lock().unwrap().flush()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = {
+            let buf = buf.clone();
+            move || SharedBuf(buf.clone())
+        };
+
+        let filter = cap_rmcp_log_level(EnvFilter::new(base_filter));
+        let subscriber = tracing_subscriber::registry().with(filter).with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(make_writer)
+                .with_ansi(false),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(
+                target: "rmcp::transport::async_rw",
+                "raw untrusted peer line"
+            );
+            tracing::debug!(target: "mcp_execution_cli", "own debug event");
+        });
+
+        let written = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        (
+            written.contains("raw untrusted peer line"),
+            written.contains("own debug event"),
+        )
+    }
+
+    /// Regression coverage for issue #421: `--verbose`'s `EnvFilter::new("debug")` branch (no
+    /// `RUST_LOG` involved) must not let `rmcp`'s own `tracing` targets -- which log raw,
+    /// unsanitized peer input at `debug` -- through, while this crate's own `debug` events must
+    /// still pass.
+    #[test]
+    fn cap_rmcp_log_level_suppresses_rmcp_debug_but_keeps_own_debug() {
+        let (rmcp_visible, own_visible) = rmcp_capped_filter_captures("debug");
+        assert!(
+            !rmcp_visible,
+            "rmcp debug line was not suppressed under a global `debug` base"
+        );
+        assert!(
+            own_visible,
+            "own debug event was unexpectedly suppressed under a global `debug` base"
+        );
+    }
+
+    /// Regression coverage for critic finding S1: `tracing_subscriber`'s `Directive` ordering
+    /// does not compare level, so `EnvFilter::add_directive` *replaces* a same-target directive
+    /// rather than merging it. An operator's explicit `RUST_LOG=rmcp=debug` is therefore silently
+    /// downgraded to this cap's own `rmcp=info`, not left to coexist at `debug` -- this was named
+    /// by the original security audit as the ambiguous case to verify with a test rather than
+    /// assume. The escape hatch for an operator who needs this is a *more specific* target (see
+    /// the test below) -- documented in `cap_rmcp_log_level`'s doc comment and the CHANGELOG.
+    #[test]
+    fn cap_rmcp_log_level_replaces_a_same_target_rmcp_debug_directive() {
+        let (rmcp_visible, _) = rmcp_capped_filter_captures("rmcp=debug");
+        assert!(
+            !rmcp_visible,
+            "RUST_LOG=rmcp=debug was expected to be replaced by this cap's rmcp=info, not merged \
+             with it -- if this now fails, `tracing_subscriber`'s directive-merge behavior \
+             changed and `cap_rmcp_log_level`'s doc comment needs updating"
+        );
+    }
+
+    /// Counterpart to the test above: a target *more specific* than `rmcp` (e.g.
+    /// `RUST_LOG=rmcp::transport=debug`) is not overwritten by this cap's `rmcp=info` --
+    /// `tracing_subscriber` orders directives by target specificity, and a longer target wins.
+    /// This is the documented escape hatch for an operator who deliberately wants rmcp transport
+    /// debug output.
+    #[test]
+    fn cap_rmcp_log_level_does_not_override_a_more_specific_rmcp_target() {
+        let (rmcp_visible, _) = rmcp_capped_filter_captures("rmcp::transport=debug");
+        assert!(
+            rmcp_visible,
+            "RUST_LOG=rmcp::transport=debug should still surface rmcp debug output -- a more \
+             specific target must win over this cap's rmcp=info"
+        );
     }
 
     /// Serializes tests in this module that mutate `MCP_EXECUTION_LOG_FORMAT`, mirroring

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -556,6 +556,43 @@ where
     })
 }
 
+/// Caps `rmcp`'s own `tracing` targets at `info`, on top of whatever base filter is already in
+/// effect.
+///
+/// `rmcp` 3.1.2's transport layer logs raw, unsanitized peer input at `debug` level (e.g.
+/// `rmcp::transport::async_rw`'s parse-failure line embeds the offending line verbatim) — this
+/// fires inside the server's own decode path *before* [`JsonRpcMessageCodecError`]'s sanitizing
+/// `Display` (the issue #415 mitigation) ever sees it, so a broad `RUST_LOG=debug` (or any base
+/// filter enabling `debug` globally) streams untrusted peer text into the log unfiltered (issue
+/// #421). This closes the *debug-level, raw-line* logging specifically — `rmcp` also logs a
+/// `Debug`-formatted peer notification at `info` (`service.rs`'s `tracing::info!(?notification,
+/// ...)`), which this cap does not and cannot suppress (`rmcp=info` still allows `info`); that
+/// site is mitigated by `Debug`-escaping control characters, not eliminated, and fires under the
+/// server's default filter with no `RUST_LOG` at all.
+///
+/// Applied via [`EnvFilter::add_directive`] to the *result* of `try_from_default_env`, not just
+/// its fallback branch: a directive folded only into the fallback string is dead code whenever
+/// `RUST_LOG` parses successfully, which is exactly the case this exists to cover.
+///
+/// Directive sets order by target specificity, so this `rmcp=info` directive (more specific than
+/// a bare global `debug`) wins over it. An operator who explicitly sets a *more specific*
+/// directive, e.g. `RUST_LOG=rmcp::transport=debug`, still wins over this one -- that is
+/// intentional: this cap closes the accidental broad-`debug` case, not an operator's deliberate
+/// request for `rmcp` transport debug logs -- **this is the escape hatch**: a target under
+/// `rmcp::` (not the bare `rmcp` target this cap sets) survives the cap and can be raised back to
+/// `debug` explicitly. Note this is target *specificity*, not level: an equally-specific
+/// `RUST_LOG=rmcp=debug` (same target as this cap, different level) is *replaced* by this cap's
+/// `rmcp=info`, not merged with it -- `tracing_subscriber`'s `Directive` ordering does not compare
+/// level, so a same-target `add_directive` call overwrites the existing entry. Both behaviors are
+/// pinned by tests below rather than assumed.
+fn cap_rmcp_log_level(filter: EnvFilter) -> EnvFilter {
+    filter.add_directive(
+        "rmcp=info"
+            .parse()
+            .expect("static \"rmcp=info\" directive string is always valid"),
+    )
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = ServerArgs::parse();
@@ -571,10 +608,10 @@ async fn main() -> Result<()> {
     };
 
     tracing_subscriber::registry()
-        .with(
+        .with(cap_rmcp_log_level(
             EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| EnvFilter::new("info,mcp_execution_server=debug")),
-        )
+        ))
         .with(
             // Not wrapped in `mcp-execution-cli::runner`'s URL-redacting writer (see #353):
             // this process only ever builds a stdio server config from `IntrospectServerParams`
@@ -619,11 +656,11 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AsyncRead, GetExtensions, JsonRpcMessage, LOG_FORMAT_ENV_VAR, LogFormat,
+        AsyncRead, EnvFilter, GetExtensions, JsonRpcMessage, LOG_FORMAT_ENV_VAR, LogFormat,
         MAX_CONCURRENT_REQUESTS, MAX_REQUEST_LINE_SIZE, MAX_UNTRUSTED_FIELD_LEN,
         OwnedSemaphorePermit, RoleServer, RxJsonRpcMessage, SanitizedCodecError, Semaphore,
-        ServerArgs, Stream, StreamExt, bounded_request_stream, log_format_env_is_invalid,
-        resolve_log_format, warn_on_rejected_log_format,
+        ServerArgs, Stream, StreamExt, bounded_request_stream, cap_rmcp_log_level,
+        log_format_env_is_invalid, resolve_log_format, warn_on_rejected_log_format,
     };
     use clap::Parser as _;
     use mcp_execution_server::service::GeneratorService;
@@ -1794,5 +1831,106 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(line)
                 .unwrap_or_else(|e| panic!("invalid JSON line: {e}\n{line}"));
         }
+    }
+
+    /// Shared harness for the `cap_rmcp_log_level` regression tests below: builds
+    /// `cap_rmcp_log_level(EnvFilter::new(base_filter))`, wires it into a real `fmt::layer()`
+    /// over a scoped subscriber, emits one `rmcp::transport::async_rw`-targeted `debug!`
+    /// (standing in for `rmcp`'s own raw-peer-line logging) and one `mcp_execution_server`-
+    /// targeted `debug!` (standing in for this crate's own diagnostics), and returns
+    /// `(rmcp_line_visible, own_line_visible)`. Does not mutate `RUST_LOG` (parallel test threads
+    /// share one process) -- `base_filter` plays the same role a real `RUST_LOG` value would, but
+    /// only ever reaches `EnvFilter::new` directly.
+    fn rmcp_capped_filter_captures(base_filter: &str) -> (bool, bool) {
+        use std::sync::Mutex;
+
+        #[derive(Clone)]
+        struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+        impl std::io::Write for SharedBuf {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                std::io::Write::write(&mut *self.0.lock().unwrap(), buf)
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                std::io::Write::flush(&mut *self.0.lock().unwrap())
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let make_writer = {
+            let buf = buf.clone();
+            move || SharedBuf(buf.clone())
+        };
+
+        let filter = cap_rmcp_log_level(EnvFilter::new(base_filter));
+        let subscriber = tracing_subscriber::registry().with(filter).with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(make_writer)
+                .with_ansi(false),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(
+                target: "rmcp::transport::async_rw",
+                "raw untrusted peer line"
+            );
+            tracing::debug!(target: "mcp_execution_server", "own debug event");
+        });
+
+        let written = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        (
+            written.contains("raw untrusted peer line"),
+            written.contains("own debug event"),
+        )
+    }
+
+    /// Regression coverage for issue #421: a broad `debug` base filter must not let `rmcp`'s
+    /// own `tracing` targets (which log raw, unsanitized peer input at `debug`) through, while
+    /// this crate's own `debug` events must still pass.
+    #[test]
+    fn cap_rmcp_log_level_suppresses_rmcp_debug_but_keeps_own_debug() {
+        let (rmcp_visible, own_visible) = rmcp_capped_filter_captures("debug");
+        assert!(
+            !rmcp_visible,
+            "rmcp debug line was not suppressed under a global `debug` base"
+        );
+        assert!(
+            own_visible,
+            "own debug event was unexpectedly suppressed under a global `debug` base"
+        );
+    }
+
+    /// Regression coverage for critic finding S1: `tracing_subscriber`'s `Directive` ordering
+    /// does not compare level, so `EnvFilter::add_directive` *replaces* a same-target directive
+    /// rather than merging it. An operator's explicit `RUST_LOG=rmcp=debug` is therefore silently
+    /// downgraded to this cap's own `rmcp=info`, not left to coexist at `debug` -- this was named
+    /// by the original security audit as the ambiguous case to verify with a test rather than
+    /// assume. The escape hatch for an operator who needs this is a *more specific* target (see
+    /// the test below) -- documented in `cap_rmcp_log_level`'s doc comment and the CHANGELOG.
+    #[test]
+    fn cap_rmcp_log_level_replaces_a_same_target_rmcp_debug_directive() {
+        let (rmcp_visible, _) = rmcp_capped_filter_captures("rmcp=debug");
+        assert!(
+            !rmcp_visible,
+            "RUST_LOG=rmcp=debug was expected to be replaced by this cap's rmcp=info, not merged \
+             with it -- if this now fails, `tracing_subscriber`'s directive-merge behavior \
+             changed and `cap_rmcp_log_level`'s doc comment needs updating"
+        );
+    }
+
+    /// Counterpart to the test above: a target *more specific* than `rmcp` (e.g.
+    /// `RUST_LOG=rmcp::transport=debug`) is not overwritten by this cap's `rmcp=info` --
+    /// `tracing_subscriber` orders directives by target specificity, and a longer target wins.
+    /// This is the documented escape hatch for an operator who deliberately wants rmcp transport
+    /// debug output.
+    #[test]
+    fn cap_rmcp_log_level_does_not_override_a_more_specific_rmcp_target() {
+        let (rmcp_visible, _) = rmcp_capped_filter_captures("rmcp::transport=debug");
+        assert!(
+            rmcp_visible,
+            "RUST_LOG=rmcp::transport=debug should still surface rmcp debug output -- a more \
+             specific target must win over this cap's rmcp=info"
+        );
     }
 }

--- a/crates/mcp-skill/src/context.rs
+++ b/crates/mcp-skill/src/context.rs
@@ -310,8 +310,6 @@ fn build_generation_prompt(
 **Server ID**: {server_id}
 **Total Tools**: {}
 
-### Categories and Tools
-
 "#,
         categories.iter().map(|c| c.tools.len()).sum::<usize>()
     ));
@@ -637,6 +635,10 @@ mod tests {
         // exactly one real opening and one real closing delimiter in the prompt.
         assert_eq!(prompt.matches("<untrusted-data>").count(), 1);
         assert_eq!(prompt.matches("</untrusted-data>").count(), 1);
+        // Issue #419: the "### Categories and Tools" heading must be emitted exactly once, from
+        // inside the untrusted-data boundary -- not once there and once again in the trusted
+        // preamble above it.
+        assert_eq!(prompt.matches("### Categories and Tools").count(), 1);
     }
 
     /// Issue #411 (S1): a custom `skill_name` (attacker-controlled the same way tool metadata

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -439,6 +439,21 @@ pub enum SkillMetadataError {
         /// Name of the missing/empty field (e.g. `"name"`, `"description"`).
         field: &'static str,
     },
+
+    /// The frontmatter `name` exceeded [`MAX_SKILL_NAME_LENGTH`](crate::types::MAX_SKILL_NAME_LENGTH).
+    ///
+    /// Enforced here rather than only on the two `generate` call sites
+    /// (`crates/mcp-cli/src/commands/skill.rs`, `crates/mcp-server/src/service.rs`) so that
+    /// `save_skill` — which writes caller-supplied `SKILL.md` content directly and never routes
+    /// through [`crate::types::validate_skill_name`] — cannot persist an unbounded `name` into
+    /// the always-loaded skill index (issue #419).
+    #[error("skill_name too long: {len} chars exceeds {limit} limit")]
+    NameTooLong {
+        /// Actual length of the rejected name, in `char`s.
+        len: usize,
+        /// Maximum allowed length (`MAX_SKILL_NAME_LENGTH`).
+        limit: usize,
+    },
 }
 
 /// Renders a `serde_norway` deserialization error, correcting its line number
@@ -523,8 +538,9 @@ fn require_field(value: Option<String>, field: &'static str) -> Result<String, S
 /// # Errors
 ///
 /// Returns [`SkillMetadataError`] if the YAML frontmatter is missing, too
-/// large (`MAX_FRONTMATTER_SIZE`), malformed, or a required field (`name`,
-/// `description`) is absent or empty.
+/// large (`MAX_FRONTMATTER_SIZE`), malformed, a required field (`name`,
+/// `description`) is absent or empty, or `name` exceeds
+/// [`MAX_SKILL_NAME_LENGTH`](crate::types::MAX_SKILL_NAME_LENGTH).
 ///
 /// # Examples
 ///
@@ -573,6 +589,19 @@ pub fn extract_skill_metadata(
         .map_err(|e| SkillMetadataError::InvalidYaml(describe_yaml_error(&e)))?;
 
     let name = require_field(frontmatter.name, "name")?;
+    match crate::types::validate_skill_name(&name) {
+        Ok(()) => {}
+        // `require_field` already rejects a blank/empty `name`, so this arm is unreachable via
+        // this call site today — mapped onto the equivalent `MissingField` rather than a `panic!`
+        // or a second, inconsistent "empty" error so the match stays exhaustive and safe even if
+        // `require_field`'s blank-rejection is ever relaxed.
+        Err(crate::types::SkillNameError::Empty) => {
+            return Err(SkillMetadataError::MissingField { field: "name" });
+        }
+        Err(crate::types::SkillNameError::TooLong { len, limit }) => {
+            return Err(SkillMetadataError::NameTooLong { len, limit });
+        }
+    }
     let description = require_field(frontmatter.description, "description")?;
 
     // Count sections (H2 headers)
@@ -1123,6 +1152,37 @@ More content.
             result,
             Err(SkillMetadataError::MissingField { field: "name" })
         ));
+    }
+
+    #[test]
+    fn test_extract_skill_metadata_name_too_long_rejected() {
+        // Issue #419: `save_skill` writes caller-supplied SKILL.md content directly, never
+        // routing `name` through `validate_skill_name` the way the two `generate` call sites do.
+        // `extract_skill_metadata` is the one chokepoint both paths share, so the bound has to
+        // live here.
+        let long_name = "a".repeat(crate::types::MAX_SKILL_NAME_LENGTH + 1);
+        let content = format!("---\nname: {long_name}\ndescription: test\n---\n# Test");
+
+        let result = extract_skill_metadata(&content);
+
+        assert!(matches!(
+            result,
+            Err(SkillMetadataError::NameTooLong {
+                len,
+                limit
+            }) if len == crate::types::MAX_SKILL_NAME_LENGTH + 1
+                && limit == crate::types::MAX_SKILL_NAME_LENGTH
+        ));
+    }
+
+    #[test]
+    fn test_extract_skill_metadata_name_at_max_length_accepted() {
+        let max_name = "a".repeat(crate::types::MAX_SKILL_NAME_LENGTH);
+        let content = format!("---\nname: {max_name}\ndescription: test\n---\n# Test");
+
+        let result = extract_skill_metadata(&content);
+
+        assert_eq!(result.unwrap().name, max_name);
     }
 
     #[test]

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -285,6 +285,50 @@ URL sitting inside a JSON-escaped string (`serde_json` escaping `"` to
 otherwise leave an unescaped `"` and invalid JSON — see
 [[../core/spec#redact module|redact_urls_in_text]].
 
+Issue #421: this crate is a *client* of third-party MCP servers
+(`mcp_execution_introspector::Introspector`), and `rmcp` 3.1.2's transport layer logs raw,
+unsanitized peer input at `debug` level. `RedactingWriter` only rewrites embedded URLs — it does
+not neutralize this, so without a cap, `--verbose` alone (`filter = EnvFilter::new("debug")`, no
+`RUST_LOG` involved at all) streams an untrusted server's raw stdout lines into stderr. `init_logging`
+closes this specific path — *debug-level, raw-line* logging — via a private pure function,
+`cap_rmcp_log_level(EnvFilter) -> EnvFilter`, applied to *both* branches of the `verbose` `if`/`else`
+— not just the non-verbose branch's `try_from_default_env().unwrap_or_else(...)` fallback, since a
+directive folded only into that fallback string would never apply to the verbose branch (which
+never calls `try_from_default_env` at all) and is dead code in the non-verbose branch whenever
+`RUST_LOG` parses successfully:
+
+```rust
+let filter = cap_rmcp_log_level(if verbose {
+    EnvFilter::new("debug")
+} else {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+});
+```
+
+The cap is level-based, not a content filter: `rmcp` also logs a `Debug`-formatted peer
+notification at `info` (`service.rs`'s `tracing::info!(?notification, ...)`), which `rmcp=info`
+does not and cannot suppress. That site is mitigated (`?` renders via `Debug`, which escapes
+control characters, unlike the raw-`Display` `message`-field sites this cap targets), not
+eliminated — the full notification content still reaches stderr. Closing it would require
+content-level sanitization of `rmcp`'s own event, not a level directive, and is out of scope here.
+
+`cap_rmcp_log_level` adds an `rmcp=info` directive via `EnvFilter::add_directive`.
+`tracing_subscriber` orders directives by target specificity, so this directive (more specific
+than a bare global `debug`) wins over it. An operator who explicitly sets a *more specific*
+directive, e.g. `RUST_LOG=rmcp::transport=debug`, still wins over this one — intentional, since
+the goal is closing the accidental broad-`debug` case (including plain `--verbose`), not blocking
+a deliberate request for `rmcp` transport debug logs; this is the escape hatch for an operator who
+needs one. Specificity is a different axis from level, though: an *equally* specific
+`RUST_LOG=rmcp=debug` (same `rmcp` target this cap sets, different level) is not merged with this
+cap's `rmcp=info` — `tracing_subscriber`'s `Directive` ordering does not compare level, so
+`EnvFilter::add_directive` on a same-target directive *replaces* the existing entry, silently
+downgrading an operator's explicit `rmcp=debug` to `info`. Both the escape hatch and the
+replace-not-merge behavior are pinned by dedicated tests rather than assumed. Being a pure
+function (no `std::env` access), `cap_rmcp_log_level` is unit-tested directly with a scoped
+subscriber rather than by mutating `RUST_LOG` in-process (parallel test threads share one
+process) — mirroring the `SharedBuf`-based scoped-subscriber pattern `runner.rs`'s
+`RedactingWriter` tests already establish.
+
 `execute_command` **never propagates a handler failure as `Err`** — it
 always resolves to `Ok(classified_exit_code)` (issue #195's fix, so `main`
 can always reach `std::process::exit` with a semantic code instead of

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -556,6 +556,41 @@ by `SanitizedCodecError` rather than by omitting the value outright, since
 that value (a codec error's `Display`) carries diagnostic content worth
 keeping, unlike the rejected-env-var case above.
 
+Issue #421: `rmcp` 3.1.2's own transport layer logs raw, unsanitized peer input at `debug` level
+(`rmcp::transport::async_rw`'s parse-failure line embeds the offending line verbatim) — this fires
+inside this binary's own decode path *before* §8's `SanitizedCodecError` mitigation ever sees it,
+so a broad `RUST_LOG=debug` streams untrusted peer text into the log unfiltered. `main`'s private
+`cap_rmcp_log_level(EnvFilter) -> EnvFilter` closes this specific path — *debug-level, raw-line*
+logging — by `add_directive`-ing `rmcp=info` onto the *result* of
+`EnvFilter::try_from_default_env().unwrap_or_else(...)`, not folded into only the fallback string —
+a directive added solely to the fallback is dead code whenever `RUST_LOG` parses successfully,
+which is exactly the case this exists to cover.
+
+The cap is level-based, not a content filter, so it does not cover every untrusted-data-into-log
+site: `rmcp`'s `service.rs` also logs a `Debug`-formatted peer notification at `info`
+(`tracing::info!(?notification, "received notification")`), which `rmcp=info` does not and cannot
+suppress — `info` is exactly the level this cap still allows. That site fires under this binary's
+*default* filter with no `RUST_LOG` set at all. It is mitigated, not eliminated: `?` renders via
+`Debug`, which escapes control characters, so it lacks the newline/ANSI-forging vector the
+`message`-field `debug!` sites carry — but the full notification content still reaches the log
+verbatim otherwise. Closing that site (if ever warranted) would require a content-level
+sanitization of `rmcp`'s own event, not a level directive.
+
+`tracing_subscriber` orders directives by target specificity, so this `rmcp=info` directive (more
+specific than a bare global `debug`) wins over it; an operator who explicitly sets a *more
+specific* directive, e.g. `RUST_LOG=rmcp::transport=debug`, still wins over this one —
+intentional, since the goal is closing the accidental broad-`debug` case, not blocking a
+deliberate request for `rmcp` transport debug logs, and it is the escape hatch for an operator who
+needs one. Specificity is not the same axis as level, though: an *equally* specific
+`RUST_LOG=rmcp=debug` (same `rmcp` target this cap sets, different level) is not merged with this
+cap's `rmcp=info` — `tracing_subscriber`'s `Directive` ordering does not compare level, so
+`EnvFilter::add_directive` on a same-target directive *replaces* the existing entry, silently
+downgrading an operator's explicit `rmcp=debug` to `info`. Both the escape hatch and the
+replace-not-merge behavior are pinned by dedicated tests rather than assumed, per the original
+audit's request. `cap_rmcp_log_level` is a pure function (not env-mutating), so it is unit-tested
+directly with a scoped subscriber rather than by setting `RUST_LOG` in-process (parallel test
+threads share one process).
+
 ## 10. Error Conditions
 
 `StateError`: `AtCapacity { limit }`, `MemoryBudgetExceeded { limit }`.

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -273,6 +273,19 @@ document-size limit (see [[../constitution#V. Security]]).
 line number is corrected to be file-relative (the block starts one line
 after the file's opening `---`).
 
+`name` is additionally passed through `crate::types::validate_skill_name` (issue #419): the two
+`generate` call sites (`mcp-cli`'s `skill` command, `mcp-server`'s `generate_skill` tool) already
+enforce `MAX_SKILL_NAME_LENGTH` by calling `validate_skill_name` directly on a caller-supplied
+override before it reaches this function, but `save_skill` writes caller-supplied `SKILL.md`
+content straight through to `extract_skill_metadata` and never calls `validate_skill_name`
+itself — so before this fix, `save_skill`'s `name` was bounded only by `MAX_FRONTMATTER_SIZE` (8
+KiB), while every other path bounded it at 200 chars. `extract_skill_metadata` is the one `pub`
+chokepoint both paths share, so the bound lives here rather than being duplicated in the
+`save_skill` handler. `SkillNameError::TooLong` maps onto `SkillMetadataError::NameTooLong`;
+`SkillNameError::Empty` maps onto the existing `SkillMetadataError::MissingField { field: "name" }`
+— unreachable via this call site today, since `require_field` already rejects a blank `name`
+first, but mapped rather than panicking so the match stays safe if that ordering ever changes.
+
 > [!note]
 > `serde_norway` remains this project's mandated YAML parser. A pure-Rust
 > replacement (`serde-saphyr`) was evaluated and **not adopted** — see
@@ -337,7 +350,8 @@ name before any filesystem work; the rest is delegated with
 `StaleMetadata`.
 
 `SkillMetadataError`: `MissingFrontmatter`, `FrontmatterTooLarge`,
-`InvalidYaml`, `MissingField`.
+`InvalidYaml`, `MissingField`, `NameTooLong { len, limit }` (issue #419 — `name` exceeded
+`MAX_SKILL_NAME_LENGTH`; see §7).
 
 `OutputPathError`: `InvalidServerId { server_id, source: ServerIdSlugError }` (issue #401 —
 confinement now validates `server_id` via `mcp_execution_core::validate_server_id_slug`, the


### PR DESCRIPTION
## Summary

- Enforce `validate_skill_name` inside `extract_skill_metadata` so the `save_skill` path (and any future caller) rejects an oversized frontmatter name instead of round-tripping through a later `FrontmatterTooLarge` rejection. Also drops the duplicated "Categories and Tools" heading in the generation prompt preamble.
- Cap `rmcp`'s own tracing level to `info` at all `EnvFilter` construction points (server default filter, CLI verbose and non-verbose branches) so a broad `RUST_LOG=debug`, or `mcp-cli`'s `--verbose` flag, no longer re-exposes raw untrusted transport lines that `rmcp` logs before this project's own sanitization sees them. An explicit, more specific directive such as `rmcp::transport=debug` still overrides the cap for operators who need it.

## Breaking change

`SkillMetadataError` gains a `NameTooLong { len, limit }` variant, returned when a SKILL.md frontmatter `name` exceeds `MAX_SKILL_NAME_LENGTH`.

Closes #419, Closes #421

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` (1261 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests for the exact `MAX_SKILL_NAME_LENGTH` boundary and for `cap_rmcp_log_level`'s replace-vs-merge and escape-hatch directive semantics