### PR TITLE
fix(server): sanitize categorized-tools error messages and split not-found/ambiguous cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-server`**: a `categorized_tools` entry whose `name` cannot be resolved to a raw
+  introspected tool now reports which of two distinct causes applies, instead of one message
+  covering both regardless of which occurred: "not found in introspected tools" when no raw tool
+  produces that display key at all, versus a separate "ambiguous" message when the key is shared
+  by two or more raw tools whose display forms collided (only reachable via
+  `sanitize_untrusted_text`'s truncation, per `validate_categorized_tools`'s S3 doc comment).
+  Not-found remains the common case for a genuinely mistyped or stale name; distinguishing it from
+  the rare ambiguous case just gives the caller a more actionable message either way (#456).
 - **`mcp-execution-core`**: `validate_env_name` now rejects any environment variable name that
   does not match the conventional POSIX/Windows identifier charset `[A-Za-z_][A-Za-z0-9_]*`,
   before the forbidden-name comparison runs. The prior ASCII-case-insensitive comparison (#428)
@@ -508,6 +516,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mcp-execution-cli` user rejecting an id/name containing `&`/`<`/`>` now sees the entity-escaped
   form in their terminal too (e.g. `invalid server id "my&amp;server"` rather than
   `"my&server"`) — an accepted, intentional trade-off rather than a regression (#446).
+- **`mcp-execution-server`**: `save_categorized_tools`'s `validate_categorized_tools` no longer
+  echoes a rejected `categorized_tools` entry's `name` raw into `McpError::invalid_params` text.
+  At the not-found/ambiguous branch specifically, `cat_tool.name` has not yet passed the
+  `MAX_CATEGORIZED_TOOL_NAME_LEN` check — that runs later, only for entries that already resolved
+  to a raw tool — and the `#[schemars(length(max = 128))]` on `CategorizedTool::name` is schema
+  metadata that `serde` itself never enforces, so at this point the value is bounded by nothing
+  but the transport frame and `sanitize_untrusted_inline`'s own `MAX_UNTRUSTED_FIELD_LEN`
+  truncation (500 chars, up to 2500 once escaped). That not-found branch could previously carry
+  attacker-controlled markup or a boundary delimiter straight into the returned text, unbounded in
+  length. The other three sites this change also sanitizes — ambiguous-display-name,
+  duplicate-entry, and the per-field length-cap messages — are not reachable with hostile content
+  in practice, since reaching them requires `cat_tool.name` to already equal a `ToolName`-validated
+  display key (see the `seen_raw_names` code comment); they're sanitized anyway for a single
+  consistent code path. Every one of these messages now interpolates the same
+  `untrusted::sanitize_untrusted_inline` form #446 introduced for `ServerIdError`/`ToolNameError`,
+  applied once per entry and reused across all four error sites (#460).
 - **`mcp-execution-cli`**: `runner::init_logging` now applies the same `cap_rmcp_log_level`
   treatment to both the non-verbose (`RUST_LOG`-driven) and `--verbose` branches. The `--verbose`
   branch previously set a bare `EnvFilter::new("debug")` with no `RUST_LOG` involved at all —

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -1306,8 +1306,9 @@ type CategorizedToolsValidation<'p> =
 /// keep only the last one, misattributing one tool's categorization to a different tool's
 /// `_meta.json` entry with no error surfaced. Instead, `owners` tracks every raw name that could
 /// produce each key, and any key with more than one distinct owner is dropped from
-/// `display_to_raw` entirely, so a caller trying to use it hits the "not found" branch below
-/// explicitly.
+/// `display_to_raw` entirely and recorded in `ambiguous_display_keys`, so a caller trying to use
+/// it hits the ambiguous-key branch below with a message distinguishable from a plain
+/// not-found (issue #456).
 ///
 /// Since issue #433, `ToolName::new`'s Unicode-identifier allowlist rejects every character
 /// [`display_tool_name`] would otherwise transform, so this collision is reachable only via
@@ -1339,16 +1340,18 @@ fn validate_categorized_tools<'p>(
             .or_default()
             .insert(raw);
     }
-    let display_to_raw: HashMap<String, &str> = display_key_owners
-        .into_iter()
-        .filter_map(|(key, owners)| {
-            if owners.len() == 1 {
-                owners.into_iter().next().map(|raw| (key, raw))
-            } else {
-                None
+    let mut display_to_raw: HashMap<String, &str> =
+        HashMap::with_capacity(display_key_owners.len());
+    let mut ambiguous_display_keys: HashSet<String> = HashSet::new();
+    for (key, owners) in display_key_owners {
+        if owners.len() == 1 {
+            if let Some(raw) = owners.into_iter().next() {
+                display_to_raw.insert(key, raw);
             }
-        })
-        .collect();
+        } else {
+            ambiguous_display_keys.insert(key);
+        }
+    }
 
     // A legitimate call can never submit more entries than there are introspected tools.
     // Reject early, before any per-entry validation, HashMap insertion, or codegen work
@@ -1395,48 +1398,70 @@ fn validate_categorized_tools<'p>(
     let mut categories: HashMap<String, usize> = HashMap::with_capacity(tool_count);
 
     for cat_tool in categorized_tools {
+        // `cat_tool.name` is caller-supplied and, at the not-found/ambiguous branch below,
+        // genuinely unbounded: the `MAX_CATEGORIZED_TOOL_NAME_LEN` check runs later in this loop
+        // and only for entries that already resolved to a raw tool, and `CategorizedTool::name`'s
+        // `#[schemars(length(max = 128))]` is schema metadata that `serde` itself never enforces.
+        // So the only bound in effect here is `sanitize_untrusted_inline`'s own
+        // `MAX_UNTRUSTED_FIELD_LEN` truncation. Every error message that echoes `cat_tool.name`
+        // back must use this sanitized form instead of the raw value (issue #460), matching the
+        // same escaping `display_tool_name` applies to introspected names.
+        let sanitized_name = sanitize_untrusted_inline(&cat_tool.name);
+
         let Some(&raw_name) = display_to_raw.get(cat_tool.name.as_str()) else {
-            return Err(McpError::invalid_params(
+            let message = if ambiguous_display_keys.contains(cat_tool.name.as_str()) {
                 format!(
-                    "Tool '{}' not found in introspected tools (or its sanitized display \
-                     name is ambiguous between two or more introspected tools)",
-                    cat_tool.name
-                ),
-                None,
-            ));
+                    "Tool '{sanitized_name}' could not be resolved because its sanitized \
+                     display name is ambiguous between two or more introspected tools"
+                )
+            } else {
+                format!("Tool '{sanitized_name}' not found in introspected tools")
+            };
+            return Err(McpError::invalid_params(message, None));
         };
 
         if !seen_raw_names.insert(raw_name) {
+            // Reaching this branch requires `cat_tool.name` to already equal a key in
+            // `display_to_raw`, which is only ever built from `ToolName`-validated raw names -
+            // so `sanitized_name` is an identity transform here in practice (the identifier
+            // allowlist excludes every character entity-escaping would touch, and a name long
+            // enough to hit `sanitize_untrusted_text`'s truncation would already have been
+            // rejected by `check_categorized_field_length` on its first occurrence). This is a
+            // no-op today, not a hedge against future allowlist drift: if a disallowed character
+            // were ever readmitted, `display_tool_name` would already have escaped it once when
+            // building `display_to_raw`'s key, and `cat_tool.name` has to equal that escaped key
+            // to reach this branch at all - re-sanitizing an already-escaped value here would
+            // double-escape (`&amp;` -> `&amp;amp;`), not protect. Sanitized anyway purely to keep
+            // one code path across all three branches.
             return Err(McpError::invalid_params(
                 format!(
-                    "Tool '{}' appears more than once in categorized_tools (resolves to \
-                     the same introspected tool as an earlier entry)",
-                    cat_tool.name
+                    "Tool '{sanitized_name}' appears more than once in categorized_tools \
+                     (resolves to the same introspected tool as an earlier entry)"
                 ),
                 None,
             ));
         }
 
         check_categorized_field_length(
-            &cat_tool.name,
+            &sanitized_name,
             "name",
             &cat_tool.name,
             MAX_CATEGORIZED_TOOL_NAME_LEN,
         )?;
         check_categorized_field_length(
-            &cat_tool.name,
+            &sanitized_name,
             "category",
             &cat_tool.category,
             MAX_CATEGORY_LEN,
         )?;
         check_categorized_field_length(
-            &cat_tool.name,
+            &sanitized_name,
             "keywords",
             &cat_tool.keywords,
             MAX_KEYWORDS_LEN,
         )?;
         check_categorized_field_length(
-            &cat_tool.name,
+            &sanitized_name,
             "short_description",
             &cat_tool.short_description,
             MAX_SHORT_DESCRIPTION_LEN,
@@ -1453,6 +1478,10 @@ fn validate_categorized_tools<'p>(
 /// wording each check used before this helper existed: the tool's own `name` field
 /// renders as `Tool name '<name>'`, every other field as `<field_label> for tool
 /// '<name>'`.
+///
+/// `tool_name` is echoed verbatim into the error message, so callers must pass an
+/// already-sanitized display form (e.g. [`sanitize_untrusted_inline`]) rather than a raw,
+/// caller-supplied value - see issue #460.
 fn check_categorized_field_length(
     tool_name: &str,
     field_label: &str,
@@ -3146,6 +3175,84 @@ mod tests {
         assert!(err.message.contains("appears more than once"));
     }
 
+    /// Regression guard for issue #460: a `categorized_tools` entry whose `name` matches no
+    /// introspected tool falls straight into the not-found branch without ever being compared
+    /// against a `ToolName`-validated raw name, so unlike the duplicate/ambiguous branches below
+    /// it is reachable with entirely attacker-controlled content - markup and all. The rejected
+    /// value must be entity-escaped in the error text, not echoed raw.
+    #[tokio::test]
+    async fn test_save_categorized_tools_not_found_error_sanitizes_hostile_name() {
+        let service = GeneratorService::new();
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(1))
+            .await
+            .unwrap();
+
+        let hostile_name = "<script>alert(1)</script>&pwned";
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool(hostile_name)],
+        };
+
+        let result = service
+            .save_categorized_tools(Parameters(params), CancellationToken::new())
+            .await;
+
+        let err = result.expect_err("an unmatched hostile tool name must be rejected");
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            !err.message.contains("<script>") && !err.message.contains("</script>"),
+            "raw markup must not reach the error message: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("&lt;script&gt;") && err.message.contains("&amp;pwned"),
+            "the rejected name must be entity-escaped in the error message: {}",
+            err.message
+        );
+        assert!(err.message.contains("not found in introspected tools"));
+        assert!(
+            !err.message.contains("ambiguous"),
+            "a plain not-found is not the same failure as an ambiguous match and must not \
+             reuse its wording: {}",
+            err.message
+        );
+    }
+
+    /// Regression guard for issue #460: a not-found `name` well past
+    /// `MAX_UNTRUSTED_FIELD_LEN` (500 chars) must still be rejected safely - the error message
+    /// reflects the truncated, sanitized form rather than growing unbounded with the input.
+    #[tokio::test]
+    async fn test_save_categorized_tools_not_found_error_truncates_oversized_hostile_name() {
+        let service = GeneratorService::new();
+        let session_id = service
+            .state
+            .store(pending_with_tool_count(1))
+            .await
+            .unwrap();
+
+        let hostile_name = "<".repeat(5000);
+        let params = SaveCategorizedToolsParams {
+            session_id,
+            categorized_tools: vec![categorized_tool(&hostile_name)],
+        };
+
+        let result = service
+            .save_categorized_tools(Parameters(params), CancellationToken::new())
+            .await;
+
+        let err = result.expect_err("an unmatched oversized hostile tool name must be rejected");
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            !err.message.contains('<'),
+            "raw markup must not reach the error message: {}",
+            err.message.chars().take(80).collect::<String>()
+        );
+        assert!(err.message.contains("&lt;"));
+        assert!(err.message.contains("not found in introspected tools"));
+    }
+
     // ========================================================================
     // save_categorized_tools Session Survival Tests (issue #371)
     // ========================================================================
