### PR TITLE
fix(core): sanitize disallowed characters before they reach error text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,6 +493,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`tracing::info!(?notification, ...)`), which it does not and cannot suppress; that site is
   mitigated by `Debug`-escaping control characters, not eliminated, and fires under the server's
   default filter with no `RUST_LOG` at all (#421).
+- **`mcp-execution-core`**: `ServerId::new`/`ToolName::new` no longer echo a rejected input's raw
+  `&`/`<`/`>`/control/bidi-reordering characters into `ServerIdError`/`ToolNameError`. The stored
+  `id`/`name` field is now sanitized (`untrusted::sanitize_untrusted_inline`, capped at
+  `MAX_UNTRUSTED_FIELD_LEN`) and `&`/`<`/`>` entity-escaped before the error variant is
+  constructed, closing both the `Display` and `Debug` paths in one change. Previously an
+  attacker-controlled tool name or server id that failed validation could carry the raw offending
+  characters — including an unbounded length, since `ServerId::new` has no length cap of its own
+  — straight into LLM-facing error text or a `tracing`-logged error, letting a malicious MCP
+  server attempt to forge Markdown/HTML-like structure or a boundary delimiter such as
+  `wrap_untrusted_block`'s `</untrusted-data>`. The offending `code_point` reported alongside
+  `DisallowedCharacter` is unaffected — it is computed from the raw input before sanitization.
+  Same sanitization path applies uniformly to both the LLM- and human-facing surfaces: an
+  `mcp-execution-cli` user rejecting an id/name containing `&`/`<`/`>` now sees the entity-escaped
+  form in their terminal too (e.g. `invalid server id "my&amp;server"` rather than
+  `"my&server"`) — an accepted, intentional trade-off rather than a regression (#446).
 - **`mcp-execution-cli`**: `runner::init_logging` now applies the same `cap_rmcp_log_level`
   treatment to both the non-verbose (`RUST_LOG`-driven) and `--verbose` branches. The `--verbose`
   branch previously set a bare `EnvFilter::new("debug")` with no `RUST_LOG` involved at all —
@@ -576,6 +591,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`mcp-execution-cli`**: dropped clap's `env` and `cargo` features — neither an
   `#[arg(env = ...)]` attribute nor any `crate_version!`/`crate_name!`/`crate_authors!`/
   `crate_description!` macro is used anywhere in the crate (#414).
+- **`mcp-execution-core`**: removed `Error::is_duplicate_generated_file_path` — it had no
+  production call site anywhere in the workspace, only test call sites (its own doc-test and
+  unit test, plus `mcp-execution-codegen`'s `GeneratedCode::add_file` tests, which now match
+  `Error::DuplicateGeneratedFilePath` directly instead) (#445).
 
 ## [0.9.0] - 2026-07-27
 

--- a/crates/mcp-codegen/src/common/types.rs
+++ b/crates/mcp-codegen/src/common/types.rs
@@ -77,6 +77,7 @@ impl GeneratedCode {
     ///
     /// ```
     /// use mcp_execution_codegen::{GeneratedCode, GeneratedFile};
+    /// use mcp_execution_core::Error;
     ///
     /// let mut code = GeneratedCode::new();
     /// code.add_file(GeneratedFile {
@@ -93,7 +94,7 @@ impl GeneratedCode {
     ///         content: "export const x = 1;".to_string(),
     ///     })
     ///     .unwrap_err();
-    /// assert!(err.is_duplicate_generated_file_path());
+    /// assert!(matches!(err, Error::DuplicateGeneratedFilePath { .. }));
     /// ```
     pub fn add_file(&mut self, file: GeneratedFile) -> Result<()> {
         if self.files.iter().any(|existing| existing.path == file.path) {
@@ -323,7 +324,7 @@ mod tests {
             })
             .unwrap_err();
 
-        assert!(err.is_duplicate_generated_file_path());
+        assert!(matches!(err, Error::DuplicateGeneratedFilePath { .. }));
         // The original file must be left untouched, not silently overwritten.
         assert_eq!(code.file_count(), 1);
         assert_eq!(code.files[0].content, "first");

--- a/crates/mcp-core/src/error.rs
+++ b/crates/mcp-core/src/error.rs
@@ -288,23 +288,6 @@ impl Error {
     pub const fn is_resource_limit_exceeded(&self) -> bool {
         matches!(self, Self::ResourceLimitExceeded { .. })
     }
-
-    /// Returns `true` if this is a duplicate-generated-file-path error.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mcp_execution_core::Error;
-    ///
-    /// let err = Error::DuplicateGeneratedFilePath {
-    ///     path: "index.ts".to_string(),
-    /// };
-    /// assert!(err.is_duplicate_generated_file_path());
-    /// ```
-    #[must_use]
-    pub const fn is_duplicate_generated_file_path(&self) -> bool {
-        matches!(self, Self::DuplicateGeneratedFilePath { .. })
-    }
 }
 
 /// Result type alias for MCP operations.
@@ -405,11 +388,10 @@ mod tests {
     }
 
     #[test]
-    fn test_duplicate_generated_file_path_detection() {
+    fn test_duplicate_generated_file_path_display() {
         let err = Error::DuplicateGeneratedFilePath {
             path: "index.ts".to_string(),
         };
-        assert!(err.is_duplicate_generated_file_path());
         assert!(!err.is_resource_limit_exceeded());
         let display = format!("{err}");
         assert!(display.contains("index.ts"));

--- a/crates/mcp-core/src/types.rs
+++ b/crates/mcp-core/src/types.rs
@@ -21,11 +21,26 @@
 //! ```
 
 use crate::path::{first_disallowed_identifier_char, validate_path_segment};
+use crate::untrusted::sanitize_untrusted_inline;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
 /// Error returned when a candidate string fails the invariant [`ServerId::new`] enforces.
+///
+/// Every variant's `#[error(...)]` message formats its stored string field with `{:?}`
+/// (`Debug`), not `{}` (`Display`) — this is a required second layer of defense, not
+/// incidental formatting, and must not be "simplified" to `{}`. [`sanitize_untrusted_inline`]
+/// only neutralizes `&`/`<`/`>` plus the control/bidi-reordering characters
+/// `sanitize_untrusted_text` targets; it deliberately leaves other characters untouched (e.g.
+/// U+200C/U+200D, orthographically load-bearing in some scripts and emoji ZWJ sequences — see
+/// that function's doc comment), so the stored field can still carry a raw invisible or
+/// format character. `Debug`'s own escaping (`\u{200d}` rather than the literal character) is
+/// what keeps that residual case from smuggling an invisible payload into LLM-facing or
+/// terminal-rendered error text (issues #425/#430); switching to `Display` would silently
+/// reopen that channel for every field this crate stores unsanitized-but-quoted this way.
+///
+/// [`sanitize_untrusted_inline`]: crate::untrusted::sanitize_untrusted_inline
 ///
 /// # Examples
 ///
@@ -43,7 +58,11 @@ pub enum ServerIdError {
         "invalid server id {id:?}: must be a single non-empty path segment with no `..` or path separator"
     )]
     InvalidFormat {
-        /// The rejected input.
+        /// Sanitized form of the rejected input (see
+        /// [`sanitize_untrusted_inline`](crate::untrusted::sanitize_untrusted_inline)):
+        /// control characters, bidi-reordering characters, and other invisible/structural
+        /// characters are neutralized, and `&`/`<`/`>` are entity-escaped, since this value is
+        /// attacker-controlled and reaches LLM-facing error text.
         id: String,
     },
 
@@ -53,9 +72,14 @@ pub enum ServerIdError {
         "invalid server id {id:?}: disallowed character U+{code_point:04X} (identifiers accept only UTS #39 Identifier_Status=Allowed characters)"
     )]
     DisallowedCharacter {
-        /// The rejected input.
+        /// Sanitized form of the rejected input (see
+        /// [`sanitize_untrusted_inline`](crate::untrusted::sanitize_untrusted_inline)):
+        /// control characters, bidi-reordering characters, and other invisible/structural
+        /// characters are neutralized, and `&`/`<`/`>` are entity-escaped, since this value is
+        /// attacker-controlled and reaches LLM-facing error text.
         id: String,
-        /// Unicode scalar value of the first disallowed character found.
+        /// Unicode scalar value of the first disallowed character found, computed from the
+        /// raw (unsanitized) input.
         code_point: u32,
     },
 }
@@ -133,11 +157,13 @@ impl ServerId {
     pub fn new(id: impl Into<String>) -> Result<Self, ServerIdError> {
         let id = id.into();
         if validate_path_segment(&id).is_none() {
-            return Err(ServerIdError::InvalidFormat { id });
+            return Err(ServerIdError::InvalidFormat {
+                id: sanitize_untrusted_inline(&id),
+            });
         }
         if let Some(c) = first_disallowed_identifier_char(&id) {
             return Err(ServerIdError::DisallowedCharacter {
-                id,
+                id: sanitize_untrusted_inline(&id),
                 code_point: c as u32,
             });
         }
@@ -265,6 +291,11 @@ pub fn validate_server_id_slug(id: &str) -> Result<(), ServerIdSlugError> {
 
 /// Error returned when a candidate string fails the invariant [`ToolName::new`] enforces.
 ///
+/// Every variant's `#[error(...)]` message formats its stored string field with `{:?}`
+/// (`Debug`), not `{}` (`Display`) — see [`ServerIdError`]'s doc comment for why this is a
+/// required second layer of defense, not incidental formatting, and must not be "simplified"
+/// away.
+///
 /// # Examples
 ///
 /// ```
@@ -281,7 +312,11 @@ pub enum ToolNameError {
         "invalid tool name {name:?}: must be a single non-empty path segment with no `..` or path separator"
     )]
     InvalidFormat {
-        /// The rejected input.
+        /// Sanitized form of the rejected input (see
+        /// [`sanitize_untrusted_inline`](crate::untrusted::sanitize_untrusted_inline)):
+        /// control characters, bidi-reordering characters, and other invisible/structural
+        /// characters are neutralized, and `&`/`<`/`>` are entity-escaped, since this value is
+        /// attacker-controlled and reaches LLM-facing error text.
         name: String,
     },
 
@@ -291,9 +326,14 @@ pub enum ToolNameError {
         "invalid tool name {name:?}: disallowed character U+{code_point:04X} (identifiers accept only UTS #39 Identifier_Status=Allowed characters)"
     )]
     DisallowedCharacter {
-        /// The rejected input.
+        /// Sanitized form of the rejected input (see
+        /// [`sanitize_untrusted_inline`](crate::untrusted::sanitize_untrusted_inline)):
+        /// control characters, bidi-reordering characters, and other invisible/structural
+        /// characters are neutralized, and `&`/`<`/`>` are entity-escaped, since this value is
+        /// attacker-controlled and reaches LLM-facing error text.
         name: String,
-        /// Unicode scalar value of the first disallowed character found.
+        /// Unicode scalar value of the first disallowed character found, computed from the
+        /// raw (unsanitized) input.
         code_point: u32,
     },
 }
@@ -376,11 +416,13 @@ impl ToolName {
     pub fn new(name: impl Into<String>) -> Result<Self, ToolNameError> {
         let name = name.into();
         if validate_path_segment(&name).is_none() {
-            return Err(ToolNameError::InvalidFormat { name });
+            return Err(ToolNameError::InvalidFormat {
+                name: sanitize_untrusted_inline(&name),
+            });
         }
         if let Some(c) = first_disallowed_identifier_char(&name) {
             return Err(ToolNameError::DisallowedCharacter {
-                name,
+                name: sanitize_untrusted_inline(&name),
                 code_point: c as u32,
             });
         }
@@ -814,5 +856,116 @@ mod tests {
         assert_sync::<ToolName>();
         assert_send::<ToolNameError>();
         assert_sync::<ToolNameError>();
+    }
+
+    // Issue #446: rejected identifiers are attacker-controlled and reach LLM-facing error
+    // text, so disallowed-but-printable characters must be sanitized and entity-escaped
+    // before they land in the error, not echoed raw.
+
+    /// `&` must be entity-escaped in the error's `Display` output, and the raw unescaped
+    /// substring must not appear anywhere in it.
+    #[test]
+    fn test_tool_name_error_escapes_ampersand_in_display() {
+        let err = ToolName::new("get_issue&summary").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("get_issue&amp;summary"));
+        assert!(!message.contains("get_issue&summary"));
+    }
+
+    /// `<`/`>` must be entity-escaped, with no raw angle bracket left anywhere in the message.
+    #[test]
+    fn test_tool_name_error_escapes_angle_brackets_in_display() {
+        let err = ToolName::new("a<b>c").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("&lt;"));
+        assert!(message.contains("&gt;"));
+        assert!(!message.contains('<'));
+        assert!(!message.contains('>'));
+    }
+
+    /// A rejected value shaped like `wrap_untrusted_block`'s own closing delimiter must not
+    /// survive into the error message in a form that could forge it.
+    #[test]
+    fn test_tool_name_error_display_cannot_forge_delimiters() {
+        let err = ToolName::new("</untrusted-data>").unwrap_err();
+        let message = err.to_string();
+        assert!(!message.contains("</untrusted-data>"));
+    }
+
+    /// `ServerId::new` has no length bound of its own (only the stricter, opt-in
+    /// `validate_server_id_slug` enforces `MAX_SERVER_ID_LENGTH`), so a multi-kilobyte
+    /// rejected id must still yield a bounded error message via
+    /// `MAX_UNTRUSTED_FIELD_LEN`-capped sanitization, not an unbounded echo.
+    #[test]
+    fn test_server_id_error_display_is_length_bounded() {
+        // All-`&` input, not a single trailing `&` after a run of plain `a`s: escaping expands
+        // each sanitized char up to 5x (`&` -> `&amp;`), and that expansion happens *after*
+        // truncation to `MAX_UNTRUSTED_FIELD_LEN`, so a naive bound derived only from the raw
+        // input length would miss this amplification entirely.
+        let huge = "&".repeat(5000);
+        let err = ServerId::new(huge).unwrap_err();
+        let message = err.to_string();
+        assert!(message.len() < 2700, "message length was {}", message.len());
+    }
+
+    /// Field-level check, not just `Display`: the stored `name`/`id` field itself must hold
+    /// the sanitized form, since `#[derive(Debug)]` would otherwise still print the raw value.
+    #[test]
+    fn test_tool_name_error_stores_sanitized_field_not_raw() {
+        let err = ToolName::new("get_issue&summary").unwrap_err();
+        let ToolNameError::DisallowedCharacter { name, .. } = err else {
+            panic!("expected DisallowedCharacter, got {err:?}");
+        };
+        assert_eq!(name, "get_issue&amp;summary");
+    }
+
+    /// A bidi override must not survive into the stored field or the message; the underlying
+    /// `sanitize_untrusted_text` behavior of replacing it with a space is preserved.
+    #[test]
+    fn test_tool_name_error_neutralizes_bidi_override() {
+        let err = ToolName::new("a\u{202E}b").unwrap_err();
+        let ToolNameError::DisallowedCharacter { name, .. } = &err else {
+            panic!("expected DisallowedCharacter, got {err:?}");
+        };
+        assert_eq!(name, "a b");
+        assert!(!err.to_string().contains('\u{202E}'));
+    }
+
+    /// The same escaping must apply to the pre-existing `InvalidFormat` variant, not just
+    /// `DisallowedCharacter` — a path separator trips `InvalidFormat` before the
+    /// disallowed-character check ever runs.
+    #[test]
+    fn test_tool_name_invalid_format_error_escapes_ampersand() {
+        let err = ToolName::new("a/b&c").unwrap_err();
+        assert!(matches!(err, ToolNameError::InvalidFormat { .. }));
+        let message = err.to_string();
+        assert!(message.contains("a/b&amp;c"));
+        assert!(!message.contains("a/b&c"));
+    }
+
+    /// `sanitize_untrusted_inline` deliberately leaves U+200D (ZERO WIDTH JOINER) untouched —
+    /// see `sanitize_untrusted_text`'s own doc comment — since it's orthographically load-bearing
+    /// (emoji ZWJ sequences, Indic/Persian script joining) rather than a pure invisible-payload
+    /// channel. The stored `name` field therefore still carries a raw ZWJ; this is only safe
+    /// because the `{name:?}` `Debug` formatting used in the `#[error(...)]` attribute escapes it
+    /// to the visible `\u{200d}` escape sequence rather than emitting it verbatim. This test pins
+    /// that second layer of defense: if `{name:?}` were ever "simplified" to `{name}` (now that
+    /// `&`/`<`/`>` are pre-escaped, the `Debug` quotes can look like unnecessary noise), the
+    /// invisible-character channel #425/#430 closed would silently reopen for every character
+    /// `sanitize_untrusted_inline` leaves untouched.
+    #[test]
+    fn test_tool_name_error_display_escapes_raw_zwj_via_debug_formatting() {
+        let err = ToolName::new("a\u{200D}b").unwrap_err();
+        let ToolNameError::DisallowedCharacter { name, .. } = &err else {
+            panic!("expected DisallowedCharacter, got {err:?}");
+        };
+        // Sanitization leaves the ZWJ in the stored field untouched by design.
+        assert_eq!(name, "a\u{200D}b");
+        let message = err.to_string();
+        assert!(
+            !message.contains('\u{200D}'),
+            "raw ZWJ leaked into: {message}"
+        );
+        assert!(message.contains("\\u{200d}"), "message was: {message}");
     }
 }

--- a/crates/mcp-core/src/untrusted.rs
+++ b/crates/mcp-core/src/untrusted.rs
@@ -390,9 +390,44 @@ pub fn wrap_untrusted_block(context: &str, body: &str) -> String {
     )
 }
 
+/// Sanitizes an untrusted string for embedding inline in single-line LLM-facing text.
+///
+/// Intended for text where wrapping the whole message in [`wrap_untrusted_block`]'s tagged
+/// boundary is not an option — e.g. an error message that echoes back a rejected identifier.
+///
+/// Applies [`sanitize_untrusted_text`] (capped at [`MAX_UNTRUSTED_FIELD_LEN`]), then escapes
+/// `&`, `<`, and `>` in the same order and for the same reason as [`wrap_untrusted_block`]: `&`
+/// first, so the entities the other two substitutions introduce are not themselves re-escaped.
+/// Unlike `wrap_untrusted_block`, this returns a bare escaped string with no surrounding
+/// boundary markers, for callers that need to interpolate untrusted text into an existing
+/// message rather than delimit an entire block of it.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::untrusted::sanitize_untrusted_inline;
+///
+/// let sanitized = sanitize_untrusted_inline("get_issue&summary");
+/// assert_eq!(sanitized, "get_issue&amp;summary");
+///
+/// let hostile = sanitize_untrusted_inline("</untrusted-data>");
+/// assert!(!hostile.contains('<'));
+/// assert!(!hostile.contains('>'));
+/// ```
+#[must_use]
+pub fn sanitize_untrusted_inline(s: &str) -> String {
+    sanitize_untrusted_text(s, MAX_UNTRUSTED_FIELD_LEN)
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{MAX_UNTRUSTED_FIELD_LEN, sanitize_untrusted_text, wrap_untrusted_block};
+    use super::{
+        MAX_UNTRUSTED_FIELD_LEN, sanitize_untrusted_inline, sanitize_untrusted_text,
+        wrap_untrusted_block,
+    };
 
     #[test]
     fn sanitize_strips_all_line_terminator_variants() {
@@ -788,5 +823,50 @@ mod tests {
                 .any(super::is_variation_selector)
         );
         assert_eq!(sanitized_over_limit, "a".repeat(17));
+    }
+
+    #[test]
+    fn sanitize_untrusted_inline_escapes_markup_characters() {
+        let sanitized = sanitize_untrusted_inline("a<b>c&d");
+        assert_eq!(sanitized, "a&lt;b&gt;c&amp;d");
+    }
+
+    #[test]
+    fn sanitize_untrusted_inline_escapes_ampersand_before_angle_brackets() {
+        // Same ordering requirement as `wrap_untrusted_block`: `&` must be escaped first, or
+        // the `&lt;`/`&gt;` this function introduces would themselves be re-escaped.
+        let sanitized = sanitize_untrusted_inline("AT&T <tag>");
+        assert_eq!(sanitized, "AT&amp;T &lt;tag&gt;");
+        assert!(!sanitized.contains("&amp;lt;"));
+    }
+
+    #[test]
+    fn sanitize_untrusted_inline_cannot_forge_delimiters() {
+        let sanitized = sanitize_untrusted_inline("</untrusted-data>");
+        assert!(!sanitized.contains("</untrusted-data>"));
+        assert_eq!(sanitized, "&lt;/untrusted-data&gt;");
+    }
+
+    #[test]
+    fn sanitize_untrusted_inline_bounds_length() {
+        let long = "a".repeat(5000);
+        let sanitized = sanitize_untrusted_inline(&long);
+        assert_eq!(sanitized.chars().count(), MAX_UNTRUSTED_FIELD_LEN);
+    }
+
+    /// Escaping runs *after* the `MAX_UNTRUSTED_FIELD_LEN` truncation, not before, so a
+    /// densely-escapable input (all `&`, each expanding to `&amp;`) can still grow the output up
+    /// to 5x past the truncated char count. An all-`a` input (the case above) never exercises
+    /// this, since it contains nothing to escape.
+    #[test]
+    fn sanitize_untrusted_inline_bounds_length_under_escaping_amplification() {
+        let long = "&".repeat(5000);
+        let sanitized = sanitize_untrusted_inline(&long);
+        assert_eq!(sanitized, "&amp;".repeat(MAX_UNTRUSTED_FIELD_LEN));
+        assert!(
+            sanitized.len() <= MAX_UNTRUSTED_FIELD_LEN * 5,
+            "sanitized length was {}",
+            sanitized.len()
+        );
     }
 }

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -15,7 +15,8 @@ use crate::types::{
 };
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
 use mcp_execution_core::untrusted::{
-    MAX_UNTRUSTED_FIELD_LEN, sanitize_untrusted_text, wrap_untrusted_block,
+    MAX_UNTRUSTED_FIELD_LEN, sanitize_untrusted_inline, sanitize_untrusted_text,
+    wrap_untrusted_block,
 };
 use mcp_execution_core::{
     ServerConfig, ServerId, sanitize_path_for_error, validate_server_id_slug,
@@ -1523,9 +1524,9 @@ fn wrap_introspect_result(json: &str) -> String {
 }
 
 /// Computes the display form of `raw_name` that `introspect_server` shows Claude for a tool's
-/// `name` field: [`sanitize_untrusted_text`] followed by the same `&`/`<`/`>` entity-escaping
-/// [`wrap_untrusted_block`] applies afterward to the whole serialized response (see its
-/// escaping-order doc comment).
+/// `name` field: [`sanitize_untrusted_inline`] (identical to [`sanitize_untrusted_text`]
+/// followed by the same `&`/`<`/`>` entity-escaping [`wrap_untrusted_block`] applies afterward to
+/// the whole serialized response — see its escaping-order doc comment).
 ///
 /// `build_introspected_summaries` deliberately does *not* apply this escaping itself — it only
 /// sanitizes control characters — because `wrap_introspect_result` escapes the entire
@@ -1547,10 +1548,7 @@ fn wrap_introspect_result(json: &str) -> String {
 /// decoded literal form instead of this escaped one gets a hard "not found" error — the exact
 /// #307 S2 symptom `display_forms` existed to avoid.
 fn display_tool_name(raw_name: &str) -> String {
-    sanitize_untrusted_text(raw_name, MAX_UNTRUSTED_FIELD_LEN)
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+    sanitize_untrusted_inline(raw_name)
 }
 
 /// Extracts parameter names from a JSON Schema.

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -98,10 +98,11 @@ deliberately passes through by design (see its own doc comment). The Allowed set
 detect homoglyphs (e.g. Cyrillic `а` U+0430 is Allowed and renders identically to Latin `a`) —
 that is an explicitly out-of-scope, separate protection. A path-traversal attempt is still
 reported as `InvalidFormat` (checked first), not `DisallowedCharacter`. `DisallowedCharacter`'s
-`code_point` is the `u32` Unicode scalar value of the first rejected character; the `{:?}`
-`Debug` formatting used in both variants' error messages escapes control/format code points in
-the rejected string, so an attacker-controlled value can't smuggle an escape sequence into the
-rendered error. There is no `From<String>`/`From<&str>` impl, and
+`code_point` is the `u32` Unicode scalar value of the first rejected character, computed from
+the *raw* (unsanitized) input so it is not thrown off by construction-time sanitization (below).
+The `{:?}` `Debug` formatting used in both variants' error messages escapes control/format code
+points in the rejected string, so an attacker-controlled value can't smuggle an escape sequence
+into the rendered error. There is no `From<String>`/`From<&str>` impl, and
 `#[serde(try_from = "String")]` (backed by `impl TryFrom<String>` delegating to `new`) routes
 `Deserialize` through `new` too — `new` is the only construction path, including through
 deserialization, so neither invariant can be bypassed by an infallible conversion or a
@@ -152,6 +153,41 @@ one place a `ServerId`'s raw `&str` form reaches generated code) performs its ow
 length-bound/defense-in-depth pass regardless of either type's construction-time gate, since
 generated code is a sink both hand-built and introspected values can reach
 ([[../codegen/spec#7. Injection Defense (Sanitization Pipeline)]]).
+
+Since issue #446, the `id`/`name` field stored in both `InvalidFormat` and `DisallowedCharacter`
+holds a *sanitized* form of the rejected input, not the raw one: `new` runs the raw value through
+`untrusted::sanitize_untrusted_inline` (`sanitize_untrusted_text`, capped at
+`MAX_UNTRUSTED_FIELD_LEN` **chars**, then `&`/`<`/`>` entity-escaped) before constructing the
+error variant, in every branch that stores the input — the `code_point` computation above still
+reads the raw value first. This closes the same class of gap #433 closed for tool-name
+collisions: `Identifier_Status=Allowed` rejects a tool name containing `&`/`<`/`>`/control
+characters/bidi overrides, but the rejection's own error message previously echoed that same
+raw, disallowed substring back into `Display`/`Debug`-formatted text that reaches an LLM (via
+`mcp-introspector`'s `Error::ValidationError` mapping and `mcp-server`'s
+`caller_or_internal_error` — [[../server/spec]]) or a terminal (`mcp-cli`, `tracing`), letting a
+malicious server forge Markdown structure, HTML-like tags (including
+`untrusted::wrap_untrusted_block`'s own `</untrusted-data>` delimiter shape), or an unbounded
+message (`ServerId::new` has no length bound of its own).
+
+The cap is on the *pre-escaping* char count, not the final message size: escaping runs after
+truncation, and each escaped `&` expands to `&amp;` (5x), so a densely-escapable input (e.g. 5000
+`&` characters) still yields a bounded but noticeably larger message than
+`MAX_UNTRUSTED_FIELD_LEN` alone suggests — up to `MAX_UNTRUSTED_FIELD_LEN * 5` bytes of escaped
+content, observed at ~2600 bytes for the full error message in the all-`&` case, not the ~500-700
+bytes a naive reading of the cap implies.
+
+Every variant's `#[error(...)]` formats the stored field with `{:?}` (`Debug`), not `{}`
+(`Display`) — a required second layer of defense, not incidental. `sanitize_untrusted_inline`
+deliberately leaves some characters untouched (e.g. U+200C/U+200D — see
+`sanitize_untrusted_text`'s own doc comment), so `Debug`'s own escaping of those characters
+(`\u{200d}` rather than the literal) is what actually closes the invisible-payload channel
+#425/#430 closed for those residual cases; using `Display` here would silently reopen it.
+
+Emoji is a deliberate exception, not neutralized by this fix — see the edge-case table below.
+Human `mcp-cli` users now see the entity-escaped form too (e.g. `invalid server id
+"my&amp;server"` rather than `"my&server"`) when a rejected id/name contains `&`/`<`/`>` — an
+accepted trade-off of applying one sanitization path uniformly to both the LLM- and
+human-facing surfaces, rather than maintaining two different escaping rules for the same field.
 
 ### `validate_server_id_slug` / `ServerIdSlugError` (`src/types.rs`, issue #401)
 
@@ -215,8 +251,7 @@ adding variants here: `mcp-files` has no direct dependency on `mcp-core` (only a
 via `mcp-execution-codegen`), so sharing this enum would mean adding a new direct dependency on
 `mcp-core` for a single error variant — see [[../files/spec#7. Error Conditions]].
 Most variants have an `is_*` predicate (`is_security_error`, `is_validation_error`,
-`is_script_generation_error`, `is_resource_limit_exceeded`,
-`is_duplicate_generated_file_path`). No predicate exists for
+`is_script_generation_error`, `is_resource_limit_exceeded`). No predicate exists for
 `InvalidArgument`/`SerializationError` — callers match directly.
 `ConnectionFailed`/`Timeout` have no `is_connection_error`/`is_timeout` predicate either
 (removed, issue #427, mirroring #199/#202's identical dead-predicate-removal precedent): their
@@ -226,6 +261,18 @@ than through a predicate — adding a variant there is a compile error at that `
 guarantee an `if`/`else if` predicate chain would silently lose. `ScriptGenerationError.source`
 is the vehicle for preserving an inner `Error`'s own classification through wrapping (see
 `mcp-cli`'s `classify_core_error`, which recurses into it — [[../cli/spec]]).
+`DuplicateGeneratedFilePath` likewise has no `is_duplicate_generated_file_path` predicate
+(removed, issue #445): it had no production call site anywhere in the workspace, only test
+call sites (`mcp-core`'s own doc-test/unit test, and `mcp-codegen`'s `GeneratedCode::add_file`
+tests), which now match the variant directly instead. `is_security_error` and
+`is_validation_error` were both flagged as candidates by the same issue but were kept: unlike
+the removed predicate, both are used together at a single real production call site,
+`mcp-server`'s `caller_or_internal_error` ([[../server/spec]]) —
+`err.is_validation_error() || err.is_security_error()` — which classifies a `ValidationError` or
+`SecurityViolation` as a caller-facing `invalid_params` response rather than an internal error.
+The issue's premise ("zero call sites anywhere, including tests") was correct for
+`is_duplicate_generated_file_path` but factually wrong for `is_security_error`; do not re-attempt
+removing either predicate in a future cleanup pass without re-checking this call site first.
 
 `Error::DuplicateGeneratedFilePath { path: String }` (issue #312) is raised by
 `mcp-execution-codegen`'s `GeneratedCode::add_file` when a second file is added at a path
@@ -614,15 +661,23 @@ absorbed into the token's "scheme" and survives, exact parity with what
 ```rust
 pub const MAX_UNTRUSTED_FIELD_LEN: usize = 500;
 pub fn sanitize_untrusted_text(s: &str, max_len: usize) -> String; // flattens control chars, U+2028/U+2029, bidi override/isolate controls, and U+200B to spaces; removes bidi marks, the Unicode Tags block (U+E0000-U+E007F), U+FEFF, and U+2060-U+2064 entirely; leaves U+200C/U+200D untouched; THEN, on the filtered result, drops all variation selectors if their whole-value total exceeds 16, else drops any run of more than 2 consecutive ones; truncates by char count
+pub fn sanitize_untrusted_inline(s: &str) -> String;  // sanitize_untrusted_text(s, MAX_UNTRUSTED_FIELD_LEN), then escapes &, <, > in place — same escaping as wrap_untrusted_block's body but with no surrounding boundary markers
 pub fn wrap_untrusted_block(context: &str, body: &str) -> String;  // escapes &, <, > in body; wraps in <untrusted-data>...</untrusted-data>
 ```
 Threat model: an introspected MCP server's tool names/descriptions/keywords
-are attacker-controlled from this project's perspective. Both functions
-exist because `mcp-skill` (SKILL.md + prompt generation) and
+are attacker-controlled from this project's perspective. Both `sanitize_untrusted_text`/
+`wrap_untrusted_block` exist because `mcp-skill` (SKILL.md + prompt generation) and
 `mcp-server` (introspection summaries returned to Claude) both embed this
 data into text an LLM later reads as instructions — see
 [[../server/spec#Prompt injection defense]] and
 [[../skill/spec#Prompt injection defense]].
+
+Since issue #446, `sanitize_untrusted_inline` (added because `wrap_untrusted_block`'s boundary
+markers don't fit a single-line message like an error's `Display` output) is used by
+`ServerId`/`ToolName`'s error-construction sites ([[#ServerId / ToolName (src/types.rs)]]) to
+sanitize and escape a rejected identifier before it is stored in the error, since that value is
+attacker-controlled and reaches LLM-facing text with no `wrap_untrusted_block` boundary around
+it.
 
 Since issue #422, `sanitize_untrusted_text` also neutralizes the Unicode bidirectional-formatting
 characters a "Trojan Source"-style attack relies on to visually reorder or relabel text for a
@@ -796,6 +851,8 @@ and byte-preserving of each variant's existing `Display` message.
 | `resolve_confined_path` terminal component exists as the other `ConfinementTarget` kind (file where `Directory` expected, or vice versa) | `WrongTargetKind`, mapped by each caller to its own truthful variant name |
 | `resolve_confined_path` with `target: None` | Returns the walked `relative_dirs` chain itself; nothing beyond the segment directory is created |
 | `resolve_confined_path`'s lenient intermediate walk hits a symlink loop (`ELOOP`) | Surfaces as `Io`, not `Escape` — `canonicalize`'s error propagates via `?` before any confinement comparison runs |
+| `ServerId::new`/`ToolName::new` rejects an input containing `&`, `<`, `>`, a control character, or a bidi override (issue #446) | The rejected value is sanitized (`untrusted::sanitize_untrusted_inline`) and `&`/`<`/`>` entity-escaped before being stored in `ServerIdError`/`ToolNameError`, so the raw disallowed characters never reach the `Display`/`Debug`-formatted error text an LLM or terminal renders |
+| `ServerId::new`/`ToolName::new` rejects an input containing emoji | **Not** sanitized or stripped — a deliberate accepted-risk exception, not an oversight: emoji is printable, cannot forge Markdown/HTML-like structure the way `&`/`<`/`>` can, and stripping arbitrary non-identifier printables would need a new allowlist pass that risks corrupting legitimate non-ASCII text elsewhere in the sanitizer |
 
 ## 6. See Also
 

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -185,17 +185,20 @@ issue #381).
    (`display_to_raw`) before validating any entry, since a caller can only ever echo
    back the *display* form of a tool name `introspect_server` showed it, never the
    raw one. For each introspected tool, its display key is computed
-   (`display_tool_name`): `sanitize_untrusted_text` followed by `&`/`<`/`>` →
-   `&amp;`/`&lt;`/`&gt;` entity-escaping, mirroring `wrap_untrusted_block`'s own
-   escaping. Since issue #433, `ToolName::new`'s Unicode-identifier allowlist
-   rejects every character this transform would otherwise change, so for any valid
-   `ToolName` under `sanitize_untrusted_text`'s truncation point,
-   `display_tool_name` is the identity function — raw and display keys coincide. If
-   two **distinct** raw tool names still collide on the same display key (reachable
-   today only via truncation past `MAX_UNTRUSTED_FIELD_LEN`), that key is dropped
-   from the lookup entirely — genuinely ambiguous, so a caller using it hits "not
-   found" rather than silently having one raw tool's categorization misattributed
-   to another's. Each `categorized_tools` entry's `name` is resolved through this
+   (`display_tool_name`, which since issue #446 delegates to
+   `mcp-execution-core`'s `untrusted::sanitize_untrusted_inline` — sanitization
+   followed by `&`/`<`/`>` → `&amp;`/`&lt;`/`&gt;` entity-escaping, byte-identical
+   to what it did before delegating — see [[../core/spec#`untrusted` module
+   (`src/untrusted.rs`)]]), mirroring `wrap_untrusted_block`'s own escaping. Since
+   issue #433, `ToolName::new`'s Unicode-identifier allowlist rejects every
+   character this transform would otherwise change, so for any valid `ToolName`
+   under `sanitize_untrusted_text`'s truncation point, `display_tool_name` is the
+   identity function — raw and display keys coincide. If two **distinct** raw
+   tool names still collide on the same display key (reachable today only via
+   truncation past `MAX_UNTRUSTED_FIELD_LEN`), that key is dropped from the
+   lookup entirely — genuinely ambiguous, so a caller using it hits "not found"
+   rather than silently having one raw tool's categorization misattributed to
+   another's. Each `categorized_tools` entry's `name` is resolved through this
    lookup to a raw tool name once; both the duplicate check and the codegen
    categorization map are keyed by that **resolved raw name**, not the submitted
    string. This fixes a categorization-lookup desync (issue #307): an earlier


### PR DESCRIPTION
## Summary

- `ServerIdError`/`ToolNameError` no longer echo a rejected identifier's raw `&`/`<`/`>`/emoji into `Display`/`Debug`-formatted error text. Both `InvalidFormat` and `DisallowedCharacter` now sanitize and entity-escape the stored input at construction time via a new `untrusted::sanitize_untrusted_inline` helper, closing the path that let a malicious MCP server smuggle markup or a boundary delimiter into LLM-facing error text (or produce an unbounded-length message, since `ServerId::new` has no length cap of its own). The reported `code_point` is still computed from the raw input. Emoji intentionally passes through unsanitized as a documented, deliberate accepted-risk exception (signed off before implementation) — it is printable and cannot forge markup, and stripping it would need a new allowlist pass that risks corrupting legitimate non-ASCII text. `mcp-server::display_tool_name` now delegates to the same helper.
- Removes `Error::is_duplicate_generated_file_path`, which had no production call site anywhere in the workspace, consistent with the precedent set by #199/#202/#427. `Error::is_security_error` was evaluated under the same criterion but kept — it has a real production call site in `mcp-server`'s `caller_or_internal_error`, so the originating issue's premise was factually wrong for that predicate.

Both issues were grouped into a single PR during triage since they touch the same crate (`mcp-core`) and are independent, non-conflicting, low-risk changes.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1326 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests cover: `&`/`<`/`>` escaping, delimiter-forgery shape, length-bound under escaping amplification, field-level sanitization (not just `Display`), bidi override, and the pre-existing `InvalidFormat` variant
- [x] `specs/core/spec.md` and `specs/server/spec.md` updated to reflect the new sanitization path and predicate-removal rationale

Fixes #446
Fixes #445