### PR TITLE
fix(core,codegen): make forbidden env-var name check case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-core`**: `validate_env_name` now compares environment variable names against
+  `FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` (`DYLD_`) with an ASCII-case-insensitive match
+  instead of an exact byte comparison. Windows treats environment variable names as
+  case-insensitive at the OS/`CreateProcess` level, so a case-varied spelling such as `Path` or
+  `path` previously bypassed the forbidden-name check entirely while still overriding `PATH` for
+  the spawned subprocess (#428). As a behavior change, a POSIX-legal but distinctly-cased name
+  that is not the canonical spelling (e.g. `path`, `node_options`, `ld_preload`) is now rejected
+  too, even on platforms where env var names are case-sensitive, so the check behaves
+  identically regardless of host OS.
+- **`mcp-execution-codegen`**: the generated runtime bridge's `validateEnvName` (rendered into
+  `_runtime/mcp-bridge.ts`) now mirrors the same case-insensitive comparison, closing the
+  matching gap in the TypeScript copy of this check (#428).
 - **`mcp-execution-skill`**: `render_skill_md`'s YAML frontmatter (`name`, `description`) is
   now serialized as a whole via `serde-saphyr`'s emitter instead of hand-rolled escaping applied
   only to `description`. The previous escaper covered just `\`, `"`, and `\n`/`\r`, leaving other

