### PR TITLE
chore(workspace): restore rationale comments for clippy lint-allow entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,12 @@ unused_lifetimes = "warn"
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
 cargo = { level = "deny", priority = -1 }
-cargo_common_metadata = { level = "allow", priority = 10 }
-multiple_crate_versions = { level = "allow", priority = 10 }
-needless_borrows_for_generic_args = { level = "allow", priority = 10 }
+cargo_common_metadata = { level = "allow", priority = 10 }             # All crates already carry complete metadata; kept as a guard for newly added crates
+multiple_crate_versions = { level = "allow", priority = 10 }           # Transitive-only; mostly rmcp and the proc-macro stack (syn, darling, base64)
+needless_borrows_for_generic_args = { level = "allow", priority = 10 } # Only trivial hits in test fixtures (e.g. `&format!(...)`), not worth the churn
 nursery = { level = "deny", priority = -1 }
 pedantic = { level = "deny", priority = -1 }
-too_many_lines = { level = "allow", priority = 10 }
+too_many_lines = { level = "allow", priority = 10 }                    # Generator and test functions legitimately exceed the line threshold
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
## Summary
- Restores one-line rationale comments on the four workspace-wide clippy allows in `[workspace.lints.clippy]` (`cargo_common_metadata`, `multiple_crate_versions`, `needless_borrows_for_generic_args`, `too_many_lines`), which were dropped in an earlier reformat of the table.
- Each rationale was independently re-verified against the current dependency tree and MSRV rather than copied verbatim from the earlier comments, since those predate later dependency changes. One claim (`cargo_common_metadata`: "not published to crates.io") turned out to be stale/incorrect and was corrected to reflect that metadata is already complete on all crates; the `multiple_crate_versions` rationale was reworded to avoid over-attributing duplicate versions solely to `rmcp`.
- Comment-only change: no `level`/`priority` values were modified, no behavior change.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1292/1292 passed)
- [x] `cargo test --doc --all-features --workspace` (42/42 passed)

Closes #439