### PR TITLE
docs(server,cli): add rustdoc Examples to output_dir and generate::run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,6 +476,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it through `display_to_raw`, so an oversized `name` that matches no introspected tool is
   reported as not-found rather than too-long — an intentional, truthful trade-off, not a defect
   (#462).
+- **`mcp-execution-server`**, **`mcp-execution-cli`**: added `# Examples` doc-test sections to
+  `relative_subpath`, `resolve_output_dir`, and `generate::run`. `output_dir::relative_subpath`,
+  `output_dir::resolve_output_dir`, and `OutputDirError` are now re-exported from
+  `mcp-execution-server`'s crate root — the `output_dir` module is private, so these `pub fn`
+  items were otherwise unreachable outside the crate, mirroring the existing
+  `resolve_skill_output_path`/`OutputPathError` re-export pattern in `mcp-execution-skill`
+  (#472).
 
 ### Testing
 

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -111,6 +111,52 @@ fn format_size(bytes: usize) -> String {
 /// - Tool introspection fails
 /// - Code generation fails
 /// - File export fails (skipped in dry-run mode)
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_cli::commands::common::{ServerSource, TransportArgs};
+/// use mcp_execution_cli::commands::generate;
+/// use mcp_execution_core::cli::OutputFormat;
+/// use std::path::PathBuf;
+///
+/// # async fn example() -> anyhow::Result<()> {
+/// // Generate from a stdio transport
+/// let exit_code = generate::run(
+///     ServerSource::Flags {
+///         transport: TransportArgs::Stdio {
+///             command: "github-mcp-server".to_string(),
+///             args: vec![],
+///             env: vec![],
+///             cwd: None,
+///         },
+///         connect_timeout_secs: None,
+///         discover_timeout_secs: None,
+///     },
+///     None,
+///     None,
+///     false,
+///     OutputFormat::Pretty
+/// ).await?;
+///
+/// // Generate with custom output directory and name override
+/// let exit_code = generate::run(
+///     ServerSource::Flags {
+///         transport: TransportArgs::Http {
+///             url: "https://api.example.com/mcp/".to_string(),
+///             headers: vec!["Authorization=Bearer token".to_string()],
+///         },
+///         connect_timeout_secs: Some(10),
+///         discover_timeout_secs: Some(30),
+///     },
+///     Some("my-custom-name".to_string()),
+///     Some(PathBuf::from("/tmp/generated")),
+///     false,
+///     OutputFormat::Json
+/// ).await?;
+/// # Ok(())
+/// # }
+/// ```
 pub async fn run(
     source: ServerSource,
     name: Option<String>,

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -57,6 +57,7 @@ pub mod state;
 pub mod types;
 
 pub use clock::{Clock, SystemClock};
+pub use output_dir::{OutputDirError, relative_subpath, resolve_output_dir};
 pub use service::GeneratorService;
 pub use state::StateManager;
 pub use types::{

--- a/crates/mcp-server/src/output_dir.rs
+++ b/crates/mcp-server/src/output_dir.rs
@@ -161,6 +161,29 @@ impl From<ConfinementError> for OutputDirError {
 ///
 /// Returns [`OutputDirError::AbsolutePath`] if `output_dir` is absolute, or
 /// [`OutputDirError::ParentTraversal`] if it contains a `..` component.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_server::relative_subpath;
+/// use std::path::Path;
+///
+/// // No override: returns empty path (use server_id's directory directly)
+/// let result = relative_subpath(None).unwrap();
+/// assert!(result.as_os_str().is_empty());
+///
+/// // Relative subdirectory: valid and accepted
+/// let result = relative_subpath(Some(Path::new("nested/custom"))).unwrap();
+/// assert_eq!(result.to_str().unwrap(), "nested/custom");
+///
+/// // Absolute path: rejected
+/// let err = relative_subpath(Some(Path::new("/etc/config"))).unwrap_err();
+/// assert!(err.to_string().contains("absolute"));
+///
+/// // Parent traversal: rejected
+/// let err = relative_subpath(Some(Path::new("../../etc"))).unwrap_err();
+/// assert!(err.to_string().contains(".."));
+/// ```
 pub fn relative_subpath(output_dir: Option<&Path>) -> Result<PathBuf, OutputDirError> {
     let Some(path) = output_dir else {
         return Ok(PathBuf::new());
@@ -230,6 +253,26 @@ pub fn relative_subpath(output_dir: Option<&Path>) -> Result<PathBuf, OutputDirE
 /// symlink, if the resolved path escapes `base_dir`, if a required directory could not be
 /// created, or if a path component that must be a directory already exists as the wrong kind of
 /// entry.
+///
+/// # Examples
+///
+/// ```no_run
+/// use mcp_execution_server::{resolve_output_dir, OutputDirError};
+/// use std::path::Path;
+///
+/// # async fn example() -> Result<(), OutputDirError> {
+/// let base_dir = Path::new("/home/user/.claude/servers");
+///
+/// // Resolve with no subdirectory override (uses server_id's directory directly)
+/// let resolved = resolve_output_dir(base_dir, "github", None).await?;
+/// println!("Resolved to {}", resolved.display());
+///
+/// // Resolve with custom subdirectory
+/// let resolved = resolve_output_dir(base_dir, "github", Some(Path::new("custom"))).await?;
+/// println!("Resolved to {}", resolved.display());
+/// # Ok(())
+/// # }
+/// ```
 pub async fn resolve_output_dir(
     base_dir: &Path,
     server_id: &str,

--- a/crates/mcp-server/src/output_dir.rs
+++ b/crates/mcp-server/src/output_dir.rs
@@ -176,8 +176,10 @@ impl From<ConfinementError> for OutputDirError {
 /// let result = relative_subpath(Some(Path::new("nested/custom"))).unwrap();
 /// assert_eq!(result.to_str().unwrap(), "nested/custom");
 ///
-/// // Absolute path: rejected
-/// let err = relative_subpath(Some(Path::new("/etc/config"))).unwrap_err();
+/// // Absolute path: rejected. `Path::is_absolute()` requires a drive prefix on Windows, so
+/// // the path used here must be genuinely absolute on the current platform.
+/// let absolute = if cfg!(windows) { r"C:\Windows\System32\config" } else { "/etc/config" };
+/// let err = relative_subpath(Some(Path::new(absolute))).unwrap_err();
 /// assert!(err.to_string().contains("absolute"));
 ///
 /// // Parent traversal: rejected


### PR DESCRIPTION
## Summary
- Add a `# Examples` doctest section to `relative_subpath` and `resolve_output_dir` in `crates/mcp-server/src/output_dir.rs`, and to `generate::run` in `crates/mcp-cli/src/commands/generate.rs` — the three public functions were missing them despite having full `# Errors` documentation, inconsistent with sibling functions in the same crates.
- Re-export `OutputDirError`, `relative_subpath`, and `resolve_output_dir` from `mcp-execution-server`'s crate root, since `output_dir` is a private module and these `pub fn` items were otherwise unreachable outside the crate. This mirrors the existing `resolve_skill_output_path`/`OutputPathError` re-export pattern already used in `mcp-execution-skill`.
- No behavior or signature changes.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1357 passed)
- [x] `cargo test --doc --all-features --workspace` (new doctests confirmed running, not skipped)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`

Closes #472