### PR TITLE
fix(core): reject env var names outside POSIX/Windows identifier charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-core`**: `validate_env_name` now rejects any environment variable name that
+  does not match the conventional POSIX/Windows identifier charset `[A-Za-z_][A-Za-z0-9_]*`,
+  before the forbidden-name comparison runs. The prior ASCII-case-insensitive comparison (#428)
+  only folds ASCII letters, but Windows' own environment-name comparison folds case using the
+  OS's Unicode uppercase table, which is broader — e.g. `ı` (U+0131, Turkish dotless i)
+  uppercases to `I` and `ſ` (U+017F, long s) uppercases to `S` on Windows. A forbidden name
+  spelled with one of these in place of the ASCII letter (e.g. `NODE_OPTıONS`) previously passed
+  the ASCII-only comparison in this validator, yet would still resolve as the forbidden name once
+  handed to the OS environment block on a real Windows host. Closing this via an input-charset
+  invariant avoids having to chase every such Unicode case-confusable individually (#438). As a
+  behavior change, this now rejects outright any environment variable name that was never a
+  valid identifier to begin with — including legitimate-looking names that fall outside
+  `[A-Za-z_][A-Za-z0-9_]*`, such as Windows' `ProgramFiles(x86)` or a bash `BASH_FUNC_x%%`
+  function-export name. This is acceptable pre-1.0.0 per this project's compatibility policy.
 - **`mcp-execution-core`**: `validate_env_name` now compares environment variable names against
   `FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` (`DYLD_`) with an ASCII-case-insensitive match
   instead of an exact byte comparison. Windows treats environment variable names as

--- a/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
+++ b/crates/mcp-codegen/templates/progressive/runtime-bridge.ts.hbs
@@ -211,12 +211,21 @@ function validateCommandString(value: unknown, context: string): void {
 /**
  * Validates an environment variable name against the forbidden list.
  *
- * Mirrors `validate_env_name` in `mcp-execution-core`'s `command.rs`, including its
- * case-insensitive comparison: Windows treats environment variable names as case-insensitive
- * at the OS/`CreateProcess` level, so a case-varied spelling such as `Path` or `path` must be
- * rejected exactly like the canonical `PATH`. `FORBIDDEN_ENV_NAMES`/`FORBIDDEN_ENV_PREFIX` are
- * rendered from the Rust source already upper-cased, so upper-casing `name` before comparing
- * is sufficient.
+ * Mirrors the case-insensitive forbidden-name/prefix comparison in `validate_env_name`
+ * (`mcp-execution-core`'s `command.rs`): Windows treats environment variable names as
+ * case-insensitive at the OS/`CreateProcess` level, so a case-varied spelling such as `Path`
+ * or `path` must be rejected exactly like the canonical `PATH`. `FORBIDDEN_ENV_NAMES`/
+ * `FORBIDDEN_ENV_PREFIX` are rendered from the Rust source already upper-cased, so upper-casing
+ * `name` before comparing is sufficient.
+ *
+ * As of `mcp-execution-core` #438, the Rust validator is strictly stricter than this function:
+ * it additionally rejects any name outside the `[A-Za-z_][A-Za-z0-9_]*` charset outright, which
+ * closes a Unicode-case-confusable bypass (e.g. `ı` U+0131, `ſ` U+017F) that ASCII-only case
+ * folding cannot catch. This function has no equivalent explicit charset check — whatever
+ * coverage it has against such names is incidental to `String.prototype.toUpperCase()`'s own
+ * Unicode-aware case mapping, not a deliberate guarantee, and a name JavaScript's mapping does
+ * not fold onto a forbidden entry will pass through unrejected here even though the Rust side
+ * now rejects it.
  *
  * @param name - The environment variable name to validate
  * @throws {Error} If the name is forbidden (exact match or `DYLD_*` prefix, case-insensitive)

--- a/crates/mcp-core/src/command.rs
+++ b/crates/mcp-core/src/command.rs
@@ -270,6 +270,10 @@ pub const fn forbidden_env_prefix() -> &'static str {
 /// # Security Rules
 ///
 /// - **Forbidden chars in command/args**: `;`, `|`, `&`, `>`, `<`, `` ` ``, `$`, `(`, `)`, `\n`, `\r`
+/// - **Env name charset**: must match `[A-Za-z_][A-Za-z0-9_]*` (POSIX/Windows environment
+///   variable identifier convention); rejects non-ASCII Unicode confusables (e.g. U+0131 `ı`,
+///   U+017F `ſ`) that could otherwise dodge the ASCII-only case-insensitive comparison below
+///   while still resolving as the forbidden name on Windows
 /// - **Forbidden env names**: dynamic-linker (`LD_PRELOAD`, `LD_LIBRARY_PATH`,
 ///   `LD_AUDIT`, `DYLD_*`), `PATH`, and interpreter hijack vectors
 ///   (`NODE_OPTIONS`, `BASH_ENV`, `PYTHONPATH`, `PYTHONSTARTUP`, `RUBYOPT`,
