### PR TITLE
fix(skill): thread custom skill_name into prompt and reject tilde paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   embedding/override controls are spaced (rather than removed) to avoid. U+200C/U+200D (ZWNJ/ZWJ)
   are deliberately left untouched, since — unlike every character above — they are
   orthographically load-bearing in Persian/Indic scripts and in emoji ZWJ sequences (#425).
+- **`mcp-execution-skill`**, **`mcp-execution-server`**, **`mcp-execution-cli`**: a caller-supplied
+  `skill_name` passed to `generate_skill` (or the CLI's `--skill-name` flag) was reflected in the
+  response's `skill_name` field but never reached `generation_prompt`, which always embedded the
+  `{server_id}-progressive` default in its `**Skill Name**` line — so an LLM faithfully following
+  the prompt wrote the default name into `SKILL.md`'s frontmatter regardless of the requested
+  custom name. `build_skill_context` now takes the (validated) custom name directly, flattens it
+  with the same `sanitize_untrusted_text` treatment `generation_prompt` applies, and bakes that
+  flattened name into both the response's `skill_name` field and the prompt, so the two are always
+  textually consistent rather than the response field carrying the raw, unflattened name while the
+  prompt showed a flattened one; validation of an oversized/blank name now also happens before
+  `generation_prompt` is built, not after (#435).
+- **`mcp-execution-skill`**, **`mcp-execution-server`**: `save_skill`'s `output_path` parameter
+  silently accepted a value containing a literal `~` path component — notably
+  `generate_skill`'s own informational `output_path` response field
+  (`~/.claude/skills/{server_id}/SKILL.md`), which a client could plausibly echo straight back in
+  — treating `~` as an ordinary directory name and creating a nonsensical nested directory tree
+  with `success: true`. `resolve_skill_output_path` now rejects any `~` path component (leading
+  or not) with a dedicated `OutputPathError::TildeComponent` error, surfaced the same way as the
+  existing `AbsolutePath`/`ParentTraversal` rejections. Doc comments on both `output_path` fields
+  now cross-reference their incompatible semantics (#434).
 
 ### Testing
 

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -121,8 +121,13 @@ pub async fn run(
 
     let scan_result = scan_server_tools(&tool_dir, &server).await?;
 
-    let context =
-        prepare_skill_context(&server, &scan_result.tools, hints, skill_name, output_path)?;
+    let context = prepare_skill_context(
+        &server,
+        &scan_result.tools,
+        hints,
+        skill_name.as_deref(),
+        output_path,
+    )?;
 
     // Check if output file exists and overwrite flag
     let output_path = PathBuf::from(&context.output_path);
@@ -229,23 +234,23 @@ fn prepare_skill_context(
     server: &str,
     tools: &[ParsedToolFile],
     hints: Vec<String>,
-    skill_name: Option<String>,
+    skill_name: Option<&str>,
     output_path: Option<PathBuf>,
 ) -> Result<GenerateSkillResult> {
-    // Step 6: Build skill context
+    // Step 6: Build skill context. Custom skill name is validated up front (same pattern as
+    // `validate_server_id` above) and passed into `build_skill_context` itself — not applied as
+    // a post-hoc override — so an oversized name fails fast here instead of being rendered and
+    // written to disk only for `extract_skill_metadata` to reject it later (issue #413), and so
+    // the name is consistently reflected in `generation_prompt` as well as `skill_name` (issue
+    // #435).
     let hints_ref: Option<Vec<String>> = if hints.is_empty() { None } else { Some(hints) };
 
-    let mut context = build_skill_context(server, tools, hints_ref.as_deref());
-
-    // Apply custom skill name if provided. Validated up front (same pattern as
-    // `validate_server_id` above) so an oversized name fails fast here instead of being
-    // rendered and written to disk only for `extract_skill_metadata` to reject it later
-    // (issue #413).
     if let Some(name) = skill_name {
-        validate_skill_name(&name)
+        validate_skill_name(name)
             .map_err(|e| CoreError::InvalidArgument(format!("Invalid skill name: {e}")))?;
-        context.skill_name = name;
     }
+
+    let mut context = build_skill_context(server, tools, hints_ref.as_deref(), skill_name);
 
     // Apply custom output path if provided
     if let Some(path) = output_path {
@@ -790,7 +795,7 @@ mod tests {
         let result = run(
             "github".to_string(),
             Some(temp.path().to_path_buf()),
-            Some(output_path),
+            Some(output_path.clone()),
             Some("github-advanced".to_string()),
             vec![],
             false,
@@ -802,6 +807,14 @@ mod tests {
             result.is_ok(),
             "Expected success but got: {:?}",
             result.err()
+        );
+
+        // Issue #435: confirm the custom name actually landed in the written SKILL.md, not just
+        // that the call reported success.
+        let written = std::fs::read_to_string(&output_path).unwrap();
+        assert!(
+            written.contains("name: github-advanced"),
+            "written SKILL.md must use the custom skill name: {written}"
         );
     }
 

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -882,6 +882,11 @@ impl GeneratorService {
     /// 2. Claude receives context and `generation_prompt`
     /// 3. Claude generates SKILL.md content
     /// 4. Call `save_skill` with the generated content
+    ///
+    /// The result's `output_path` field is informational/display-only (the default location the
+    /// file *would* land at) and must not be passed as `save_skill`'s own `output_path`
+    /// parameter — despite the shared field name, the two have incompatible semantics; omit
+    /// `save_skill`'s `output_path` to use its default (issue #434).
     #[tool(
         description = "Analyze generated TypeScript files and return context for Claude to create a SKILL.md file. Returns tool metadata, categories, and a generation prompt."
     )]
@@ -961,27 +966,30 @@ impl GeneratorService {
             ));
         }
 
-        // Build context
+        // Validate a custom skill name up front, before `build_skill_context` renders
+        // `generation_prompt`, so an oversized/blank name fails fast here instead of being
+        // rendered and written to disk only for `extract_skill_metadata` to reject it later
+        // (issue #413). Validating before rather than after also means an invalid name never
+        // reaches `generation_prompt` at all (issue #435).
+        if let Some(name) = params.skill_name.as_deref() {
+            validate_skill_name(name).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        }
+
+        // Build context. The validated custom name (if any) is threaded straight into
+        // `build_skill_context` so it's the name actually embedded in `generation_prompt`, not
+        // just an after-the-fact override of `result.skill_name` that leaves the prompt still
+        // instructing the stale `{server_id}-progressive` default (issue #435).
         let mut result = build_skill_context(
             &params.server_id,
             &scan_result.tools,
             params.use_case_hints.as_deref(),
+            params.skill_name.as_deref(),
         );
 
         // Surface non-fatal drift warnings (e.g. `.ts` files excluded for lacking
         // a sidecar entry) in the structured response, not just server-side
         // tracing output (issue #161).
         result.warnings = scan_result.warnings;
-
-        // Override skill name if provided. Validated up front (same pattern as
-        // `validate_server_id_slug` above) so an oversized name fails fast here instead of
-        // being rendered and written to disk only for `extract_skill_metadata` to reject it
-        // later (issue #413).
-        if let Some(name) = params.skill_name {
-            validate_skill_name(&name)
-                .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-            result.skill_name = name;
-        }
 
         Ok(CallToolResult::success(vec![ContentBlock::text(
             serde_json::to_string_pretty(&result).map_err(|e| {
@@ -1095,6 +1103,7 @@ impl GeneratorService {
             }
             OutputPathError::AbsolutePath { .. }
             | OutputPathError::ParentTraversal { .. }
+            | OutputPathError::TildeComponent { .. }
             | OutputPathError::InvalidPath { .. }
             | OutputPathError::ServerIdIsSymlink { .. }
             | OutputPathError::Escape { .. }
@@ -5110,6 +5119,95 @@ mod tests {
         assert!(result.is_err(), "oversized skill_name must be rejected");
         let err = result.unwrap_err();
         assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        // Pins the rejection to `validate_skill_name`'s `TooLong` variant specifically (not some
+        // other, coincidentally-erroring path). The `Err` variant of this handler's
+        // `Result<CallToolResult, McpError>` return type structurally cannot carry a
+        // `GenerateSkillResult`/`generation_prompt` — FR-003 ("no generation_prompt is returned
+        // on rejection") holds by construction whenever this assertion holds.
+        assert!(
+            err.message.contains("too long"),
+            "must be rejected specifically for being too long: {}",
+            err.message
+        );
+    }
+
+    /// Issue #435: a valid custom `skill_name` must be honored end to end through the actual
+    /// `generate_skill` MCP handler — this is the exact layer the original bug lived in (the
+    /// handler called `build_skill_context` before threading the custom name through, so
+    /// `generation_prompt` always embedded the `{server_id}-progressive` default regardless of
+    /// what was requested). Covers FR-001/FR-005: `generation_prompt` contains the custom name,
+    /// the stale default does not appear, and `result.skill_name` matches what's in the prompt.
+    #[tokio::test]
+    async fn test_generate_skill_honors_custom_skill_name() {
+        use mcp_execution_core::metadata::{
+            METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata,
+            ToolMetadata as SidecarToolMetadata,
+        };
+        use mcp_execution_skill::GenerateSkillResult;
+        use tempfile::TempDir;
+
+        let service = GeneratorService::new();
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().to_path_buf();
+
+        let target_dir = base_dir.join("test-server");
+        tokio::fs::create_dir_all(&target_dir).await.unwrap();
+        let meta = ServerMetadata {
+            schema_version: METADATA_SCHEMA_VERSION,
+            server_id: ServerId::new("test-server").unwrap(),
+            server_name: "Test Server".to_string(),
+            server_version: "1.0.0".to_string(),
+            tools: vec![SidecarToolMetadata {
+                name: ToolName::new("create_issue").unwrap(),
+                typescript_name: "createIssue".to_string(),
+                category: None,
+                keywords: vec![],
+                description: None,
+                parameters: vec![ParameterMetadata {
+                    name: "title".to_string(),
+                    typescript_type: "string".to_string(),
+                    required: true,
+                    description: None,
+                }],
+            }],
+        };
+        let content = serde_json::to_string_pretty(&meta).unwrap();
+        tokio::fs::write(target_dir.join(METADATA_FILE_NAME), content)
+            .await
+            .unwrap();
+        tokio::fs::write(target_dir.join("createIssue.ts"), "export {}")
+            .await
+            .unwrap();
+
+        let params = GenerateSkillParams {
+            server_id: "test-server".to_string(),
+            skill_name: Some("my-custom-skill".to_string()),
+            use_case_hints: None,
+            servers_dir: Some(base_dir),
+        };
+
+        let result = service
+            .generate_skill(Parameters(params), CancellationToken::new())
+            .await;
+
+        assert!(result.is_ok(), "valid custom skill_name must be accepted");
+        let content = result.unwrap();
+        let text_content = content.content[0].as_text().unwrap();
+        let parsed: GenerateSkillResult = serde_json::from_str(&text_content.text).unwrap();
+
+        assert_eq!(parsed.skill_name, "my-custom-skill");
+        assert!(
+            parsed
+                .generation_prompt
+                .contains("**Skill Name**: my-custom-skill"),
+            "generation_prompt must embed the custom name: {}",
+            parsed.generation_prompt
+        );
+        assert!(
+            !parsed.generation_prompt.contains("test-server-progressive"),
+            "generation_prompt must not fall back to the default name: {}",
+            parsed.generation_prompt
+        );
     }
 
     // ========================================================================
@@ -5165,6 +5263,39 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
         assert!(err.message.contains("lowercase"));
+    }
+
+    /// Issue #434: a caller echoing `generate_skill`'s informational, display-only
+    /// `output_path` response field (`~/.claude/skills/{server_id}/SKILL.md`) straight into
+    /// `save_skill`'s `output_path` parameter must fail with a clear error naming the `~`
+    /// component, not silently succeed and create a nonsensical `~`-named directory tree.
+    #[tokio::test]
+    async fn test_save_skill_rejects_tilde_prefixed_output_path() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let service =
+            GeneratorService::new().with_skills_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let params = SaveSkillParams {
+            server_id: "my-server".to_string(),
+            content: "---\nname: test\ndescription: test\n---\n# Test".to_string(),
+            output_path: Some(PathBuf::from("~/.claude/skills/my-server/SKILL.md")),
+            overwrite: false,
+        };
+
+        let result = service
+            .save_skill(Parameters(params), CancellationToken::new())
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains('~'));
+        assert!(
+            !temp_dir.path().join("~").exists(),
+            "no garbage '~'-named directory should be created"
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp-server/tests/skill_tests.rs
+++ b/crates/mcp-server/tests/skill_tests.rs
@@ -145,7 +145,7 @@ async fn test_build_skill_context_integration() {
     ];
 
     let use_case_hints = vec!["CI/CD".to_string()];
-    let context = build_skill_context("github", &tools, Some(&use_case_hints));
+    let context = build_skill_context("github", &tools, Some(&use_case_hints), None);
 
     assert_eq!(context.server_id, "github");
     assert_eq!(context.skill_name, "github-progressive");
@@ -275,7 +275,7 @@ async fn test_build_skill_context_many_categories() {
         })
         .collect();
 
-    let context = build_skill_context("test", &tools, None);
+    let context = build_skill_context("test", &tools, None, None);
 
     assert_eq!(context.tool_count, 20);
     assert_eq!(context.categories.len(), 5);
@@ -290,7 +290,7 @@ async fn test_build_skill_context_many_categories() {
 async fn test_build_skill_context_empty_tools() {
     let tools: Vec<ParsedToolFile> = vec![];
 
-    let context = build_skill_context("test", &tools, None);
+    let context = build_skill_context("test", &tools, None, None);
 
     assert_eq!(context.tool_count, 0);
     assert_eq!(context.categories.len(), 0);

--- a/crates/mcp-skill/src/context.rs
+++ b/crates/mcp-skill/src/context.rs
@@ -17,6 +17,17 @@ use std::collections::HashMap;
 /// * `server_id` - Server identifier (e.g., "github")
 /// * `tools` - Parsed tool files from `scan_tools_directory`
 /// * `use_case_hints` - Optional hints about intended use cases
+/// * `custom_name` - Optional caller-supplied skill name. Callers MUST validate this with
+///   [`crate::validate_skill_name`] before passing it in — this function does not validate it
+///   itself, matching `server_id`, which callers likewise validate upstream. When `None`, the
+///   name defaults to `{server_id}-progressive`. Either way, the resulting name is flattened with
+///   [`sanitize_untrusted_text`] before being stored in `GenerateSkillResult::skill_name` — the
+///   same flattening `generation_prompt`'s `**Skill Name**` line applies to it — so the two never
+///   disagree on control characters, invisible Unicode, or length truncation (issue #435). The
+///   prompt's `**Skill Name**` line additionally passes through `wrap_untrusted_block`'s
+///   `<`/`>`/`&` boundary-escaping, applied to the entire untrusted-data block as an
+///   injection defense (issue #411, S1) — that escaping is a prompt-rendering concern, not part
+///   of the name's identity, so it is not applied to `GenerateSkillResult::skill_name`.
 ///
 /// # Returns
 ///
@@ -28,15 +39,21 @@ use std::collections::HashMap;
 /// use mcp_execution_skill::{build_skill_context, ParsedToolFile, ParsedParameter};
 ///
 /// let tools: Vec<ParsedToolFile> = vec![]; // Parsed from scan_tools_directory
-/// let context = build_skill_context("github", &tools, None);
+/// let context = build_skill_context("github", &tools, None, None);
 ///
 /// assert_eq!(context.server_id, "github");
+/// assert_eq!(context.skill_name, "github-progressive");
+///
+/// let custom = build_skill_context("github", &tools, None, Some("my-custom-skill"));
+/// assert_eq!(custom.skill_name, "my-custom-skill");
+/// assert!(custom.generation_prompt.contains("my-custom-skill"));
 /// ```
 #[must_use]
 pub fn build_skill_context(
     server_id: &str,
     tools: &[ParsedToolFile],
     use_case_hints: Option<&[String]>,
+    custom_name: Option<&str>,
 ) -> GenerateSkillResult {
     let tool_count = tools.len();
 
@@ -46,8 +63,17 @@ pub fn build_skill_context(
     // Select representative examples
     let example_tools = select_example_tools(tools, 5);
 
-    // Generate skill name
-    let skill_name = format!("{server_id}-progressive");
+    // Generate skill name: caller-supplied name takes precedence over the default, and — unlike
+    // the pre-#435 handler-side override — this is the name actually baked into
+    // `generation_prompt` below, not just the response's `skill_name` field. Flattened with
+    // `sanitize_untrusted_text` up front (idempotent against `build_generation_prompt`'s own
+    // identical call below) so `GenerateSkillResult::skill_name` holds exactly the same
+    // control-character-flattened, length-truncated text as the prompt's `**Skill Name**` line —
+    // not the raw, unflattened custom name (issue #435, S1).
+    let skill_name = sanitize_untrusted_text(
+        &custom_name.map_or_else(|| format!("{server_id}-progressive"), ToString::to_string),
+        MAX_UNTRUSTED_FIELD_LEN,
+    );
 
     // Build output path
     let output_path = format!("~/.claude/skills/{server_id}/SKILL.md");
@@ -476,13 +502,55 @@ mod tests {
             create_test_tool("list_repos", Some("repos")),
         ];
 
-        let context = build_skill_context("github", &tools, None);
+        let context = build_skill_context("github", &tools, None, None);
 
         assert_eq!(context.server_id, "github");
         assert_eq!(context.skill_name, "github-progressive");
         assert_eq!(context.tool_count, 2);
         assert_eq!(context.categories.len(), 2);
         assert!(!context.generation_prompt.is_empty());
+    }
+
+    /// Issue #435: a caller-supplied `custom_name` must be the name actually embedded in
+    /// `generation_prompt`'s `**Skill Name**` line, not just `GenerateSkillResult::skill_name` —
+    /// otherwise the LLM consuming the prompt writes the stale `{server_id}-progressive` default
+    /// into `SKILL.md`'s frontmatter regardless of what the caller asked for.
+    #[test]
+    fn test_build_skill_context_honors_custom_name_in_prompt() {
+        let tools = vec![create_test_tool("create_issue", Some("issues"))];
+
+        let context = build_skill_context("github", &tools, None, Some("my-custom-skill"));
+
+        assert_eq!(context.skill_name, "my-custom-skill");
+        assert!(
+            context
+                .generation_prompt
+                .contains("**Skill Name**: my-custom-skill")
+        );
+        assert!(!context.generation_prompt.contains("github-progressive"));
+    }
+
+    /// Issue #435, S1: `GenerateSkillResult::skill_name` must hold exactly the same
+    /// control-character-flattened, length-truncated text as the name embedded in
+    /// `generation_prompt`'s `**Skill Name**` line — not the raw, unflattened custom name. A
+    /// hostile name with an embedded newline is the sharpest test: the pre-fix code stored the
+    /// raw (newline-containing) name in `skill_name` while the prompt showed the flattened
+    /// (space-joined) version, so the two visibly disagreed.
+    #[test]
+    fn test_build_skill_context_skill_name_matches_flattened_prompt_name() {
+        let tools = vec![create_test_tool("create_issue", Some("issues"))];
+        let hostile_name = "evil\nname";
+
+        let context = build_skill_context("github", &tools, None, Some(hostile_name));
+
+        assert!(!context.skill_name.contains('\n'), "{}", context.skill_name);
+        assert!(
+            context
+                .generation_prompt
+                .contains(&format!("**Skill Name**: {}", context.skill_name)),
+            "the exact text stored in `skill_name` must be the text embedded in the prompt: {}",
+            context.generation_prompt
+        );
     }
 
     #[test]
@@ -622,7 +690,7 @@ mod tests {
             parameters: vec![],
         };
 
-        let context = build_skill_context("github", std::slice::from_ref(&hostile), None);
+        let context = build_skill_context("github", std::slice::from_ref(&hostile), None, None);
         let prompt = &context.generation_prompt;
 
         assert!(prompt.contains("<untrusted-data>"));

--- a/crates/mcp-skill/src/lib.rs
+++ b/crates/mcp-skill/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! # async fn example() -> Result<(), ScanError> {
 //! let result = scan_tools_directory(Path::new("~/.claude/servers/github")).await?;
-//! let context = build_skill_context("github", &result.tools, None);
+//! let context = build_skill_context("github", &result.tools, None, None);
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/mcp-skill/src/output_path.rs
+++ b/crates/mcp-skill/src/output_path.rs
@@ -12,7 +12,8 @@ use mcp_execution_core::{
     ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
     validate_server_id_slug,
 };
-use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
 /// Errors from resolving and confining a skill output path to its base directory.
@@ -43,6 +44,23 @@ pub enum OutputPathError {
     /// The caller-supplied `output_path` contains a `..` component.
     #[error("output_path must not contain '..' components: {path}")]
     ParentTraversal {
+        /// Sanitized display form of the rejected path.
+        path: String,
+    },
+
+    /// The caller-supplied `output_path` contains a literal `~` path component (anywhere in the
+    /// path, not just as the first segment).
+    ///
+    /// `output_path` is resolved relative to `base_dir/{server_id}` with no home-directory
+    /// expansion (see [`resolve_skill_output_path`]'s doc comment), so a `~` component is never
+    /// meaningful here — it is just a directory literally named `~`. The most common way this
+    /// value shows up is a caller echoing `generate_skill`'s informational, display-only
+    /// `output_path` response field (of the shape `~/.claude/skills/{server_id}/SKILL.md`)
+    /// straight back into `save_skill`'s `output_path` parameter: that string is a valid
+    /// *relative* path with no `..` component, so without this dedicated check it would be
+    /// silently accepted and create a nonsensical `~` directory instead of failing (issue #434).
+    #[error("output_path must not contain a literal '~' path component: {path}")]
+    TildeComponent {
         /// Sanitized display form of the rejected path.
         path: String,
     },
@@ -152,6 +170,14 @@ fn relative_target(output_path: Option<&Path>) -> Result<PathBuf, OutputPathErro
             path: sanitize_path_for_error(path),
         });
     }
+    if path
+        .components()
+        .any(|c| matches!(c, Component::Normal(segment) if segment == OsStr::new("~")))
+    {
+        return Err(OutputPathError::TildeComponent {
+            path: sanitize_path_for_error(path),
+        });
+    }
     if mcp_execution_core::contains_parent_dir(path) {
         return Err(OutputPathError::ParentTraversal {
             path: sanitize_path_for_error(path),
@@ -208,10 +234,10 @@ fn relative_target(output_path: Option<&Path>) -> Result<PathBuf, OutputPathErro
 /// # Errors
 ///
 /// Returns [`OutputPathError`] if `server_id` fails [`validate_server_id_slug`], if `output_path`
-/// is absolute, contains a `..` component, or has no file name, if the resolved path escapes
-/// `base_dir` (including via a symlink at `server_id` itself or any deeper component), if a
-/// required directory could not be created, or if a path component that must be a directory (or
-/// must hold the output file) already exists as the wrong kind of entry.
+/// is absolute, contains a `..` component, contains a literal `~` component, or has no file name,
+/// if the resolved path escapes `base_dir` (including via a symlink at `server_id` itself or any
+/// deeper component), if a required directory could not be created, or if a path component that
+/// must be a directory (or must hold the output file) already exists as the wrong kind of entry.
 ///
 /// # Examples
 ///
@@ -412,6 +438,66 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, OutputPathError::AbsolutePath { .. }));
         assert!(!base.path().join("my-server").exists());
+    }
+
+    /// Issue #434: a caller echoing `generate_skill`'s display-only `output_path` response
+    /// field (`~/.claude/skills/{server_id}/SKILL.md`) straight into `save_skill`'s
+    /// `output_path` parameter must be rejected, not silently accepted as a legitimate relative
+    /// path that creates a literal `~` directory.
+    #[tokio::test]
+    async fn tilde_prefixed_path_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(
+            base.path(),
+            "my-server",
+            Some(Path::new("~/.claude/skills/my-server/SKILL.md")),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, OutputPathError::TildeComponent { .. }));
+        assert!(!base.path().join("my-server").exists());
+    }
+
+    /// Same rejection class as `tilde_prefixed_path_is_rejected`, for the shorter `~/SKILL.md`
+    /// form (tilde as the sole leading segment).
+    #[tokio::test]
+    async fn bare_tilde_leading_segment_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err =
+            resolve_skill_output_path(base.path(), "my-server", Some(Path::new("~/SKILL.md")))
+                .await
+                .unwrap_err();
+        assert!(matches!(err, OutputPathError::TildeComponent { .. }));
+    }
+
+    /// FR-001 requires rejecting a `~` component anywhere in the path, not only when leading.
+    #[tokio::test]
+    async fn non_leading_tilde_component_is_rejected() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(
+            base.path(),
+            "my-server",
+            Some(Path::new("notes/~/SKILL.md")),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, OutputPathError::TildeComponent { .. }));
+    }
+
+    /// A `~` character that is part of a longer segment (not a standalone path component) is not
+    /// a home-directory-expansion lookalike and must continue to be accepted.
+    #[tokio::test]
+    async fn tilde_within_a_longer_segment_is_accepted() {
+        let base = TempDir::new().unwrap();
+        let resolved = resolve_skill_output_path(
+            base.path(),
+            "my-server",
+            Some(Path::new("my~file/SKILL.md")),
+        )
+        .await
+        .unwrap();
+        let canonical_base = base.path().canonicalize().unwrap();
+        assert!(resolved.starts_with(&canonical_base));
     }
 
     #[tokio::test]

--- a/crates/mcp-skill/src/template.rs
+++ b/crates/mcp-skill/src/template.rs
@@ -143,7 +143,7 @@ impl Frontmatter<'_> {
 /// ```no_run
 /// use mcp_execution_skill::{build_skill_context, render_generation_prompt};
 ///
-/// let context = build_skill_context("github", &[], None);
+/// let context = build_skill_context("github", &[], None, None);
 /// let prompt = render_generation_prompt(&context).unwrap();
 /// ```
 pub fn render_generation_prompt(context: &GenerateSkillResult) -> Result<String, TemplateError> {
@@ -210,7 +210,7 @@ pub fn render_generation_prompt(context: &GenerateSkillResult) -> Result<String,
 /// ```no_run
 /// use mcp_execution_skill::{build_skill_context, render_skill_md};
 ///
-/// let context = build_skill_context("github", &[], None);
+/// let context = build_skill_context("github", &[], None, None);
 /// let md = render_skill_md(&context).unwrap();
 /// assert!(md.starts_with("---\n"));
 /// ```
@@ -482,7 +482,7 @@ mod tests {
             parameters: vec![],
         };
 
-        let context = build_skill_context("test", std::slice::from_ref(&hostile), None);
+        let context = build_skill_context("test", std::slice::from_ref(&hostile), None, None);
         let md = render_skill_md(&context).unwrap();
 
         // The hostile description must be flattened to a single line before reaching
@@ -529,7 +529,7 @@ mod tests {
             parameters: vec![],
         };
 
-        let context = build_skill_context("test", std::slice::from_ref(&hostile), None);
+        let context = build_skill_context("test", std::slice::from_ref(&hostile), None, None);
         let md = render_skill_md(&context).unwrap();
 
         // Only the one legitimate category heading may start a line; the injected

--- a/crates/mcp-skill/src/types.rs
+++ b/crates/mcp-skill/src/types.rs
@@ -74,7 +74,13 @@ pub struct GenerateSkillParams {
     /// Default: `{server_id}-progressive`. Max 200 characters (see `validate_skill_name`'s
     /// `MAX_SKILL_NAME_LENGTH`, mirrored here as a literal since schemars attributes cannot
     /// reference a `const`; JSON Schema's `maxLength` already counts Unicode code points, the
-    /// same unit `validate_skill_name` checks at runtime).
+    /// same unit `validate_skill_name` checks at runtime). When supplied, this name is embedded
+    /// in both the response's `skill_name` field and its `generation_prompt` (the `**Skill
+    /// Name**` line the LLM is instructed to use in `SKILL.md`'s frontmatter) — both hold the
+    /// same control-character-flattened, length-truncated text (see
+    /// `mcp_execution_skill::build_skill_context`'s doc comment for the one cosmetic exception:
+    /// the prompt's surrounding untrusted-data block additionally HTML-escapes `<`/`>`/`&` as an
+    /// injection defense).
     #[schemars(length(max = 200))]
     pub skill_name: Option<String>,
 
@@ -112,7 +118,15 @@ pub struct GenerateSkillResult {
     /// Claude uses this prompt to generate SKILL.md content.
     pub generation_prompt: String,
 
-    /// Output path for the skill file.
+    /// Suggested output path for the skill file, for display purposes only.
+    ///
+    /// Shaped like `~/.claude/skills/{server_id}/SKILL.md` (with a literal, unexpanded `~`) —
+    /// this shows where the file will land under its *default* location, but is never validated
+    /// as a real filesystem path. **Do not** pass this value as `save_skill`'s `output_path`
+    /// parameter: despite sharing the same field name, that parameter has entirely different
+    /// semantics (a bare relative path with no `~`, resolved under `base_dir/{server_id}` — see
+    /// [`SaveSkillParams::output_path`]) and will reject a `~`-containing value (issue #434).
+    /// Omit `save_skill`'s `output_path` entirely to use its own default.
     pub output_path: String,
 
     /// Non-fatal drift warnings, e.g. `.ts` files on disk excluded from
@@ -215,7 +229,13 @@ pub struct SaveSkillParams {
 
     /// Custom output path.
     ///
-    /// Default: `~/.claude/skills/{server_id}/SKILL.md`
+    /// Default: `SKILL.md` under `~/.claude/skills/{server_id}/`. Must be a **bare relative
+    /// path** with no leading path separator, no `..` component, and no literal `~` component —
+    /// it is resolved relative to `base_dir/{server_id}`, not the caller's home directory, so a
+    /// `~` here is just a directory name, not a home-directory shortcut. In particular, do
+    /// **not** pass [`GenerateSkillResult::output_path`] (a display-only string of the shape
+    /// `~/.claude/skills/{server_id}/SKILL.md`) here — it is rejected (issue #434). See
+    /// [`crate::resolve_skill_output_path`] for the full resolution/confinement contract.
     pub output_path: Option<PathBuf>,
 
     /// Overwrite if exists.


### PR DESCRIPTION
## Summary
- `generate_skill` built `generation_prompt` from the auto-derived `{server_id}-progressive` name before checking `params.skill_name`, so a caller-supplied custom name reached only the informational `result.skill_name` field and never the prompt the LLM reads. `build_skill_context` now takes the validated, sanitized custom name and bakes it into the prompt up front; `result.skill_name` is sanitized to stay byte-identical with what the prompt embeds.
- `save_skill`'s `output_path` parameter is semantically unrelated to `generate_skill`'s `output_path` response field (relative-only, no home expansion) but shares its name, so echoing the response value back in (e.g. `"~/.claude/skills/{server_id}/SKILL.md"`) passed validation as an ordinary relative path and silently created a bogus nested `~` directory tree. Path resolution now rejects any literal `~` path component with a clear error, and both fields carry cross-referencing doc comments.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1300 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Handler-level regression test for `generate_skill` with a custom `skill_name` (mcp-server)
- [x] Regression tests for `~` path components (leading, non-leading, and non-tilde-segment false-positive checks) in `save_skill` (mcp-skill, mcp-server)
- [x] CLI test reads back the written `SKILL.md` to confirm the custom name lands in it

Closes #435, #434