### PR TITLE
refactor(codegen): split generate_with_categories, narrow too_many_lines allow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mcp-execution-codegen`**: split `ProgressiveGenerator::generate_with_categories` into the
+  public method plus three private helpers (`emit_tool_files`, `emit_index_file`,
+  `emit_scaffolding_files`), bringing it under clippy's `too_many_lines` threshold with no change
+  to behavior, output ordering, or error conditions. The workspace-wide `too_many_lines` allow is
+  removed from the root `Cargo.toml`; the two test functions that still legitimately exceed the
+  threshold now carry a narrow, rationale-commented item-level allow instead (#443).
 - **`mcp-execution-core`**: added `validate_server_id_slug`, `ServerIdSlugError`, and
   `MAX_SERVER_ID_LENGTH` — the authoritative, core-owned invariant for a slug-shaped server id
   (1-64 lowercase ASCII letters, digits, or hyphens), distinct from `ServerId::new()`'s own

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ multiple_crate_versions = { level = "allow", priority = 10 }           # Transit
 needless_borrows_for_generic_args = { level = "allow", priority = 10 } # Only trivial hits in test fixtures (e.g. `&format!(...)`), not worth the churn
 nursery = { level = "deny", priority = -1 }
 pedantic = { level = "deny", priority = -1 }
-too_many_lines = { level = "allow", priority = 10 }                    # Generator and test functions legitimately exceed the line threshold
 
 [profile.release]
 opt-level = 3

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -348,11 +348,66 @@ impl ProgressiveGenerator<'_> {
 
         let mut code = GeneratedCode::new();
         let mut total_bytes = 0usize;
-        let server_id = server_info.id.as_str();
         let typescript_names = resolve_typescript_names(&server_info.tools);
+
+        let tool_metadata = self.emit_tool_files(
+            server_info,
+            categorizations,
+            &typescript_names,
+            &mut code,
+            &mut total_bytes,
+        )?;
+
+        self.emit_index_file(
+            server_info,
+            categorizations,
+            &typescript_names,
+            &mut code,
+            &mut total_bytes,
+        )?;
+
+        self.emit_scaffolding_files(&mut code, &mut total_bytes)?;
+
+        // Generate _meta.json sidecar with structured tool metadata
+        add_tracked(
+            &mut code,
+            &mut total_bytes,
+            Self::create_metadata_file(server_info, tool_metadata)?,
+        )?;
+
+        tracing::debug!("Generated {}", METADATA_FILE_NAME);
+
+        if categorizations.is_empty() {
+            tracing::info!(
+                "Successfully generated {} files for {} (progressive loading)",
+                code.file_count(),
+                server_info.name
+            );
+        } else {
+            tracing::info!(
+                "Successfully generated {} files for {} with categorizations (progressive loading)",
+                code.file_count(),
+                server_info.name
+            );
+        }
+
+        Ok(code)
+    }
+
+    /// Renders one `.ts` file per tool with categorization metadata, tracking each into `code`.
+    ///
+    /// Returns per-tool [`ToolMetadata`] in tool order for the `_meta.json` sidecar.
+    fn emit_tool_files(
+        &self,
+        server_info: &ServerInfo,
+        categorizations: &HashMap<String, ToolCategorization>,
+        typescript_names: &[String],
+        code: &mut GeneratedCode,
+        total_bytes: &mut usize,
+    ) -> Result<Vec<ToolMetadata>> {
+        let server_id = server_info.id.as_str();
         let mut tool_metadata = Vec::with_capacity(server_info.tools.len());
 
-        // Generate tool files (one per tool) with categorization metadata
         for (idx, tool) in server_info.tools.iter().enumerate() {
             let tool_name = tool.name.as_str();
             let categorization = categorizations.get(tool_name);
@@ -380,8 +435,8 @@ impl ProgressiveGenerator<'_> {
                 })?;
 
             add_tracked(
-                &mut code,
-                &mut total_bytes,
+                code,
+                total_bytes,
                 GeneratedFile {
                     path: format!("{}.ts", tool_context.typescript_name),
                     content: tool_code,
@@ -405,14 +460,25 @@ impl ProgressiveGenerator<'_> {
             ));
         }
 
-        // Generate index.ts with category grouping
+        Ok(tool_metadata)
+    }
+
+    /// Builds and renders `index.ts` with category grouping, tracking it into `code`.
+    fn emit_index_file(
+        &self,
+        server_info: &ServerInfo,
+        categorizations: &HashMap<String, ToolCategorization>,
+        typescript_names: &[String],
+        code: &mut GeneratedCode,
+        total_bytes: &mut usize,
+    ) -> Result<()> {
         let index_context =
-            Self::create_index_context(server_info, Some(categorizations), &typescript_names);
+            Self::create_index_context(server_info, Some(categorizations), typescript_names);
         let index_code = self.engine.render("progressive/index", &index_context)?;
 
         add_tracked(
-            &mut code,
-            &mut total_bytes,
+            code,
+            total_bytes,
             GeneratedFile {
                 path: "index.ts".to_string(),
                 content: index_code,
@@ -424,6 +490,16 @@ impl ProgressiveGenerator<'_> {
             categorizations.len()
         );
 
+        Ok(())
+    }
+
+    /// Emits the tool-independent scaffolding files: the runtime bridge, `package.json`, and
+    /// `tsconfig.json`.
+    fn emit_scaffolding_files(
+        &self,
+        code: &mut GeneratedCode,
+        total_bytes: &mut usize,
+    ) -> Result<()> {
         // Generate runtime bridge (same as non-categorized)
         let bridge_context = BridgeContext::default();
         let bridge_code = self
@@ -431,8 +507,8 @@ impl ProgressiveGenerator<'_> {
             .render("progressive/runtime-bridge", &bridge_context)?;
 
         add_tracked(
-            &mut code,
-            &mut total_bytes,
+            code,
+            total_bytes,
             GeneratedFile {
                 path: "_runtime/mcp-bridge.ts".to_string(),
                 content: bridge_code,
@@ -444,8 +520,8 @@ impl ProgressiveGenerator<'_> {
         // Generate package.json for ES module identification and the @types/node devDependency
         // needed for the runtime bridge to type-check (see PACKAGE_JSON doc comment)
         add_tracked(
-            &mut code,
-            &mut total_bytes,
+            code,
+            total_bytes,
             GeneratedFile {
                 path: "package.json".to_string(),
                 content: PACKAGE_JSON.to_string(),
@@ -457,8 +533,8 @@ impl ProgressiveGenerator<'_> {
         // Generate tsconfig.json so `tsc --noEmit` accepts the `.ts`-extensioned import in
         // each tool file (see TSCONFIG_JSON doc comment)
         add_tracked(
-            &mut code,
-            &mut total_bytes,
+            code,
+            total_bytes,
             GeneratedFile {
                 path: "tsconfig.json".to_string(),
                 content: TSCONFIG_JSON.to_string(),
@@ -467,30 +543,7 @@ impl ProgressiveGenerator<'_> {
 
         tracing::debug!("Generated tsconfig.json");
 
-        // Generate _meta.json sidecar with structured tool metadata
-        add_tracked(
-            &mut code,
-            &mut total_bytes,
-            Self::create_metadata_file(server_info, tool_metadata)?,
-        )?;
-
-        tracing::debug!("Generated {}", METADATA_FILE_NAME);
-
-        if categorizations.is_empty() {
-            tracing::info!(
-                "Successfully generated {} files for {} (progressive loading)",
-                code.file_count(),
-                server_info.name
-            );
-        } else {
-            tracing::info!(
-                "Successfully generated {} files for {} with categorizations (progressive loading)",
-                code.file_count(),
-                server_info.name
-            );
-        }
-
-        Ok(code)
+        Ok(())
     }
 
     /// Creates tool context from MCP tool information.

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -1544,6 +1544,9 @@ fn test_runtime_bridge_times_out_when_server_never_replies() {
 ///
 /// Skips (does not fail) when `tsc` or `node` is not on `PATH`.
 #[test]
+// One end-to-end scenario (generate -> embed fake out-of-order MCP server -> compile -> run ->
+// assert) whose fake-server script and assertions must stay in one body to remain readable.
+#[allow(clippy::too_many_lines)]
 fn test_runtime_bridge_dispatches_concurrent_out_of_order_responses_by_request_id() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -2573,6 +2573,9 @@ mod tests {
     /// mismatched `server_id` leaking from one call's span stack into the other's
     /// events is exactly what the assertions below detect.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    // The test's length is a custom `tracing_subscriber::Layer` plus span-field capture
+    // harness that only makes sense inline with the assertions it feeds.
+    #[allow(clippy::too_many_lines)]
     async fn test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id() {
         use std::sync::{Arc, Mutex};
         use tokio::sync::Barrier;

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -81,8 +81,10 @@ related:
 
 - Clippy `all`, `cargo`, `nursery`, `pedantic` are `deny` at workspace level;
   narrow, per-crate `#[allow(...)]`s are used only where the lint's intent