--- a/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
@@ -211,16 +211,22 @@ function validateCommandString(value: unknown, context: string): void {
 /**
  * Validates an environment variable name against the forbidden list.
  *
- * Mirrors `validate_env_name` in `mcp-execution-core`'s `command.rs`.
+ * Mirrors `validate_env_name` in `mcp-execution-core`'s `command.rs`, including its
+ * case-insensitive comparison: Windows treats environment variable names as case-insensitive
+ * at the OS/`CreateProcess` level, so a case-varied spelling such as `Path` or `path` must be
+ * rejected exactly like the canonical `PATH`. `FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` are
+ * rendered from the Rust source already upper-cased, so upper-casing `name` before comparing
+ * is sufficient.
  *
  * @param name - The environment variable name to validate
- * @throws {Error} If the name is forbidden (exact match or `DYLD_*` prefix)
+ * @throws {Error} If the name is forbidden (exact match or `DYLD_*` prefix, case-insensitive)
  */
 function validateEnvName(name: string): void {
-  if (FORBIDDEN_ENV_NAMES.includes(name)) {
+  const upperName = name.toUpperCase();
+  if (FORBIDDEN_ENV_NAMES.includes(upperName)) {
     throw new Error(`Forbidden environment variable name: ${name}`);
   }
-  if (name.startsWith(FORBIDDEN_ENV_PREFIX)) {
+  if (upperName.startsWith(FORBIDDEN_ENV_PREFIX)) {
     throw new Error(`Forbidden environment variable prefix ${FORBIDDEN_ENV_PREFIX}: ${name}`);
   }
 }

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -1027,6 +1027,80 @@ fn test_runtime_bridge_rejects_forbidden_env_var_before_spawn() {
         stdout.contains("LD_PRELOAD"),
         "rejection reason should name the forbidden env var: {stdout}"
     );
+
+    // Case-varied regression guard for #428: the bridge's `validateEnvName` must reject a
+    // differently-cased spelling of a forbidden name too, mirroring the Rust-side
+    // `validate_env_name` fix — Windows treats environment variable names as
+    // case-insensitive, so `Ld_Preload` is just as real a `LD_PRELOAD` override as the
+    // canonical spelling once the subprocess is spawned.
+    let mcp_json_case_varied = json!({
+        "mcpServers": {
+            "github": {
+                "command": "node",
+                "args": ["--version"],
+                "env": { "Ld_Preload": "/tmp/evil.so" }
+            }
+        }
+    });
+
+    let Some((success, stdout, stderr)) = run_bridge_harness(
+        "test_runtime_bridge_rejects_forbidden_env_var_before_spawn_case_varied",
+        &bridge.content,
+        &mcp_json_case_varied,
+        "github",
+    ) else {
+        return;
+    };
+
+    assert!(
+        success,
+        "bridge did not reject the case-varied Ld_Preload config before spawning:\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("REJECTED:"),
+        "expected the bridge to reject the case-varied config: stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Ld_Preload"),
+        "rejection reason should name the forbidden env var as passed: {stdout}"
+    );
+
+    // Case-varied regression guard for the `DYLD_` *prefix* branch specifically (the exact-name
+    // and prefix checks are separate code paths in `validateEnvName`, so the exact-name case
+    // above does not exercise this one).
+    let mcp_json_dyld_prefix_case_varied = json!({
+        "mcpServers": {
+            "github": {
+                "command": "node",
+                "args": ["--version"],
+                "env": { "dyld_insert_libraries": "/tmp/evil.so" }
+            }
+        }
+    });
+
+    let Some((success, stdout, stderr)) = run_bridge_harness(
+        "test_runtime_bridge_rejects_forbidden_env_var_before_spawn_dyld_prefix_case_varied",
+        &bridge.content,
+        &mcp_json_dyld_prefix_case_varied,
+        "github",
+    ) else {
+        return;
+    };
+
+    assert!(
+        success,
+        "bridge did not reject the case-varied dyld_insert_libraries config before spawning:\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("REJECTED:"),
+        "expected the bridge to reject the case-varied prefix config: stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("dyld_insert_libraries"),
+        "rejection reason should name the forbidden env var as passed: {stdout}"
+    );
 }
 
 /// Behavioral regression guard for #201's critic follow-up (S3): `{"transport":"http",...}`

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -44,6 +44,11 @@ const FORBIDDEN_CHARS: &[char] = &[';', '|', '&', '>', '<', '`', '$', '(', ')', 
 
 /// Forbidden environment variable names that pose security risks.
 ///
+/// Matched by [`validate_env_name`] using an ASCII-case-insensitive comparison — Windows
+/// treats environment variable names as case-insensitive at the OS/`CreateProcess` level, so
+/// a config carrying e.g. `Path` or `NODE_options` is rejected exactly like the canonical
+/// spelling shown below.
+///
 /// # Threat Model — What This List Does and Does Not Protect Against
 ///
 /// This is an **accidental/indirect-misconfiguration guard, not a sandbox
@@ -96,6 +101,8 @@ const FORBIDDEN_ENV_NAMES: &[&str] = &[
 
 /// Environment-variable-name prefix rejected regardless of exact match: macOS's
 /// dynamic-linker variable family (`DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, ...).
+///
+/// Matched by [`validate_env_name`] case-insensitively, same as [`FORBIDDEN_ENV_NAMES`].
 const FORBIDDEN_ENV_PREFIX: &str = "DYLD_";
 
 /// Upper bound for `connect_timeout`/`discover_timeout`, matching the
@@ -266,8 +273,9 @@ pub const fn forbidden_env_prefix() -> &'static str {
 /// - **Forbidden env names**: dynamic-linker (`LD_PRELOAD`, `LD_LIBRARY_PATH`,
 ///   `LD_AUDIT`, `DYLD_*`), `PATH`, and interpreter hijack vectors
 ///   (`NODE_OPTIONS`, `BASH_ENV`, `PYTHONPATH`, `PYTHONSTARTUP`, `RUBYOPT`,
-///   `PERL5OPT`, `JAVA_TOOL_OPTIONS`) — see the `FORBIDDEN_ENV_NAMES` constant's
-///   doc comment in this module's source for the full threat-model note
+///   `PERL5OPT`, `JAVA_TOOL_OPTIONS`), matched case-insensitively — see the
+///   `FORBIDDEN_ENV_NAMES` constant's doc comment in this module's source for
+///   the full threat-model note
 /// - **Absolute paths**: Must exist and be executable
 /// - **Binary names**: Allowed (resolved via PATH at runtime)
 /// - **URL scheme**: Must be `http://` or `https://`
@@ -794,16 +802,30 @@ fn validate_absolute_path(command: &str) -> Result<()> {
 /// This is an internal helper that checks if an environment variable name is in the
 /// forbidden list. Length is already bounded unconditionally by [`validate_stdio_size_bounds`]
 /// before this runs.
+///
+/// The comparison is ASCII-case-insensitive: Windows treats environment variable names as
+/// case-insensitive at the OS/`CreateProcess` level (and so does std's `Command` environment
+/// block on that platform), so a case-varied spelling such as `Path` or `path` would otherwise
+/// bypass this list while still functioning as a real override when the subprocess is spawned.
 fn validate_env_name(name: &str) -> Result<()> {
-    // Check for forbidden env names (exact match)
-    if FORBIDDEN_ENV_NAMES.contains(&name) {
+    // Check for forbidden env names (exact match, case-insensitive)
+    if FORBIDDEN_ENV_NAMES
+        .iter()
+        .any(|forbidden| name.eq_ignore_ascii_case(forbidden))
+    {
         return Err(Error::SecurityViolation {
             reason: format!("Forbidden environment variable name: {name}"),
         });
     }
 
-    // Check for DYLD_* prefix (macOS dynamic linker variables)
-    if name.starts_with(FORBIDDEN_ENV_PREFIX) {
+    // Check for DYLD_* prefix (macOS dynamic linker variables), case-insensitive.
+    // Compared as bytes (not `str` slicing) so a multi-byte UTF-8 name can never
+    // panic on a non-char-boundary split.
+    if name
+        .as_bytes()
+        .get(..FORBIDDEN_ENV_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(FORBIDDEN_ENV_PREFIX.as_bytes()))
+    {
         return Err(Error::SecurityViolation {
             reason: format!("Forbidden environment variable prefix DYLD_: {name}"),
         });
@@ -1255,6 +1277,58 @@ mod tests {
         assert!(validate_env_name("LD_DEBUG").is_ok()); // Not in list
         assert!(validate_env_name("MY_PATH").is_ok()); // Not exact match
         assert!(validate_env_name("DYLD").is_ok()); // No underscore, not prefix match
+    }
+
+    #[test]
+    fn test_validate_env_name_case_insensitive() {
+        // Windows treats env var names as case-insensitive, so any casing of an
+        // exact-match forbidden name must be rejected, not just the canonical spelling.
+        assert!(validate_env_name("Path").is_err());
+        assert!(validate_env_name("path").is_err());
+        assert!(validate_env_name("PATH").is_err());
+        assert!(validate_env_name("PaTh").is_err());
+
+        assert!(validate_env_name("Ld_Preload").is_err());
+        assert!(validate_env_name("ld_preload").is_err());
+
+        assert!(validate_env_name("Node_Options").is_err());
+        assert!(validate_env_name("node_options").is_err());
+
+        // Prefix match must also be case-insensitive.
+        assert!(validate_env_name("dyld_insert_libraries").is_err());
+        assert!(validate_env_name("Dyld_Insert_Libraries").is_err());
+        assert!(validate_env_name("dYlD_anything").is_err());
+
+        // Sanity: names that are not case variants of a forbidden entry stay allowed.
+        assert!(validate_env_name("MyPath").is_ok());
+        assert!(validate_env_name("dyl").is_ok()); // too short for DYLD_ prefix, not a match
+    }
+
+    #[test]
+    fn test_validate_env_name_prefix_check_does_not_panic_on_utf8_boundary() {
+        // "DYL€_REST": the euro sign ('\u{20AC}') is a 3-byte UTF-8 sequence occupying byte
+        // indices 3..6, so byte index `FORBIDDEN_ENV_PREFIX.len()` (5) falls strictly inside
+        // it and is not a char boundary. A naive `name[..5]` slice would panic here; the
+        // byte-slice `eq_ignore_ascii_case` comparison in `validate_env_name` must not.
+        let name = "DYL\u{20AC}_REST";
+        assert_eq!(name.len(), 3 + 3 + 5);
+        assert!(!name.is_char_boundary(5));
+        assert!(validate_env_name(name).is_ok());
+    }
+
+    #[test]
+    fn test_forbidden_env_constants_are_already_ascii_uppercase() {
+        // The generated TS runtime bridge (`runtime-bridge.ts.hbs`) renders these constants
+        // verbatim and upper-cases only the *input* name before comparing, relying on
+        // `FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` already being upper-case. This invariant
+        // protects that render-from-Rust drift guarantee.
+        for forbidden in FORBIDDEN_ENV_NAMES {
+            assert_eq!(*forbidden, forbidden.to_ascii_uppercase());
+        }
+        assert_eq!(
+            FORBIDDEN_ENV_PREFIX,
+            FORBIDDEN_ENV_PREFIX.to_ascii_uppercase()
+        );
     }
 
     // ── Http/Sse transport validation ────────────────────────────────────────

--- a/specs/SRS-mcp-execution-2026-07-27.md
+++ b/specs/SRS-mcp-execution-2026-07-27.md
@@ -289,10 +289,13 @@ at each point it could have arrived from an unvalidated source.
   1. `ServerConfigBuilder::build()` runs full validation unconditionally and
      returns `Err` for any of: a forbidden shell metacharacter
      (`;|&><\`$()` or CR/LF) in `command`/any `arg`; a forbidden environment
-     variable name (exact match against a fixed list, or the `DYLD_` prefix);
-     an unsupported URL scheme for HTTP/SSE transport; a header name outside
-     RFC 7230 `tchar`, or a duplicate header name (case-insensitively); a
-     timeout of `0` or greater than 600s.
+     variable name (exact match against a fixed list, or the `DYLD_` prefix,
+     both compared case-insensitively — Windows treats environment variable
+     names as case-insensitive at the OS level, so e.g. `Path`/`path` are
+     rejected the same as `PATH`); an unsupported URL scheme for HTTP/SSE
+     transport; a header name outside RFC 7230 `tchar`, or a duplicate
+     header name (case-insensitively); a timeout of `0` or greater than
+     600s.
   2. `Introspector::discover_server` re-runs `validate_server_config` on its
      `config` argument even though callers are expected to have already
      validated it via the builder.

--- a/specs/codegen/spec.md
+++ b/specs/codegen/spec.md
@@ -241,7 +241,16 @@ Responsibilities:
   mirroring `mcp_execution_core::validate_server_config` (command
   metacharacters, forbidden env names, URL scheme, header safety) to the
   same depth, since the config file can be hand-edited after generation to
-  add e.g. `LD_PRELOAD`.
+  add e.g. `LD_PRELOAD`. The forbidden-env-name/prefix check is
+  case-insensitive (`validateEnvName` upper-cases `name` before comparing
+  against the already-upper-cased `FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX`),
+  mirroring `validate_env_name`'s `eq_ignore_ascii_case` comparison so a
+  case-varied spelling like `Path`/`path` cannot bypass either layer; note
+  that JS `String.prototype.toUpperCase` folds full Unicode case mappings
+  (a strict superset of Rust's ASCII-only fold), so the TS side never
+  matches *fewer* names than the Rust side — the "mirrors" claim holds in
+  the fail-closed direction, even where the two foldings could in principle
+  diverge on non-ASCII input.
 - `FORBIDDEN_CHARS`/`FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` are
   rendered **directly from the Rust constants** at generation time (via
   `BridgeContext`), not hand-copied, so the TS copy cannot silently drift

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -246,7 +246,12 @@ regardless of transport, before transport-specific checks):
    - `Stdio` → `validate_command_string` (forbidden shell metachars:
      `; | & > < \` $ ( ) \n \r`) on `command` and each `arg`; absolute-path
      commands additionally require existence + executable bit (Unix); env
-     names checked against `forbidden_env_names()`/`forbidden_env_prefix()`.
+     names checked against `forbidden_env_names()`/`forbidden_env_prefix()`,
+     ASCII-case-insensitively (so `Path`/`path`/`PATH` are all rejected) —
+     Windows treats environment variable names as case-insensitive at the
+     OS/`CreateProcess` level, so a case-varied spelling would otherwise
+     bypass this list while still functioning as a real override at spawn
+     time.
    - `Http`/`Sse` → `validate_network_config`: `url` required,
      `validate_url_scheme` (must be `http://`/`https://`, case-insensitive),
      header name (RFC 7230 `tchar` charset) and value (no control chars)
@@ -256,13 +261,13 @@ regardless of transport, before transport-specific checks):
    supported by design** (an unbounded wait would let a hung server block
    this non-interactive tool forever).
 
-Forbidden env names (exact match): `LD_PRELOAD`, `LD_LIBRARY_PATH`,
-`LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`,
+Forbidden env names (exact match, case-insensitive): `LD_PRELOAD`,
+`LD_LIBRARY_PATH`, `LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`,
 `DYLD_FRAMEWORK_PATH`, `PATH`, `NODE_OPTIONS`, `BASH_ENV`, `PYTHONPATH`,
 `PYTHONSTARTUP`, `RUBYOPT`, `PERL5OPT`, `JAVA_TOOL_OPTIONS`; plus any name
-with prefix `DYLD_`. This list is explicitly documented as an
-**accidental-misconfiguration guard, not a sandbox boundary** — it does not
-protect against a malicious command/binary itself.
+with prefix `DYLD_` (also case-insensitive). This list is explicitly
+documented as an **accidental-misconfiguration guard, not a sandbox
+boundary** — it does not protect against a malicious command/binary itself.
 
 Every rejection error omits the offending value from its message when that
 value could be secret-shaped (a misparsed `--api-key sk-...` argument, a


### PR DESCRIPTION
## Summary
- `validate_env_name` (crates/mcp-core/src/command.rs) compared `FORBIDDEN_ENV_NAMES` and the `DYLD_` prefix case-sensitively, so a variant like `Path` bypassed the block while still functioning as a real `PATH` override on Windows, where env var names are case-insensitive at the OS level.
- The generated TypeScript runtime bridge (`crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs`) duplicated the same check for its live `~/.claude/mcp.json` re-validation path and had the identical gap.
- Both validators now compare ASCII-case-insensitively; the Rust prefix check uses a byte-slice comparison to avoid panicking on non-char-boundary UTF-8 slicing, and the TS bridge upper-cases once before comparing.
- Added regression coverage: cased variants of every forbidden name, the `DYLD_` prefix branch (Rust and a live tsc/Node harness case), a UTF-8-boundary panic-safety case, and an invariant test that the Rust constants are already upper-case (protects the TS bridge's drift-free-mirror guarantee).
- Updated `specs/core/spec.md`, `specs/codegen/spec.md`, `specs/SRS-mcp-execution-2026-07-27.md`, and `CHANGELOG.md` to reflect the new behavior, including the disclosed side effect that distinctly-cased names (e.g. `path`, `node_options`) are now also rejected on case-sensitive platforms.

Closes #428.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1292 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Rebased onto latest `origin/master` (clean, no conflicts)