### PR TITLE
fix(server,skill): sanitize rejected segments before embedding in error text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sanitize_untrusted_text`'s truncation, per `validate_categorized_tools`'s S3 doc comment).
   Not-found remains the common case for a genuinely mistyped or stale name; distinguishing it from
   the rare ambiguous case just gives the caller a more actionable message either way (#456).
+- **`mcp-execution-core`**: `ConfinementError::InvalidSegment` (#452), `mcp-execution-server`'s
+  `OutputDirError::InvalidServerId` (#450), and `mcp-execution-skill`'s
+  `OutputPathError::InvalidServerId` (#451) now sanitize their rejected segment/`server_id` field
+  with `untrusted::sanitize_untrusted_inline` before storing it — the same helper and
+  construction-time pattern `ServerIdError`/`ToolNameError` adopted below (see the "Security"
+  section for that change), closing the same `&`/`<`/`>`-smuggling gap at the three sites that
+  change didn't already cover. Each `#[error(...)]` attribute keeps its pre-existing `{field:?}`
+  (`Debug`) formatting unchanged, for the same reason documented on `ServerIdError`.
 - **`mcp-execution-core`**: `validate_env_name` now rejects any environment variable name that
   does not match the conventional POSIX/Windows identifier charset `[A-Za-z_][A-Za-z0-9_]*`,
   before the forbidden-name comparison runs. The prior ASCII-case-insensitive comparison (#428)

--- a/crates/mcp-core/src/confinement.rs
+++ b/crates/mcp-core/src/confinement.rs
@@ -20,6 +20,7 @@ use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
 use crate::path::{sanitize_path_for_error, validate_path_segment};
+use crate::untrusted::sanitize_untrusted_inline;
 
 /// The terminal path component a [`resolve_confined_path`] walk resolves and confinement-checks
 /// but deliberately does not create.
@@ -71,7 +72,22 @@ pub enum ConfinementError {
     /// a single plain path component.
     #[error("segment must be a single non-empty path segment: {segment:?}")]
     InvalidSegment {
-        /// The rejected segment.
+        /// Sanitized display form of the rejected segment (see
+        /// [`sanitize_untrusted_inline`](crate::untrusted::sanitize_untrusted_inline)): control
+        /// characters, bidi-reordering characters, and other invisible/structural characters are
+        /// neutralized, and `&`/`<`/`>` are entity-escaped, since this value is
+        /// attacker-controlled and reaches LLM-facing error text. The `{segment:?}` (`Debug`)
+        /// formatting above is a required second layer of defense on top of that sanitization,
+        /// not incidental — see [`ServerIdError`](crate::ServerIdError)'s doc comment for why it
+        /// must not be "simplified" to `{segment}` (`Display`).
+        ///
+        /// This field is `pub` only because the enum itself is; [`resolve_confined_path`] is the
+        /// sole constructor of this variant, and it always passes an already-sanitized string
+        /// here. A caller building this variant directly (there are none in this workspace) must
+        /// sanitize the value the same way, or a raw value reaches every downstream consumer that
+        /// embeds this field (see `mcp-execution-server`'s `OutputDirError::InvalidServerId` and
+        /// `mcp-execution-skill`'s `OutputPathError::InvalidServerId`, both of which move this
+        /// field verbatim into their own `server_id` without re-sanitizing).
         segment: String,
     },
 
@@ -190,7 +206,7 @@ pub async fn resolve_confined_path(
 ) -> Result<PathBuf, ConfinementError> {
     let component =
         validate_path_segment(segment).ok_or_else(|| ConfinementError::InvalidSegment {
-            segment: segment.to_string(),
+            segment: sanitize_untrusted_inline(segment),
         })?;
 
     tokio::fs::create_dir_all(base_dir)
@@ -399,6 +415,67 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ConfinementError::InvalidSegment { .. }));
+    }
+
+    /// Issue #452: a segment rejected for containing a path separator can still carry
+    /// printable-but-disallowed characters (`&`, `<`, `>`, emoji) elsewhere in it; none of those
+    /// may reach the error message unescaped.
+    #[tokio::test]
+    async fn segment_with_hostile_characters_is_escaped_in_error() {
+        let base = TempDir::new().unwrap();
+        for (candidate, escaped) in [
+            ("a/b&c", "a/b&amp;c"),
+            ("a/b<c", "a/b&lt;c"),
+            ("a/b>c", "a/b&gt;c"),
+        ] {
+            let err = resolve_confined_path(base.path(), candidate, Path::new(""), None)
+                .await
+                .unwrap_err();
+            let message = err.to_string();
+            assert!(!message.contains(candidate), "{message:?}");
+            assert!(message.contains(escaped), "{message:?}");
+        }
+    }
+
+    /// S2: an emoji carries no structural or injection risk on its own, so it must appear in the
+    /// error message unchanged rather than being mangled — unlike `&`/`<`/`>` above.
+    #[tokio::test]
+    async fn segment_with_emoji_is_left_unchanged_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "a/b\u{1F600}c", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("a/b\u{1F600}c"));
+    }
+
+    /// A legitimate non-ASCII segment must pass through `sanitize_untrusted_inline` unchanged;
+    /// only the separator that triggers `InvalidSegment` is the actual problem here.
+    #[tokio::test]
+    async fn segment_with_legitimate_non_ascii_is_left_unchanged_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "café/menu_日本語", Path::new(""), None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("café/menu_日本語"));
+    }
+
+    /// `sanitize_untrusted_inline` deliberately leaves U+200D (ZERO WIDTH JOINER) untouched (see
+    /// its own doc comment), so `InvalidSegment`'s stored `segment` field still carries a raw
+    /// ZWJ. This is only safe because `{segment:?}` (`Debug`) formatting escapes it to
+    /// `\u{200d}` rather than emitting it verbatim — this test pins that second layer of
+    /// defense, mirroring `ServerIdError`'s equivalent regression test.
+    #[tokio::test]
+    async fn segment_with_zwj_is_debug_escaped_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_confined_path(base.path(), "a/b\u{200D}c", Path::new(""), None)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains('\u{200D}'),
+            "raw ZWJ leaked into: {message}"
+        );
+        assert!(message.contains("\\u{200d}"), "message was: {message}");
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/output_dir.rs
+++ b/crates/mcp-server/src/output_dir.rs
@@ -20,6 +20,7 @@
 //! confinement check that matters runs as close to the actual write as this two-step protocol
 //! allows.
 