-  doesn't apply (e.g. `too_many_lines` allowed workspace-wide;
-  `unused_async` allowed in `mcp-cli` for uniformly-dispatched handlers).
+  doesn't apply (e.g. `too_many_lines` allowed item-level on two
+  concurrency-test functions whose length is inherent to the scenario they
+  cover; `unused_async` allowed in `mcp-cli` for uniformly-dispatched
+  handlers).
 - `#![deny(unsafe_code)]` in every crate except `mcp-server`/`mcp-cli` (which
   don't need it) — no crate in this workspace uses `unsafe`.
 - `#![warn(missing_docs, missing_debug_implementations)]` everywhere: every


### PR DESCRIPTION
## Summary
- Split `ProgressiveGenerator::generate_with_categories` into the public method plus three private helpers (`emit_tool_files`, `emit_index_file`, `emit_scaffolding_files`), eliminating the only production-code driver of the workspace-wide `too_many_lines` clippy allow.
- Removed the workspace-wide `too_many_lines` allow from `Cargo.toml` and replaced it with two narrow, rationale-commented item-level allows on the remaining long test functions in `progressive_generation.rs` and `service.rs`.
- Corrected a stale reference in `specs/constitution.md` that still described the removed workspace-wide allow.
- Updated `CHANGELOG.md` under `[Unreleased]`.

Closes #443

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1332 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -W clippy::too_many_lines` confirms zero un-allowed hits workspace-wide