@@ -295,7 +299,7 @@ pub const fn forbidden_env_prefix() -> &'static str {
 /// - Command is empty or whitespace
 /// - Command/args contain shell metacharacters
 /// - Absolute path does not exist or is not executable
-/// - Environment variable name is forbidden
+/// - Environment variable name is forbidden, or outside the `[A-Za-z_][A-Za-z0-9_]*` charset
 /// - URL scheme is not `http://`/`https://`, or a header name/value contains control characters
 ///
 /// Returns `Error::ValidationError` if:
@@ -807,7 +811,32 @@ fn validate_absolute_path(command: &str) -> Result<()> {
 /// case-insensitive at the OS/`CreateProcess` level (and so does std's `Command` environment
 /// block on that platform), so a case-varied spelling such as `Path` or `path` would otherwise
 /// bypass this list while still functioning as a real override when the subprocess is spawned.
+///
+/// Before that comparison, the name is required to match the conventional POSIX/Windows
+/// environment-variable-name charset `[A-Za-z_][A-Za-z0-9_]*`. Windows' own name comparison
+/// folds case using the OS's Unicode uppercase table, which is broader than the ASCII-only
+/// folding `eq_ignore_ascii_case` performs here — e.g. `ı` (U+0131, Turkish dotless i)
+/// uppercases to `I` and `ſ` (U+017F, long s) uppercases to `S` on Windows, so a forbidden name
+/// spelled with one of these in place of the ASCII letter (e.g. `NODE_OPTıONS`) would pass the
+/// ASCII-only comparison yet still resolve as the forbidden name once handed to the OS
+/// environment block. Rather than chase every such Unicode confusable, any name outside the
+/// conventional identifier charset is rejected outright, since it is not a valid environment
+/// variable name to begin with.
 fn validate_env_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    let is_valid_charset = chars
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if !is_valid_charset {
+        return Err(Error::SecurityViolation {
+            reason: format!(
+                "environment variable name is not a valid identifier (expected \
+                 [A-Za-z_][A-Za-z0-9_]*): {name}"
+            ),
+        });
+    }
+
     // Check for forbidden env names (exact match, case-insensitive)
     if FORBIDDEN_ENV_NAMES
         .iter()
@@ -1308,12 +1337,41 @@ mod tests {
     fn test_validate_env_name_prefix_check_does_not_panic_on_utf8_boundary() {
         // "DYL€_REST": the euro sign ('\u{20AC}') is a 3-byte UTF-8 sequence occupying byte
         // indices 3..6, so byte index `FORBIDDEN_ENV_PREFIX.len()` (5) falls strictly inside
-        // it and is not a char boundary. A naive `name[..5]` slice would panic here; the
-        // byte-slice `eq_ignore_ascii_case` comparison in `validate_env_name` must not.
+        // it and is not a char boundary. A naive `name[..5]` slice would panic here. The
+        // charset check now rejects this name (non-ASCII characters are never valid identifier
+        // characters) before the byte-slice `eq_ignore_ascii_case` prefix comparison even runs,
+        // but that comparison must still not panic if reached directly.
         let name = "DYL\u{20AC}_REST";
         assert_eq!(name.len(), 3 + 3 + 5);
         assert!(!name.is_char_boundary(5));
-        assert!(validate_env_name(name).is_ok());
+        assert!(validate_env_name(name).is_err());
+    }
+
+    /// #438 — Windows' own environment-name comparison folds case using the OS's Unicode
+    /// uppercase table, which is broader than `eq_ignore_ascii_case`. A forbidden name spelled
+    /// with a Unicode confusable in place of an ASCII letter must be rejected outright by the
+    /// charset check, since it is not a valid `[A-Za-z_][A-Za-z0-9_]*` identifier to begin with.
+    #[test]
+    fn test_validate_env_name_rejects_unicode_case_confusables() {
+        // U+0131 LATIN SMALL LETTER DOTLESS I uppercases to 'I' on Windows.
+        assert!(validate_env_name("NODE_OPT\u{0131}ONS").is_err());
+        // U+017F LATIN SMALL LETTER LONG S uppercases to 'S' on Windows.
+        assert!(validate_env_name("JAVA_TOOL_OPTION\u{017F}").is_err());
+    }
+
+    #[test]
+    fn test_validate_env_name_charset_accepts_valid_ascii_identifiers() {
+        assert!(validate_env_name("MY_VAR_1").is_ok());
+        assert!(validate_env_name("_LEADING_UNDERSCORE").is_ok());
+        assert!(validate_env_name("A").is_ok());
+        assert!(validate_env_name("a1").is_ok());
+    }
+
+    #[test]
+    fn test_validate_env_name_charset_rejects_empty_and_leading_digit() {
+        assert!(validate_env_name("").is_err());
+        assert!(validate_env_name("1FOO").is_err());
+        assert!(validate_env_name("9").is_err());
     }
 
     #[test]

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -279,12 +279,22 @@ regardless of transport, before transport-specific checks):
    - `Stdio` → `validate_command_string` (forbidden shell metachars:
      `; | & > < \` $ ( ) \n \r`) on `command` and each `arg`; absolute-path
      commands additionally require existence + executable bit (Unix); env
-     names checked against `forbidden_env_names()`/`forbidden_env_prefix()`,
-     ASCII-case-insensitively (so `Path`/`path`/`PATH` are all rejected) —
-     Windows treats environment variable names as case-insensitive at the
-     OS/`CreateProcess` level, so a case-varied spelling would otherwise
-     bypass this list while still functioning as a real override at spawn
-     time.
+     names are first required to match the POSIX/Windows identifier charset
+     `^[A-Za-z_][A-Za-z0-9_]*$` (rejects empty names, names starting with a
+     digit, and any non-ASCII character), then checked against
+     `forbidden_env_names()`/`forbidden_env_prefix()`, ASCII-case-insensitively
+     (so `Path`/`path`/`PATH` are all rejected) — Windows treats environment
+     variable names as case-insensitive at the OS/`CreateProcess` level, so a
+     case-varied spelling would otherwise bypass this list while still
+     functioning as a real override at spawn time. The charset check runs
+     first because Windows' own case folding uses the OS's Unicode uppercase
+     table, which is broader than ASCII-only folding (e.g. `ı` U+0131 folds to
+     `I`, `ſ` U+017F folds to `S`); a forbidden name spelled with such a
+     confusable in place of an ASCII letter would otherwise pass the
+     ASCII-only comparison here yet still resolve as the forbidden name on a
+     real Windows host, so it is rejected outright as not being a valid
+     identifier to begin with, rather than chasing individual Unicode
+     confusables.
    - `Http`/`Sse` → `validate_network_config`: `url` required,
      `validate_url_scheme` (must be `http://`/`https://`, case-insensitive),
      header name (RFC 7230 `tchar` charset) and value (no control chars)
@@ -293,6 +303,13 @@ regardless of transport, before transport-specific checks):
    `> 0` and `<= MAX_TIMEOUT` (10 minutes); **no infinite-timeout option is
    supported by design** (an unbounded wait would let a hung server block
    this non-interactive tool forever).