+use mcp_execution_core::untrusted::sanitize_untrusted_inline;
 use mcp_execution_core::{
     ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
     validate_server_id_slug,
@@ -37,7 +38,12 @@ pub enum OutputDirError {
     /// enforced.
     #[error("invalid server_id {server_id:?}: {source}")]
     InvalidServerId {
-        /// The rejected server id.
+        /// Sanitized display form of the rejected server id (see
+        /// [`mcp_execution_core::untrusted::sanitize_untrusted_inline`]). The `{server_id:?}`
+        /// (`Debug`) formatting above is a required second layer of defense on top of that
+        /// sanitization, not incidental — see
+        /// [`mcp_execution_core::ServerIdError`]'s doc comment for why it must not be
+        /// "simplified" to `{server_id}` (`Display`).
         server_id: String,
         /// The specific slug-format violation.
         #[source]
@@ -234,7 +240,7 @@ pub async fn resolve_output_dir(
     // (`resolve_confined_path` re-validates it a second time, against the looser structural rule,
     // as part of its own walk).
     validate_server_id_slug(server_id).map_err(|source| OutputDirError::InvalidServerId {
-        server_id: server_id.to_string(),
+        server_id: sanitize_untrusted_inline(server_id),
         source,
     })?;
 
@@ -434,6 +440,68 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Issue #450: printable-but-disallowed characters (`&`, `<`, `>`) in a rejected `server_id`
+    /// must not reach the error message unescaped — `validate_server_id_slug` rejects every
+    /// character outside `[a-z0-9-]`, so any of these reaches `InvalidServerId` directly.
+    #[tokio::test]
+    async fn server_id_with_hostile_characters_is_escaped_in_error() {
+        let base = TempDir::new().unwrap();
+        for (candidate, escaped) in [
+            ("server&name", "server&amp;name"),
+            ("server<name", "server&lt;name"),
+            ("server>name", "server&gt;name"),
+        ] {
+            let err = resolve_output_dir(base.path(), candidate, None)
+                .await
+                .unwrap_err();
+            let message = err.to_string();
+            assert!(!message.contains(candidate), "{message:?}");
+            assert!(message.contains(escaped), "{message:?}");
+        }
+    }
+
+    /// S2: an emoji carries no structural or injection risk on its own, so it must appear in the
+    /// error message unchanged rather than being mangled — unlike `&`/`<`/`>` above.
+    #[tokio::test]
+    async fn server_id_with_emoji_is_left_unchanged_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_output_dir(base.path(), "server\u{1F600}name", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("server\u{1F600}name"));
+    }
+
+    /// A legitimate non-ASCII script character carries no structural or injection risk either,
+    /// so — like the emoji above — it must survive `sanitize_untrusted_inline` unchanged, even
+    /// though `validate_server_id_slug`'s `[a-z0-9-]` charset still rejects it.
+    #[tokio::test]
+    async fn server_id_with_non_ascii_script_is_left_unchanged_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_output_dir(base.path(), "café_日本語", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("café_日本語"));
+    }
+
+    /// `sanitize_untrusted_inline` deliberately leaves U+200D (ZERO WIDTH JOINER) untouched (see
+    /// its own doc comment), so `InvalidServerId`'s stored `server_id` field still carries a raw
+    /// ZWJ. This is only safe because `{server_id:?}` (`Debug`) formatting escapes it to
+    /// `\u{200d}` rather than emitting it verbatim — this test pins that second layer of
+    /// defense, mirroring `ServerIdError`'s equivalent regression test.
+    #[tokio::test]
+    async fn server_id_with_zwj_is_debug_escaped_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_output_dir(base.path(), "server\u{200D}name", None)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains('\u{200D}'),
+            "raw ZWJ leaked into: {message}"
+        );
+        assert!(message.contains("\\u{200d}"), "message was: {message}");
     }
 
     #[tokio::test]