@@ -3606,9 +3713,17 @@ mod tests {
              not silently resolved to one of them",
         );
         assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        // #456: the ambiguous case must be distinguishable from a plain not-found - not just
+        // one message covering both possibilities.
         assert!(
-            err.message.contains("not found") || err.message.contains("ambiguous"),
+            err.message.contains("ambiguous"),
             "error message should explain the ambiguity: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("not found in introspected tools"),
+            "an ambiguous match is not the same failure as a plain not-found and must not \
+             reuse its wording: {}",
             err.message
         );
     }

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -196,27 +196,44 @@ issue #381).
    identity function — raw and display keys coincide. If two **distinct** raw
    tool names still collide on the same display key (reachable today only via
    truncation past `MAX_UNTRUSTED_FIELD_LEN`), that key is dropped from the
-   lookup entirely — genuinely ambiguous, so a caller using it hits "not found"
-   rather than silently having one raw tool's categorization misattributed to
-   another's. Each `categorized_tools` entry's `name` is resolved through this
-   lookup to a raw tool name once; both the duplicate check and the codegen
-   categorization map are keyed by that **resolved raw name**, not the submitted
-   string. This fixes a categorization-lookup desync (issue #307): an earlier
-   version built the categorization map keyed by the submitted display string
-   while codegen looked up tools by their raw name, silently dropping
-   category/keywords/description for any tool name containing a control
-   character, line terminator, or `&`/`<`/`>`. Rejects: more entries than
+   `display_to_raw` lookup entirely and recorded separately in
+   `ambiguous_display_keys` — genuinely ambiguous, so a caller using it gets an
+   error distinguishable from a plain not-found (issue #456) rather than
+   silently having one raw tool's categorization misattributed to another's.
+   Each `categorized_tools` entry's `name` is resolved through this lookup to a
+   raw tool name once; both the duplicate check and the codegen categorization
+   map are keyed by that **resolved raw name**, not the submitted string. This
+   fixes a categorization-lookup desync (issue #307): an earlier version built
+   the categorization map keyed by the submitted display string while codegen
+   looked up tools by their raw name, silently dropping category/keywords/
+   description for any tool name containing a control character, line
+   terminator, or `&`/`<`/`>`. Every error that echoes `cat_tool.name` back —
+   not-found, ambiguous, duplicate, and the field-length checks below — first
+   passes it through `sanitize_untrusted_inline` (issue #460). Only the
+   not-found/ambiguous branch is actually reachable with attacker-controlled
+   content: at that point `cat_tool.name` has not yet passed the
+   `MAX_CATEGORIZED_TOOL_NAME_LEN` check (which runs later, only for entries that
+   already resolved to a raw tool) and `CategorizedTool::name`'s
+   `#[schemars(length(max = 128))]` is schema metadata `serde` never enforces —
+   so before this fix, an unmatched name could carry markup or a boundary
+   delimiter into the returned text, unbounded except by
+   `sanitize_untrusted_inline`'s own `MAX_UNTRUSTED_FIELD_LEN` truncation. The
+   other three sites are sanitized too, but only for one consistent code path:
+   reaching them requires `cat_tool.name` to already equal a `ToolName`-validated
+   display key, which cannot carry the characters entity-escaping would change.
+   Rejects: more entries than
    `min(introspected count, MAX_TOOL_FILES)` (reusing
    `mcp_execution_skill::MAX_TOOL_FILES` so this stage can never generate more
    tool files than `generate_skill` will later accept — bounded by the true
    introspected tool count, not by the lookup's size, since an ambiguous key is
    excluded from the map); a name that doesn't resolve to any raw tool (unknown,
-   or an ambiguous display key); a name that resolves to a raw tool a previous
-   entry in the same call already claimed; any field
-   (`name`/`category`/`keywords`/`short_description`) over its own byte cap
-   (`MAX_CATEGORIZED_TOOL_NAME_LEN`=128, `MAX_CATEGORY_LEN`=100,
+   or an ambiguous display key — two distinguishable error messages); a name
+   that resolves to a raw tool a previous entry in the same call already
+   claimed; any field (`name`/`category`/`keywords`/`short_description`) over
+   its own byte cap (`MAX_CATEGORIZED_TOOL_NAME_LEN`=128, `MAX_CATEGORY_LEN`=100,
    `MAX_KEYWORDS_LEN`=500, `MAX_SHORT_DESCRIPTION_LEN`=320 — each checked via a
-   single private `check_categorized_field_length` helper called once per field).
+   single private `check_categorized_field_length` helper called once per
+   field, given the already-sanitized display name rather than the raw one).
 3. `generate_and_export` runs the rest of the pipeline against the now-owned
    `pending`, **borrowed** (not consumed) so the caller can hand it back on failure:
    resolves and confines `output_dir` fresh, right here — not from any value cached


### PR DESCRIPTION
## Summary
- Sanitizes `cat_tool.name` via `sanitize_untrusted_inline` before embedding it in `save_categorized_tools`/`validate_categorized_tools` error messages, closing an unescaped-echo path at the not-found branch where the name has not yet passed length validation.
- Splits the previously-combined "not found (or ambiguous)" error in `validate_categorized_tools` into two distinguishable causes: not-found vs. ambiguous display name.

Closes #460, #456

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1344/1344)
- [x] `cargo test --doc --all-features --workspace`
- [x] New tests cover hostile-character sanitization at the not-found/duplicate sites, the not-found/ambiguous message distinction, and >500-char truncation