### PR TITLE
Close test-coverage gap in codegen error wrapper; adopt #[expect] for new lint suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to behavior, output ordering, or error conditions. The workspace-wide `too_many_lines` allow is
   removed from the root `Cargo.toml`; the two test functions that still legitimately exceed the
   threshold now carry a narrow, rationale-commented item-level allow instead (#443).
+- **`mcp-execution-codegen`**, **`mcp-execution-server`**: the two item-level
+  `#[allow(clippy::too_many_lines)]` test-function attributes added by #443 are now
+  `#[expect(clippy::too_many_lines, reason = "...")]`, preserving the same rationale text. Adopted
+  as the convention going forward for new item-level lint suppressions — `#[expect]` emits its own
+  warning if the lint stops firing, catching a suppression that has outlived its justification
+  instead of letting it go stale silently — and documented in `specs/constitution.md` §IV. This is
+  a forward-looking convention only: the 10 other pre-existing `#[allow(...)]` sites elsewhere in
+  the workspace are intentionally left unmigrated, a candidate for a separate follow-up if a full
+  migration is wanted (#459).
 - **`mcp-execution-core`**: added `validate_server_id_slug`, `ServerIdSlugError`, and
   `MAX_SERVER_ID_LENGTH` — the authoritative, core-owned invariant for a slug-shaped server id
   (1-64 lowercase ASCII letters, digits, or hyphens), distinct from `ServerId::new()`'s own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under different historical labels (plain name, formerly-ampersand, formerly-angle-bracket,
   single-display-form) into one end-to-end test plus one direct `display_tool_name` unit
   assertion, following the `display_forms` removal above (#447).
+- **`mcp-execution-codegen`**: added
+  `test_generate_with_categories_wraps_non_object_schema_as_script_generation_error`, an
+  integration test driving a real per-tool failure through the public
+  `generate_with_categories` entry point rather than only through unit tests calling the private
+  `wrap_tool_generation_error`/`add_tracked` helpers directly. Of the three `emit_tool_files`
+  stages the error wrapper covers, `extract property schema` can't fail through this entry point
+  (`extract_properties` always yields well-typed `name`/`type` strings); `render tool template`
+  and `track generated tool file` are both reachable, but only from a structurally invalid
+  `ServerInfo` a real MCP server round-trip can never produce (`mcp-introspector` always builds
+  `input_schema` as a JSON object, and bounds schema size far below what `track` needs to trip) —
+  i.e. only from a direct library caller hand-building a `ToolInfo`. The test exercises `render`:
+  a JSON-array `input_schema` fails `tool.ts.hbs`'s `{{#if input_schema.description}}` path
+  navigation under Handlebars strict mode, reaching the wrapper at effectively no cost, unlike
+  forcing `track`'s byte-count check (#458).
 
 ### Security
 

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -1598,9 +1598,12 @@ fn test_runtime_bridge_times_out_when_server_never_replies() {
 ///
 /// Skips (does not fail) when `tsc` or `node` is not on `PATH`.
 #[test]
-// One end-to-end scenario (generate -> embed fake out-of-order MCP server -> compile -> run ->
-// assert) whose fake-server script and assertions must stay in one body to remain readable.
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "One end-to-end scenario (generate -> embed fake out-of-order MCP server -> \
+              compile -> run -> assert) whose fake-server script and assertions must stay in \
+              one body to remain readable."
+)]
 fn test_runtime_bridge_dispatches_concurrent_out_of_order_responses_by_request_id() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -4,9 +4,10 @@
 //! for progressive loading pattern.
 
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
-use mcp_execution_core::{ServerId, ToolName};
+use mcp_execution_core::{Error, ServerId, ToolName};
 use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
 use serde_json::json;
+use std::collections::HashMap;
 use std::process::Command;
 
 /// Creates a mock server info for testing.
@@ -102,6 +103,59 @@ fn test_progressive_generator_creates_correct_number_of_files() {
     // - 1 tsconfig.json
     // - 1 _meta.json
     assert_eq!(code.file_count(), 8);
+}
+
+/// Issue #458: the per-tool error wrapper in `emit_tool_files` (extract/render/track stages)
+/// was previously only exercised by unit tests calling the private wrapper helper directly,
+/// never by a real failure driven through the public `generate_with_categories` entry point.
+///
+/// Of the three stages, `extract property schema` can't fail through this entry point:
+/// `extract_properties` always yields well-typed `name`/`type` strings regardless of input.
+/// `render tool template` and `track generated tool file` are both reachable, but only from a
+/// structurally invalid `ServerInfo` that `mcp-introspector` itself can never produce (it always
+/// builds `input_schema` as a JSON object, and bounds schema size far below what `track` needs
+/// to trip) — i.e. only from a direct library caller that hand-builds a `ToolInfo`, not from a
+/// real MCP server round-trip. This test exercises `render`: `TemplateEngine` runs in Handlebars
+/// strict mode, and `tool.ts.hbs` does `{{#if input_schema.description}}` — a JSON *array*
+/// `input_schema` fails that path navigation (only objects/scalars survive it), at effectively
+/// no cost, unlike forcing the `track` stage's byte-count check.
+#[test]
+fn test_generate_with_categories_wraps_non_object_schema_as_script_generation_error() {
+    let server_info = ServerInfo {
+        id: ServerId::new("bulk-server").unwrap(),
+        name: "Bulk Server".to_string(),
+        version: "1.0.0".to_string(),
+        tools: vec![ToolInfo {
+            name: ToolName::new("malformed_tool").unwrap(),
+            description: String::new(),
+            input_schema: json!([1, 2, 3]),
+            output_schema: None,
+        }],
+        capabilities: ServerCapabilities {
+            supports_tools: true,
+            supports_resources: false,
+            supports_prompts: false,
+        },
+    };
+    let generator = ProgressiveGenerator::new().expect("Failed to create generator");
+
+    let result = generator.generate_with_categories(&server_info, &HashMap::new());
+
+    match result {
+        Err(Error::ScriptGenerationError {
+            tool,
+            message,
+            source,
+        }) => {
+            assert_eq!(tool, "malformed_tool");
+            assert_eq!(message, "failed to render tool template");
+            assert!(
+                source.is_some(),
+                "source must be preserved for exit-code classification"
+            );
+        }
+        other => panic!("expected ScriptGenerationError wrapping a render failure, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -2600,9 +2600,11 @@ mod tests {
     /// mismatched `server_id` leaking from one call's span stack into the other's
     /// events is exactly what the assertions below detect.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    // The test's length is a custom `tracing_subscriber::Layer` plus span-field capture
-    // harness that only makes sense inline with the assertions it feeds.
-    #[allow(clippy::too_many_lines)]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The test's length is a custom `tracing_subscriber::Layer` plus span-field \
+                  capture harness that only makes sense inline with the assertions it feeds."
+    )]
     async fn test_introspect_server_concurrent_calls_do_not_cross_contaminate_server_id() {
         use std::sync::{Arc, Mutex};
         use tokio::sync::Barrier;

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -81,10 +81,25 @@ related:
 
 - Clippy `all`, `cargo`, `nursery`, `pedantic` are `deny` at workspace level;
   narrow, per-crate `#[allow(...)]`s are used only where the lint's intent
-  doesn't apply (e.g. `too_many_lines` allowed item-level on two
+  doesn't apply (e.g. `too_many_lines` suppressed item-level on two
   concurrency-test functions whose length is inherent to the scenario they
-  cover; `unused_async` allowed in `mcp-cli` for uniformly-dispatched
-  handlers).
+  cover — see the `#[expect]` convention below; `unused_async` allowed in
+  `mcp-cli` for uniformly-dispatched handlers).
+- Convention going forward: new item-level lint suppressions use
+  `#[expect(lint, reason = "...")]` rather than `#[allow(lint)]` — `#[expect]`
+  emits its own warning if the lint stops firing, which surfaces a
+  suppression that has outlived its justification instead of letting it go
+  stale silently. The two `too_many_lines` sites named above use `#[expect]`
+  as the first application of this convention (issue #459); the 10 other
+  pre-existing `#[allow(...)]` sites elsewhere in the workspace are
+  intentionally left unmigrated for now — a candidate for a separate,
+  dedicated follow-up if a full migration is wanted later. Under CI's
+  `-D warnings`, an unfulfilled `#[expect]` (the lint no longer fires) is a
+  hard build failure, not a warning — this is the intended mechanism, but it
+  means a routine simplification that brings a function back under a
+  threshold like `too_many_lines` breaks the build until the now-unfulfilled
+  `#[expect]` is deleted; do not pad a function back over the threshold just
+  to keep the attribute satisfied.
 - `#![deny(unsafe_code)]` in every crate except `mcp-server`/`mcp-cli` (which
   don't need it) — no crate in this workspace uses `unsafe`.
 - `#![warn(missing_docs, missing_debug_implementations)]` everywhere: every


### PR DESCRIPTION
## Summary

- Closes #458: adds an integration test that drives a real per-tool failure through the *public* `generate_with_categories(...)` entry point, closing a coverage gap where the `emit_tool_files` error wrapper was only exercised via direct calls to a private helper. Uses a non-object `input_schema` to trip the `render` stage under Handlebars strict mode — the cheapest of the two reachable stages (`render`/`track`; `extract` is structurally unreachable via any public input).
- Closes #459: converts the two `#443` item-level `#[allow(clippy::too_many_lines)]` test-function attributes to `#[expect(clippy::too_many_lines, reason = "...")]`, preserving the original rationale.

## Decision point for maintainer review

#459 also **adopts `#[expect]` as the project convention for new item-level lint suppressions going forward**, documented in `specs/constitution.md` §IV. This is scoped narrowly:

- Only the two `#443` sites are converted in this PR.
- The 10 other pre-existing `#[allow(...)]` sites elsewhere in the workspace are **intentionally left unmigrated** — a full migration is a separate, dedicated follow-up if wanted.
- Documented that an unfulfilled `#[expect]` is a hard CI failure under `-D warnings` (not just a warning), so a future simplification that brings a function back under threshold requires deleting the now-unfulfilled attribute rather than padding the function.

This convention choice (adopt now for new sites, defer full migration) was not previously settled — flagging here for explicit sign-off rather than treating it as already decided.

## Process notes

- Went through one architecture-level fix-review cycle: impl-critic found the original #458 test's core claim ("only the track stage is publicly reachable") was empirically false — `render` is also reachable, and ~178x cheaper (0.02s/96MB vs 3.56s/1.19GB for the track-stage approach). Swapped to the cheap render-stage test and corrected the doc comment/CHANGELOG accordingly.
- Code review caught a miscount (9 vs actual 10) in the pre-existing `#[allow]` site count in both CHANGELOG.md and specs/constitution.md; corrected and re-verified via `grep`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1330/1330 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`