--- a/crates/mcp-skill/src/output_path.rs
+++ b/crates/mcp-skill/src/output_path.rs
@@ -8,6 +8,7 @@
 //! confinement already used by [`crate::scan_tools_directory`], adapted for
 //! a target that may not exist yet.
 
+use mcp_execution_core::untrusted::sanitize_untrusted_inline;
 use mcp_execution_core::{
     ConfinementError, ConfinementTarget, resolve_confined_path, sanitize_path_for_error,
     validate_server_id_slug,
@@ -26,7 +27,12 @@ pub enum OutputPathError {
     /// enforced.
     #[error("invalid server_id {server_id:?}: {source}")]
     InvalidServerId {
-        /// The rejected server id.
+        /// Sanitized display form of the rejected server id (see
+        /// [`mcp_execution_core::untrusted::sanitize_untrusted_inline`]). The `{server_id:?}`
+        /// (`Debug`) formatting above is a required second layer of defense on top of that
+        /// sanitization, not incidental — see
+        /// [`mcp_execution_core::ServerIdError`]'s doc comment for why it must not be
+        /// "simplified" to `{server_id}` (`Display`).
         server_id: String,
         /// The specific slug-format violation.
         #[source]
@@ -262,7 +268,7 @@ pub async fn resolve_skill_output_path(
     // (`resolve_confined_path` re-validates it a second time, against the looser structural rule,
     // as part of its own walk).
     validate_server_id_slug(server_id).map_err(|source| OutputPathError::InvalidServerId {
-        server_id: server_id.to_string(),
+        server_id: sanitize_untrusted_inline(server_id),
         source,
     })?;
 
@@ -417,6 +423,68 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Issue #451: printable-but-disallowed characters (`&`, `<`, `>`) in a rejected `server_id`
+    /// must not reach the error message unescaped — `validate_server_id_slug` rejects every
+    /// character outside `[a-z0-9-]`, so any of these reaches `InvalidServerId` directly.
+    #[tokio::test]
+    async fn server_id_with_hostile_characters_is_escaped_in_error() {
+        let base = TempDir::new().unwrap();
+        for (candidate, escaped) in [
+            ("server&name", "server&amp;name"),
+            ("server<name", "server&lt;name"),
+            ("server>name", "server&gt;name"),
+        ] {
+            let err = resolve_skill_output_path(base.path(), candidate, None)
+                .await
+                .unwrap_err();
+            let message = err.to_string();
+            assert!(!message.contains(candidate), "{message:?}");
+            assert!(message.contains(escaped), "{message:?}");
+        }
+    }
+
+    /// S2: an emoji carries no structural or injection risk on its own, so it must appear in the
+    /// error message unchanged rather than being mangled — unlike `&`/`<`/`>` above.
+    #[tokio::test]
+    async fn server_id_with_emoji_is_left_unchanged_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(base.path(), "server\u{1F600}name", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("server\u{1F600}name"));
+    }
+
+    /// A legitimate non-ASCII script character carries no structural or injection risk either,
+    /// so — like the emoji above — it must survive `sanitize_untrusted_inline` unchanged, even
+    /// though `validate_server_id_slug`'s `[a-z0-9-]` charset still rejects it.
+    #[tokio::test]
+    async fn server_id_with_non_ascii_script_is_left_unchanged_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(base.path(), "café_日本語", None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("café_日本語"));
+    }
+
+    /// `sanitize_untrusted_inline` deliberately leaves U+200D (ZERO WIDTH JOINER) untouched (see
+    /// its own doc comment), so `InvalidServerId`'s stored `server_id` field still carries a raw
+    /// ZWJ. This is only safe because `{server_id:?}` (`Debug`) formatting escapes it to
+    /// `\u{200d}` rather than emitting it verbatim — this test pins that second layer of
+    /// defense, mirroring `ServerIdError`'s equivalent regression test.
+    #[tokio::test]
+    async fn server_id_with_zwj_is_debug_escaped_in_error() {
+        let base = TempDir::new().unwrap();
+        let err = resolve_skill_output_path(base.path(), "server\u{200D}name", None)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains('\u{200D}'),
+            "raw ZWJ leaked into: {message}"
+        );
+        assert!(message.contains("\\u{200d}"), "message was: {message}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Rejected path segments and server ids were formatted with `{x:?}` (Debug) into error text without first neutralizing printable-but-disallowed characters (`&`, `<`, `>`). Applies the `sanitize_untrusted_inline` helper (added in #454) at construction time to the remaining raw sites, keeping `{field:?}` Debug formatting per that commit's documented convention (Debug provides defense-in-depth for characters the sanitizer deliberately leaves untouched, e.g. ZWJ):

- `ConfinementError::InvalidSegment` (`crates/mcp-core/src/confinement.rs`) — closes #452
- `resolve_output_dir`'s `InvalidServerId` construction (`crates/mcp-server/src/output_dir.rs`) — closes #450
- the equivalent in `crates/mcp-skill/src/output_path.rs` — closes #451

Closes #450, #451, #452.

## Note on scope change

This PR originally also closed #446 via a different helper (`sanitize_segment_for_error`, manually-quoted Display formatting). While the PR was open, `master` landed #454, which independently closed #446 (and #445) with a different, now-canonical design (`sanitize_untrusted_inline`, keeps Debug formatting deliberately). Rebased onto that and reconciled by hand: dropped the redundant #446 work and withdrawn helper entirely, and reworked the remaining #450/#451/#452 sites to match #454's established convention instead of introducing a second escaping scheme. Added regression tests (including a ZWJ Debug-escaping guard at each site, mirroring #454's own test) covering `&`, `<`, `>`, emoji-passthrough, and legitimate non-ASCII text.

A related but out-of-scope defect (`crates/mcp-server/src/service.rs` interpolates a caller-supplied tool name into LLM-facing error text with no escaping at all) was found during the original review and filed separately as #460.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1354/1354)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Rebased onto latest `master` (includes #454); diff scoped to exactly `CHANGELOG.md` + the 3 site files, `types.rs`/`path.rs`/`lib.rs` byte-identical to master