### PR TITLE
refactor(skill): split output-path semantics from generate_skill's display hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compile error, so `classify_core_error` itself is unchanged. Mirrors the identical
   dead-predicate-removal precedent for `is_connection_error`'s siblings (#199) and
   `mcp_files::FilesError`'s equivalents (#202) (#427).
+- **`mcp-execution-skill`**: `GenerateSkillResult::output_path` is renamed to
+  `default_output_path_hint`. Three distinct concepts previously shared the `output_path`
+  identifier across the `generate_skill`/`save_skill` tool pair: `GenerateSkillResult`'s field
+  (a display-only, `~`-expanded hint with no filesystem meaning), `SaveSkillParams::output_path`
+  (a must-be-relative, confinement-checked path fragment), and `SaveSkillResult::output_path`
+  (the actual resolved, written-to path) — since `generate_skill` and `save_skill` are meant to
+  be chained, a caller could plausibly copy the first verbatim into the second, not realizing
+  the two have unrelated resolution semantics. `SaveSkillParams`/`SaveSkillResult` keep
+  `output_path`, since those two do share real filesystem-path semantics. Source-breaking for
+  any downstream consumer constructing or reading `GenerateSkillResult::output_path` directly.
+  This is also a JSON wire-format break, not just a Rust source-level one: the `generate_skill`
+  MCP tool serializes `GenerateSkillResult` directly as its response, so the `output_path` key
+  disappears from that JSON response (renamed to `default_output_path_hint`), and the tool's
+  declared `JsonSchema` output changes to match — any MCP client parsing the response by field
+  name is affected, not only Rust callers linking against this crate (#436).
 
 ### Fixed
 
@@ -397,6 +412,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or not) with a dedicated `OutputPathError::TildeComponent` error, surfaced the same way as the
   existing `AbsolutePath`/`ParentTraversal` rejections. Doc comments on both `output_path` fields
   now cross-reference their incompatible semantics (#434).
+- **`mcp-execution-cli`**: `prepare_skill_context` no longer writes the `skill` command's
+  resolved write path back into `GenerateSkillResult::default_output_path_hint`. That field is
+  a non-authoritative display hint `build_skill_context` computes and documents as "never
+  resolved or written to" — overwriting it here reproduced the exact field-reuse-across-semantics
+  pattern #436 eliminated from the MCP `generate_skill`/`save_skill` tool pair. `prepare_skill_context`
+  now returns `(GenerateSkillResult, PathBuf)`, with the resolved path returned separately
+  instead of round-tripped through the DTO (#436).
+
+### Documentation
+
+- **`mcp-execution-skill`**: added `# Examples` doc-test sections to `GenerateSkillResult`,
+  `SkillCategory`, `SkillTool`, `ToolExample`, `SaveSkillResult`, and `SkillMetadata` (#440).
+- **`mcp-execution-server`**: added `# Examples` doc-test sections to `IntrospectServerResult`,
+  `IntrospectedToolSummary`, `SaveCategorizedToolsResult`, `ToolGenerationError`,
+  `ListGeneratedServersParams`, `ListGeneratedServersResult`, `GeneratedServerInfo`, and
+  `PendingGeneration` (#440).
 
 ### Testing
 

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -121,7 +121,7 @@ pub async fn run(
 
     let scan_result = scan_server_tools(&tool_dir, &server).await?;
 
-    let context = prepare_skill_context(
+    let (context, output_path) = prepare_skill_context(
         &server,
         &scan_result.tools,
         hints,
@@ -130,7 +130,6 @@ pub async fn run(
     )?;
 
     // Check if output file exists and overwrite flag
-    let output_path = PathBuf::from(&context.output_path);
     if output_path.exists() && !overwrite {
         bail!(
             "Output file already exists: {}\n\
@@ -224,7 +223,14 @@ async fn scan_server_tools(tool_dir: &Path, server: &str) -> Result<ScanResult> 
     Ok(scan_result)
 }
 
-/// Builds the skill generation context, applying custom skill name and output path overrides.
+/// Builds the skill generation context and resolves the actual path SKILL.md will be written
+/// to, applying custom skill name and output path overrides.
+///
+/// The resolved write path is returned separately from `GenerateSkillResult` rather than
+/// written back into its `default_output_path_hint` field: that field is a non-authoritative
+/// display hint `build_skill_context` computes (see its doc comment), not a slot for this
+/// command's actual write target — overwriting it here would resurrect the same
+/// field-reuse-across-semantics pattern issue #436 eliminated from the MCP tool pair.
 ///
 /// # Errors
 ///
@@ -236,7 +242,7 @@ fn prepare_skill_context(
     hints: Vec<String>,
     skill_name: Option<&str>,
     output_path: Option<PathBuf>,
-) -> Result<GenerateSkillResult> {
+) -> Result<(GenerateSkillResult, PathBuf)> {
     // Step 6: Build skill context. Custom skill name is validated up front (same pattern as
     // `validate_server_id` above) and passed into `build_skill_context` itself — not applied as
     // a post-hoc override — so an oversized name fails fast here instead of being rendered and
@@ -250,21 +256,20 @@ fn prepare_skill_context(
             .map_err(|e| CoreError::InvalidArgument(format!("Invalid skill name: {e}")))?;
     }
 
-    let mut context = build_skill_context(server, tools, hints_ref.as_deref(), skill_name);
+    let context = build_skill_context(server, tools, hints_ref.as_deref(), skill_name);
 
-    // Apply custom output path if provided
-    if let Some(path) = output_path {
+    // Resolve the actual output path, independent of `context.default_output_path_hint`.
+    let resolved_output_path = if let Some(path) = output_path {
         // Validate output path for path traversal
         validate_output_path(&path)?;
-        context.output_path = path.display().to_string();
+        path
     } else {
         // Use default skills directory
         let skills_dir = resolve_skills_dir()?;
-        let default_output = skills_dir.join(server).join("SKILL.md");
-        context.output_path = default_output.display().to_string();
-    }
+        skills_dir.join(server).join("SKILL.md")
+    };
 
-    Ok(context)
+    Ok((context, resolved_output_path))
 }
 
 /// Writes `rendered` SKILL.md content to `output_path` atomically (write-temp then rename).
@@ -815,6 +820,50 @@ mod tests {
         assert!(
             written.contains("name: github-advanced"),
             "written SKILL.md must use the custom skill name: {written}"
+        );
+    }
+
+    /// Issue #436: a custom `--skill-name` must be threaded into `build_skill_context` as a
+    /// constructor input, not patched onto the result afterward — so `generation_prompt`
+    /// reflects the requested name instead of the stale `{server}-progressive` default.
+    /// `test_run_with_custom_skill_name` above only inspects the rendered `SKILL.md` file (which
+    /// goes through `render_skill_md`, not `generation_prompt`); this test inspects
+    /// `prepare_skill_context`'s returned `generation_prompt` directly.
+    #[test]
+    fn test_prepare_skill_context_with_custom_skill_name_reflects_it_in_generation_prompt() {
+        let tools = vec![];
+
+        let (context, _output_path) =
+            prepare_skill_context("github", &tools, vec![], Some("github-advanced"), None).unwrap();
+
+        assert_eq!(context.skill_name, "github-advanced");
+        assert!(
+            context.generation_prompt.contains("github-advanced"),
+            "generation_prompt must reflect the custom skill_name, not the default: {}",
+            context.generation_prompt
+        );
+        assert!(!context.generation_prompt.contains("github-progressive"));
+    }
+
+    /// Issue #436 (S1 follow-up): `prepare_skill_context`'s resolved output path must never be
+    /// written back into `default_output_path_hint` — that field is a non-authoritative display
+    /// hint, not this command's actual write target. Confirms the hint keeps its
+    /// `build_skill_context`-computed default shape even when a custom `output_path` is
+    /// supplied, and that the actual resolved path is returned separately.
+    #[test]
+    fn test_prepare_skill_context_does_not_overwrite_default_output_path_hint() {
+        let tools = vec![];
+        let custom_output = PathBuf::from("/tmp/custom/SKILL.md");
+
+        let (context, resolved_output_path) =
+            prepare_skill_context("github", &tools, vec![], None, Some(custom_output.clone()))
+                .unwrap();
+
+        assert_eq!(resolved_output_path, custom_output);
+        assert_eq!(
+            context.default_output_path_hint, "~/.claude/skills/github/SKILL.md",
+            "default_output_path_hint must stay build_skill_context's own default, not be \
+             overwritten with the resolved write path"
         );
     }
 

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -883,10 +883,10 @@ impl GeneratorService {
     /// 3. Claude generates SKILL.md content
     /// 4. Call `save_skill` with the generated content
     ///
-    /// The result's `output_path` field is informational/display-only (the default location the
-    /// file *would* land at) and must not be passed as `save_skill`'s own `output_path`
-    /// parameter — despite the shared field name, the two have incompatible semantics; omit
-    /// `save_skill`'s `output_path` to use its default (issue #434).
+    /// The result's `default_output_path_hint` field is informational/display-only (the default
+    /// location the file *would* land at) and must not be passed as `save_skill`'s own
+    /// `output_path` parameter — despite the similar name, the two have incompatible semantics;
+    /// omit `save_skill`'s `output_path` to use its default (issues #434, #436).
     #[tool(
         description = "Analyze generated TypeScript files and return context for Claude to create a SKILL.md file. Returns tool metadata, categories, and a generation prompt."
     )]

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -105,6 +105,29 @@ pub struct IntrospectServerParams {
 ///
 /// Contains tool metadata for Claude to categorize and a session ID
 /// for use with `save_categorized_tools`.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::{IntrospectServerResult, IntrospectedToolSummary};
+/// use chrono::Utc;
+/// use uuid::Uuid;
+///
+/// let result = IntrospectServerResult {
+///     server_id: "github".to_string(),
+///     server_name: "GitHub MCP Server".to_string(),
+///     tools_found: 1,
+///     tools: vec![IntrospectedToolSummary {
+///         name: "create_issue".to_string(),
+///         description: "Create a new issue".to_string(),
+///         parameters: vec!["title".to_string(), "body".to_string()],
+///     }],
+///     session_id: Uuid::new_v4(),
+///     expires_at: Utc::now(),
+/// };
+///
+/// assert_eq!(result.tools_found, 1);
+/// ```
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct IntrospectServerResult {
     /// Server identifier
@@ -130,6 +153,20 @@ pub struct IntrospectServerResult {
 ///
 /// Includes the tool name, description, and parameter names to help
 /// Claude understand the tool's purpose and assign appropriate categories.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::IntrospectedToolSummary;
+///
+/// let summary = IntrospectedToolSummary {
+///     name: "create_issue".to_string(),
+///     description: "Create a new issue".to_string(),
+///     parameters: vec!["title".to_string(), "body".to_string()],
+/// };
+///
+/// assert_eq!(summary.parameters.len(), 2);
+/// ```
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct IntrospectedToolSummary {
     /// Original tool name
@@ -230,6 +267,23 @@ pub struct CategorizedTool {
 ///
 /// Reports success status, number of files generated, and any errors
 /// that occurred during generation.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::SaveCategorizedToolsResult;
+/// use std::collections::HashMap;
+///
+/// let result = SaveCategorizedToolsResult {
+///     success: true,
+///     files_generated: 3,
+///     output_dir: "~/.claude/servers/github".to_string(),
+///     categories: HashMap::from([("issues".to_string(), 3)]),
+///     errors: vec![],
+/// };
+///
+/// assert!(result.success);
+/// ```
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct SaveCategorizedToolsResult {
     /// Whether generation succeeded
@@ -250,6 +304,19 @@ pub struct SaveCategorizedToolsResult {
 }
 
 /// Error that occurred while generating a specific tool.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::ToolGenerationError;
+///
+/// let error = ToolGenerationError {
+///     tool_name: "create_issue".to_string(),
+///     error: "invalid parameter schema".to_string(),
+/// };
+///
+/// assert_eq!(error.tool_name, "create_issue");
+/// ```
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ToolGenerationError {
     /// Name of the tool that failed
@@ -264,6 +331,14 @@ pub struct ToolGenerationError {
 // ============================================================================
 
 /// Parameters for listing generated servers.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::ListGeneratedServersParams;
+///
+/// let params = ListGeneratedServersParams { base_dir: None };
+/// ```
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct ListGeneratedServersParams {
     /// Base directory to scan, relative to `~/.claude/servers`
@@ -274,6 +349,24 @@ pub struct ListGeneratedServersParams {
 }
 
 /// Result from listing generated servers.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::{ListGeneratedServersResult, GeneratedServerInfo};
+///
+/// let result = ListGeneratedServersResult {
+///     servers: vec![GeneratedServerInfo {
+///         id: "github".to_string(),
+///         tool_count: 12,
+///         generated_at: None,
+///         output_dir: "~/.claude/servers/github".to_string(),
+///     }],
+///     total_servers: 1,
+/// };
+///
+/// assert_eq!(result.total_servers, 1);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ListGeneratedServersResult {
     /// List of servers with generated files
@@ -284,6 +377,21 @@ pub struct ListGeneratedServersResult {
 }
 
 /// Information about a server with generated progressive loading files.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::GeneratedServerInfo;
+///
+/// let info = GeneratedServerInfo {
+///     id: "github".to_string(),
+///     tool_count: 12,
+///     generated_at: None,
+///     output_dir: "~/.claude/servers/github".to_string(),
+/// };
+///
+/// assert_eq!(info.id, "github");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct GeneratedServerInfo {
     /// Server identifier
@@ -307,6 +415,27 @@ pub struct GeneratedServerInfo {
 ///
 /// Stores introspection data between `introspect_server` and
 /// `save_categorized_tools` calls.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::types::PendingGeneration;
+/// use mcp_execution_server::clock::SystemClock;
+/// use mcp_execution_core::{ServerId, ServerConfig};
+/// use mcp_execution_introspector::ServerInfo;
+///
+/// # fn example(server_info: ServerInfo) {
+/// let pending = PendingGeneration::new(
+///     ServerId::new("github").unwrap(),
+///     server_info,
+///     ServerConfig::builder().command("npx".to_string()).build().unwrap(),
+///     None,
+///     &SystemClock,
+/// );
+///
+/// assert_eq!(pending.server_id.as_str(), "github");
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct PendingGeneration {
     /// Server identifier

--- a/crates/mcp-skill/README.md
+++ b/crates/mcp-skill/README.md
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tools = scan_tools_directory(Path::new("~/.claude/servers/github")).await?;
 
     // Build skill generation context
-    let context = build_skill_context("github", &tools, None);
+    let context = build_skill_context("github", &tools, None, None);
 
     // Use context.generation_prompt with LLM to generate SKILL.md
     println!("Skill: {}", context.skill_name);
@@ -95,8 +95,8 @@ assert_eq!(parsed.category, Some("issues".to_string()));
 use mcp_execution_skill::build_skill_context;
 
 // Add use-case hints for better context
-let hints = vec!["managing pull requests", "code review"];
-let context = build_skill_context("github", &tools, Some(&hints));
+let hints = vec!["managing pull requests".to_string(), "code review".to_string()];
+let context = build_skill_context("github", &tools, Some(&hints), None);
 
 println!("Categories: {:?}", context.categories.len());
 ```

--- a/crates/mcp-skill/src/context.rs
+++ b/crates/mcp-skill/src/context.rs
@@ -75,8 +75,9 @@ pub fn build_skill_context(
         MAX_UNTRUSTED_FIELD_LEN,
     );
 
-    // Build output path
-    let output_path = format!("~/.claude/skills/{server_id}/SKILL.md");
+    // Build default output path hint (display-only; see
+    // `GenerateSkillResult::default_output_path_hint`)
+    let default_output_path_hint = format!("~/.claude/skills/{server_id}/SKILL.md");
 
     // Render generation prompt
     let generation_prompt = build_generation_prompt(
@@ -95,7 +96,7 @@ pub fn build_skill_context(
         tool_count,
         example_tools,
         generation_prompt,
-        output_path,
+        default_output_path_hint,
         // Populated by the caller from `ScanResult::warnings`; `build_skill_context`
         // only sees already-scanned `tools`, not the drift detected while scanning.
         warnings: Vec::new(),

--- a/crates/mcp-skill/src/template.rs
+++ b/crates/mcp-skill/src/template.rs
@@ -280,7 +280,7 @@ mod tests {
                 params_json: "{}".to_string(),
             }],
             generation_prompt: "Pre-built prompt".to_string(),
-            output_path: "~/.claude/skills/test/SKILL.md".to_string(),
+            default_output_path_hint: "~/.claude/skills/test/SKILL.md".to_string(),
             warnings: vec![],
         }
     }

--- a/crates/mcp-skill/src/types.rs
+++ b/crates/mcp-skill/src/types.rs
@@ -93,6 +93,26 @@ pub struct GenerateSkillParams {
 /// Result from `generate_skill` tool.
 ///
 /// Contains all context Claude needs to generate optimal SKILL.md content.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_skill::types::GenerateSkillResult;
+///
+/// let result = GenerateSkillResult {
+///     server_id: "github".to_string(),
+///     skill_name: "github-progressive".to_string(),
+///     server_description: Some("MCP server for issue operations".to_string()),
+///     categories: vec![],
+///     tool_count: 0,
+///     example_tools: vec![],
+///     generation_prompt: "Generate a SKILL.md for github...".to_string(),
+///     default_output_path_hint: "~/.claude/skills/github/SKILL.md".to_string(),
+///     warnings: vec![],
+/// };
+///
+/// assert_eq!(result.server_id, "github");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct GenerateSkillResult {
     /// Server identifier.
@@ -122,12 +142,15 @@ pub struct GenerateSkillResult {
     ///
     /// Shaped like `~/.claude/skills/{server_id}/SKILL.md` (with a literal, unexpanded `~`) —
     /// this shows where the file will land under its *default* location, but is never validated
-    /// as a real filesystem path. **Do not** pass this value as `save_skill`'s `output_path`
-    /// parameter: despite sharing the same field name, that parameter has entirely different
-    /// semantics (a bare relative path with no `~`, resolved under `base_dir/{server_id}` — see
-    /// [`SaveSkillParams::output_path`]) and will reject a `~`-containing value (issue #434).
-    /// Omit `save_skill`'s `output_path` entirely to use its own default.
-    pub output_path: String,
+    /// as a real filesystem path, and — unlike `SaveSkillParams`/`SaveSkillResult`, which share
+    /// real filesystem-path semantics and so keep the `output_path` name — this field is named
+    /// `default_output_path_hint` specifically so it cannot be mistaken for one of those (issue
+    /// #436). **Do not** pass this value as `save_skill`'s `output_path` parameter: that
+    /// parameter has entirely different semantics (a bare relative path with no `~`, resolved
+    /// under `base_dir/{server_id}` — see [`SaveSkillParams::output_path`]) and will reject a
+    /// `~`-containing value (issue #434). Omit `save_skill`'s `output_path` entirely to use its
+    /// own default.
+    pub default_output_path_hint: String,
 
     /// Non-fatal drift warnings, e.g. `.ts` files on disk excluded from
     /// `categories`/`tool_count` because `_meta.json` has no matching entry
@@ -137,6 +160,20 @@ pub struct GenerateSkillResult {
 }
 
 /// A category of tools for the skill.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_skill::types::SkillCategory;
+///
+/// let category = SkillCategory {
+///     name: "issues".to_string(),
+///     display_name: "Issues".to_string(),
+///     tools: vec![],
+/// };
+///
+/// assert_eq!(category.display_name, "Issues");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SkillCategory {
     /// Category name (e.g., "issues", "repositories").
@@ -150,6 +187,23 @@ pub struct SkillCategory {
 }
 
 /// Tool information for skill generation.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_skill::types::SkillTool;
+///
+/// let tool = SkillTool {
+///     name: "create_issue".to_string(),
+///     typescript_name: "createIssue".to_string(),
+///     description: "Create a new issue".to_string(),
+///     keywords: vec!["create".to_string(), "issue".to_string()],
+///     required_params: vec!["title".to_string()],
+///     optional_params: vec!["body".to_string()],
+/// };
+///
+/// assert_eq!(tool.name, "create_issue");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SkillTool {
     /// Original tool name.
@@ -172,6 +226,22 @@ pub struct SkillTool {
 }
 
 /// Example tool usage for documentation.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_skill::types::ToolExample;
+///
+/// let example = ToolExample {
+///     tool_name: "create_issue".to_string(),
+///     description: "Create a new issue".to_string(),
+///     cli_command: "node ~/.claude/servers/github/createIssue.ts '{\"title\":\"example\"}'"
+///         .to_string(),
+///     params_json: "{\"title\": \"example\"}".to_string(),
+/// };
+///
+/// assert_eq!(example.tool_name, "create_issue");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ToolExample {
     /// Tool name.
@@ -233,9 +303,9 @@ pub struct SaveSkillParams {
     /// path** with no leading path separator, no `..` component, and no literal `~` component —
     /// it is resolved relative to `base_dir/{server_id}`, not the caller's home directory, so a
     /// `~` here is just a directory name, not a home-directory shortcut. In particular, do
-    /// **not** pass [`GenerateSkillResult::output_path`] (a display-only string of the shape
-    /// `~/.claude/skills/{server_id}/SKILL.md`) here — it is rejected (issue #434). See
-    /// [`crate::resolve_skill_output_path`] for the full resolution/confinement contract.
+    /// **not** pass [`GenerateSkillResult::default_output_path_hint`] (a display-only string of
+    /// the shape `~/.claude/skills/{server_id}/SKILL.md`) here — it is rejected (issue #434).
+    /// See [`crate::resolve_skill_output_path`] for the full resolution/confinement contract.
     pub output_path: Option<PathBuf>,
 
     /// Overwrite if exists.
@@ -244,6 +314,26 @@ pub struct SaveSkillParams {
 }
 
 /// Result from saving a skill.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_skill::types::{SaveSkillResult, SkillMetadata};
+///
+/// let result = SaveSkillResult {
+///     success: true,
+///     output_path: "/home/user/.claude/skills/github/SKILL.md".to_string(),
+///     overwritten: false,
+///     metadata: SkillMetadata {
+///         name: "github-progressive".to_string(),
+///         description: "GitHub MCP skill".to_string(),
+///         section_count: 5,
+///         word_count: 320,
+///     },
+/// };
+///
+/// assert!(result.success);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SaveSkillResult {
     /// Whether save was successful.
@@ -260,6 +350,21 @@ pub struct SaveSkillResult {
 }
 
 /// Metadata extracted from saved skill.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_skill::types::SkillMetadata;
+///
+/// let metadata = SkillMetadata {
+///     name: "github-progressive".to_string(),
+///     description: "GitHub MCP skill".to_string(),
+///     section_count: 5,
+///     word_count: 320,
+/// };
+///
+/// assert_eq!(metadata.name, "github-progressive");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SkillMetadata {
     /// Skill name from frontmatter.

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -433,14 +433,30 @@ string values.
 validates `server` via `mcp_execution_skill::validate_server_id`
 (mapped to `CoreError::InvalidArgument` for correct exit-code
 classification), resolves the tool directory (default
-`~/.claude/servers/{server}`), scans via `scan_tools_directory`, builds
-context via `build_skill_context`, and **renders `SKILL.md` directly**
-(`render_skill_md`) — no LLM/prompt round-trip, unlike `mcp-server`'s
-`generate_skill`/`save_skill` split. The crate's own doc comment recommends
-preferring the MCP server path for "optimal results," since it can leverage
-Claude's own summarization instead of the mechanical template-only
-rendering this command does. Refuses to overwrite an existing output file
-unless `--overwrite`.
+`~/.claude/servers/{server}`), scans via `scan_tools_directory`, then calls
+the private `prepare_skill_context(server, tools, hints, skill_name,
+output_path) -> Result<(GenerateSkillResult, PathBuf)>`, and **renders
+`SKILL.md` directly** (`render_skill_md`) — no LLM/prompt round-trip, unlike
+`mcp-server`'s `generate_skill`/`save_skill` split. The crate's own doc
+comment recommends preferring the MCP server path for "optimal results,"
+since it can leverage Claude's own summarization instead of the mechanical
+template-only rendering this command does. Refuses to overwrite an existing
+output file unless `--overwrite`.
+
+`prepare_skill_context` validates a custom `skill_name` (if any) via
+`validate_skill_name` up front, then passes it straight into
+`build_skill_context` as that function's own `custom_name: Option<&str>`
+parameter — not patched onto the result afterward — so `generation_prompt`
+reflects a custom name the same way `mcp-server`'s `generate_skill` handler
+does (issues #435, #436). It separately resolves the actual path `SKILL.md` will
+be written to (`output_path` if supplied and traversal-validated via
+`validate_output_path`, else `{skills_dir}/{server}/SKILL.md`) and returns
+it as a plain `PathBuf`, *not* by writing it into
+`GenerateSkillResult::default_output_path_hint` — that field is
+`build_skill_context`'s own non-authoritative display hint (see
+[[../skill/spec#2. Public API Surface]]), and overwriting it here would
+reintroduce the same field-reuse-across-semantics pattern issue #436
+eliminated from the MCP `generate_skill`/`save_skill` tool pair.
 
 ## 9. `server` Command (`commands/server.rs`)
 

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -80,7 +80,7 @@ pub const MAX_FRONTMATTER_SIZE: usize = 8 * 1024; // 8 KiB, extracted YAML block
 pub async fn scan_tools_directory(dir: &Path) -> Result<ScanResult, ScanError>;
 pub struct ScanResult { pub tools: Vec<ParsedToolFile>, pub warnings: Vec<String> }
 
-pub fn build_skill_context(server_id: &str, tools: &[ParsedToolFile], use_case_hints: Option<&[String]>) -> GenerateSkillResult;
+pub fn build_skill_context(server_id: &str, tools: &[ParsedToolFile], use_case_hints: Option<&[String]>, custom_name: Option<&str>) -> GenerateSkillResult;
 
 pub fn render_generation_prompt(context: &GenerateSkillResult) -> Result<String, TemplateError>;
 pub fn render_skill_md(context: &GenerateSkillResult) -> Result<String, TemplateError>;
@@ -153,14 +153,31 @@ without a category are grouped under `"uncategorized"`, sorted last.
 category, then fills remaining slots.
 
 `skill_name` itself — unlike `ParsedToolFile`'s fields, which all flow
-through `group_by_category` — is set directly by `build_skill_context`
-(`{server_id}-progressive`, always safe: composed from `server_id`, an
-already-validated `[a-z0-9-]+` slug) or overridden afterward by a caller
-(`mcp-cli`'s `--skill-name` flag, or `generate_skill`'s `skill_name` MCP
-tool argument). Both override sites call `validate_skill_name` before
-assigning (issue #413) but do not sanitize at assignment time; sanitization
-instead happens per render surface, at the two places `skill_name` actually
-gets spliced into rendered text — see §5 and §6 below (issue #410, #411).
+through `group_by_category` — is resolved as the very first step inside
+`build_skill_context`, from its own `custom_name: Option<&str>` parameter:
+the caller's override when `Some`, else the default
+`{server_id}-progressive`. Either way, the resolved name is immediately
+flattened with `sanitize_untrusted_text` (idempotent against
+`build_generation_prompt`'s own identical call below) so
+`GenerateSkillResult::skill_name` holds exactly the same
+control-character-flattened, length-truncated text as the prompt's
+`**Skill Name**` line — the two can never visibly disagree on control
+characters, invisible Unicode, or length truncation (issue #435, S1).
+Every derived field the function builds afterward — including
+`generation_prompt` — is built from this already-resolved, already-flattened
+name, so a custom name can never be reflected in `GenerateSkillResult::
+skill_name` while `generation_prompt` still embeds the stale default
+(issue #436; previously `build_skill_context` always computed the default
+internally and callers patched `result.skill_name` onto the already-built
+result afterward, which is exactly the bug #436 fixed — `generation_prompt`
+had already been built by that point). Both callers (`mcp-cli`'s
+`--skill-name` flag, `generate_skill`'s `skill_name` MCP tool argument) call
+`validate_skill_name` *before* calling `build_skill_context` (issue #413);
+`sanitize_untrusted_text` inside `build_skill_context` is a distinct,
+additional defense layered on top of that validation, not a substitute for
+it. The prompt's `**Skill Name**` line gets one further layer beyond the
+flattening applied to `GenerateSkillResult::skill_name` — see §5 below
+(issue #410, #411).
 
 ## 5. Prompt Injection Defense
 


### PR DESCRIPTION
## Summary

- Renames `GenerateSkillResult::output_path` to `default_output_path_hint`. Three distinct concepts previously shared the `output_path` identifier across the `generate_skill`/`save_skill` tool pair: a display-only, `~`-expanded hint with no filesystem meaning (`GenerateSkillResult`), a must-be-relative, confinement-checked path fragment (`SaveSkillParams`), and the actual resolved, written-to path (`SaveSkillResult`). Since `generate_skill` and `save_skill` are meant to be chained, this invited a caller to misuse the first value as an input to the second. `SaveSkillParams`/`SaveSkillResult` keep `output_path`, since those two do share real filesystem-path semantics. Complements #441's runtime tilde-rejection guard by closing the ambiguity by construction rather than replacing that guard.
- Fixes the same field-reuse pattern inside `mcp-cli`'s `prepare_skill_context`, which overwrote the display-only field with its actually-resolved write path. It now returns `(GenerateSkillResult, PathBuf)` instead.
- Adds missing `# Examples` doc-tests to 14 public DTOs across `mcp-skill` and `mcp-server` that had doc comments but no runnable example, closing a gap a prior documentation pass missed.

This branch was rebased onto `origin/master` mid-development after PR #441 merged and closed #435/#434 with an overlapping but distinct fix (constructor-injected `skill_name` threading, plus a tilde-rejection security guard). This PR adopts #441's implementation as-is and adds only the non-duplicate delta described above; the tilde-rejection security fix was verified intact post-rebase.

Closes #436, Closes #440

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1310 passed)
- [x] `cargo test --doc --all-features --workspace` (17 doctests in mcp-skill, including 14 new)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Confirmed `OutputPathError::TildeComponent` and its tests (#434) survived the rebase intact