### PR TITLE
docs(server): clarify categorized_tools name-length check order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -466,6 +466,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `IntrospectedToolSummary`, `SaveCategorizedToolsResult`, `ToolGenerationError`,
   `ListGeneratedServersParams`, `ListGeneratedServersResult`, `GeneratedServerInfo`, and
   `PendingGeneration` (#440).
+- **`mcp-execution-server`**: clarified in the spec that `validate_categorized_tools` checks a
+  `categorized_tools` entry's `name` against `MAX_CATEGORIZED_TOOL_NAME_LEN` only after resolving
+  it through `display_to_raw`, so an oversized `name` that matches no introspected tool is
+  reported as not-found rather than too-long — an intentional, truthful trade-off, not a defect
+  (#462).
 
 ### Testing
 

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -221,6 +221,9 @@ issue #381).
    other three sites are sanitized too, but only for one consistent code path:
    reaching them requires `cat_tool.name` to already equal a `ToolName`-validated
    display key, which cannot carry the characters entity-escaping would change.
+   Consequently, a submitted `name` that exceeds `MAX_CATEGORIZED_TOOL_NAME_LEN` but
+   does not match any introspected tool will be reported as not-found, not too-long —
+   intentional, since resolution is checked before length (issue #462).
    Rejects: more entries than
    `min(introspected count, MAX_TOOL_FILES)` (reusing
    `mcp_execution_skill::MAX_TOOL_FILES` so this stage can never generate more


### PR DESCRIPTION
## Summary

- Adds a short clarifying note to `specs/server/spec.md`'s `save_categorized_tools` section explaining that `validate_categorized_tools` checks a `categorized_tools` entry's `name` against `MAX_CATEGORIZED_TOOL_NAME_LEN` only after resolving it via `display_to_raw` — so an oversized `name` that doesn't match any introspected tool is reported as not-found rather than too-long
- This ordering is intentional: the not-found message remains truthful, and reordering the check would add complexity to already-intricate resolution logic (ambiguous-key detection, sanitization ordering per #460) for a cosmetic wording improvement with no correctness or security impact
- Updates `CHANGELOG.md` under `[Unreleased] / Documentation`

Docs-only change — no source files touched.

Closes #462

## Test plan

- [x] Verified the clarifying sentence against `crates/mcp-server/src/service.rs` (`validate_categorized_tools`, `check_categorized_field_length`) — confirmed the not-found/ambiguous branch runs strictly before the length check for the `name` field
- [x] Confirmed only `specs/server/spec.md` and `CHANGELOG.md` are touched (`git diff --stat`)
- N/A: no code changes, so no build/lint/test/doc-build gates apply