+
+Env name charset (checked before the forbidden-name list below): must match
+`^[A-Za-z_][A-Za-z0-9_]*$`. A name outside this charset — including one built
+from a non-ASCII Unicode case-confusable of a forbidden name, e.g. `NODE_OPTıONS`
+using `ı` (U+0131) in place of `I` — is rejected as `Error::SecurityViolation`
+even though it is not an exact (case-insensitive ASCII) match against the list
+itself.
 
 Forbidden env names (exact match, case-insensitive): `LD_PRELOAD`,
 `LD_LIBRARY_PATH`, `LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`,


### PR DESCRIPTION
## Summary

- `validate_env_name` (`crates/mcp-core/src/command.rs`) now rejects any environment variable name that does not match the POSIX/Windows identifier charset `[A-Za-z_][A-Za-z0-9_]*`, before the forbidden-name comparison runs.
- This closes a narrower Unicode-confusable variant of the case-sensitivity bypass fixed in #437: the prior ASCII-only `eq_ignore_ascii_case` comparison did not catch names built from non-ASCII characters (e.g. `ı` U+0131, `ſ` U+017F) that Windows' own Unicode-aware case folding treats as equivalent to ASCII letters.
- `specs/core/spec.md` updated to document the new validation order and charset invariant.
- The generated TypeScript runtime bridge's `validateEnvName` doc comment corrected — it no longer claims to fully mirror the Rust validator, since the Rust side is now strictly stricter. No TS logic change: independent adversarial review confirmed the bridge's `toUpperCase()`-based comparison already incidentally catches both confusables named in the issue.
- `CHANGELOG.md` updated under `[Unreleased]` with the user-visible breaking consequence (e.g. Windows' `ProgramFiles(x86)` or a bash `BASH_FUNC_x%%` export name would now be rejected outright), acceptable pre-1.0.0.

Closes #438

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1311/1311 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests: Unicode confusables (`NODE_OPTıONS`, `JAVA_TOOL_OPTIONſ`) rejected; valid ASCII identifiers still accepted; empty/digit-leading names rejected; existing #428 case-insensitivity tests unchanged