### PR TITLE
fix(server): exclude index.ts from list_generated_servers tool_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-server`**: `list_generated_servers`'s `tool_count` no longer over-reports by
+  one for every generated server. The directory-scan filter counted every `.ts` file not starting
+  with `_`, which included `index.ts` — the package's always-present re-export entry point,
+  itself not a tool — alongside the actual per-tool `.ts` files. The exclusion now also covers
+  `index.ts`, compared case-insensitively to match `disambiguate_output_filename`'s existing
+  case-insensitive handling of `index` (#312). The filename itself now lives in a single shared
+  `mcp_execution_core::metadata::INDEX_FILE_NAME` constant, replacing a bare string literal in
+  `mcp-execution-codegen` and a locally-scoped duplicate constant in `mcp-execution-skill` (#477).
 - **`mcp-execution-skill`, `mcp-execution-cli`**: the `skill` command's `--hint` flag now has a
   real effect on the generated `SKILL.md`. Previously, use-case hints only ever reached the
   LLM-facing `generation_prompt` field, which `mcp-cli skill` never reads (it renders

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -42,7 +42,8 @@ use crate::progressive::types::{
 use crate::template_engine::TemplateEngine;
 use mcp_execution_core::ResourceKind;
 use mcp_execution_core::metadata::{
-    METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata, ToolMetadata,
+    INDEX_FILE_NAME, METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata,
+    ServerMetadata, ToolMetadata,
 };
 use mcp_execution_core::{Error, Result};
 use mcp_execution_introspector::{ServerInfo, ToolInfo};
@@ -480,7 +481,7 @@ impl ProgressiveGenerator<'_> {
             code,
             total_bytes,
             GeneratedFile {
-                path: "index.ts".to_string(),
+                path: INDEX_FILE_NAME.to_string(),
                 content: index_code,
             },
         )?;

--- a/crates/mcp-core/src/metadata.rs
+++ b/crates/mcp-core/src/metadata.rs
@@ -70,6 +70,22 @@ pub const METADATA_SCHEMA_VERSION: u32 = 1;
 /// ```
 pub const METADATA_FILE_NAME: &str = "_meta.json";
 
+/// Filename of the generated re-export entry point emitted alongside per-tool files.
+///
+/// Shared between the producer (`mcp-execution-codegen`, which renders it) and its consumers
+/// (`mcp-execution-skill` and `mcp-execution-server`, which must recognize it as the package's
+/// aggregator file rather than a per-tool file) to avoid a stringly-typed filename duplicated
+/// across crates.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::metadata::INDEX_FILE_NAME;
+///
+/// assert_eq!(INDEX_FILE_NAME, "index.ts");
+/// ```
+pub const INDEX_FILE_NAME: &str = "index.ts";
+
 /// Structured sidecar describing one server's generated tools.
 ///
 /// Serialized as `_meta.json` by `mcp-execution-codegen` and deserialized by

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -14,6 +14,7 @@ use crate::types::{
     PendingGeneration, SaveCategorizedToolsParams, SaveCategorizedToolsResult,
 };
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
+use mcp_execution_core::metadata::INDEX_FILE_NAME;
 use mcp_execution_core::untrusted::{
     MAX_UNTRUSTED_FIELD_LEN, sanitize_untrusted_inline, sanitize_untrusted_text,
     wrap_untrusted_block,
@@ -824,13 +825,25 @@ impl GeneratorService {
                         if entry.path().is_dir() {
                             let id = entry.file_name().to_string_lossy().to_string();
 
-                            // Count .ts files (excluding _runtime and starting with _)
+                            // Count per-tool .ts files. Excludes `INDEX_FILE_NAME`, the
+                            // package's always-present re-export entry point, which is not
+                            // itself a tool (issue #477); compared case-insensitively to
+                            // match `disambiguate_output_filename`'s own case-insensitive
+                            // handling of `index` (issue #312), since a tool named `Index`
+                            // would otherwise collide with it on a case-insensitive
+                            // filesystem. Also excludes files starting with `_` — real
+                            // generator output never produces a top-level `_`-prefixed
+                            // `.ts` file (`_meta.json` isn't `.ts`, and the runtime bridge
+                            // lives in the `_runtime/` subdirectory), so this clause is
+                            // defensive rather than covering a file that exists today.
                             let tool_count = std::fs::read_dir(entry.path()).map_or(0, |e| {
                                 e.flatten()
                                     .filter(|f| {
                                         let name = f.file_name();
                                         let name = name.to_string_lossy();
-                                        name.ends_with(".ts") && !name.starts_with('_')
+                                        name.ends_with(".ts")
+                                            && !name.starts_with('_')
+                                            && !name.eq_ignore_ascii_case(INDEX_FILE_NAME)
                                     })
                                     .count()
                             });
@@ -4563,6 +4576,85 @@ mod tests {
         assert_eq!(parsed.total_servers, 1);
         assert_eq!(parsed.servers[0].id, "my-server");
         assert_eq!(parsed.servers[0].tool_count, 1);
+    }
+
+    /// `tool_count` must count only per-tool `.ts` files, excluding `index.ts` (the package's
+    /// always-present re-export entry point) among files real generator output actually places
+    /// at the server directory's top level — `_meta.json` (not `.ts`, so it never matches the
+    /// filter's own extension check) and the `_runtime/` subdirectory (not a file) alongside it
+    /// (issue #477).
+    #[tokio::test]
+    async fn test_list_generated_servers_tool_count_excludes_index_and_underscore_files() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let server_dir = temp_dir.path().join("my-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        tokio::fs::write(server_dir.join("index.ts"), "export {}")
+            .await
+            .unwrap();
+        tokio::fs::write(server_dir.join("_meta.json"), "{}")
+            .await
+            .unwrap();
+        let runtime_dir = server_dir.join("_runtime");
+        tokio::fs::create_dir_all(&runtime_dir).await.unwrap();
+        tokio::fs::write(runtime_dir.join("mcp-bridge.ts"), "export {}")
+            .await
+            .unwrap();
+        tokio::fs::write(server_dir.join("tool_a.ts"), "export {}")
+            .await
+            .unwrap();
+        tokio::fs::write(server_dir.join("tool_b.ts"), "export {}")
+            .await
+            .unwrap();
+
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let params = ListGeneratedServersParams { base_dir: None };
+
+        let result = service
+            .list_generated_servers(Parameters(params), CancellationToken::new())
+            .await;
+
+        assert!(result.is_ok());
+        let content = result.unwrap();
+        let text_content = content.content[0].as_text().unwrap();
+        let parsed: ListGeneratedServersResult = serde_json::from_str(&text_content.text).unwrap();
+
+        assert_eq!(parsed.servers[0].id, "my-server");
+        assert_eq!(parsed.servers[0].tool_count, 2);
+    }
+
+    /// A server directory containing only `index.ts` (no per-tool files yet) must report a
+    /// `tool_count` of zero rather than counting the entry point itself as a tool.
+    #[tokio::test]
+    async fn test_list_generated_servers_tool_count_zero_when_only_index_ts() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let server_dir = temp_dir.path().join("empty-server");
+        tokio::fs::create_dir_all(&server_dir).await.unwrap();
+        tokio::fs::write(server_dir.join("index.ts"), "export {}")
+            .await
+            .unwrap();
+
+        let service =
+            GeneratorService::new().with_servers_base_dir_for_test(temp_dir.path().to_path_buf());
+
+        let params = ListGeneratedServersParams { base_dir: None };
+
+        let result = service
+            .list_generated_servers(Parameters(params), CancellationToken::new())
+            .await;
+
+        assert!(result.is_ok());
+        let content = result.unwrap();
+        let text_content = content.content[0].as_text().unwrap();
+        let parsed: ListGeneratedServersResult = serde_json::from_str(&text_content.text).unwrap();
+
+        assert_eq!(parsed.servers[0].id, "empty-server");
+        assert_eq!(parsed.servers[0].tool_count, 0);
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/types.rs
+++ b/crates/mcp-server/src/types.rs
@@ -397,7 +397,7 @@ pub struct GeneratedServerInfo {
     /// Server identifier
     pub id: String,
 
-    /// Number of tool files (excluding runtime)
+    /// Number of tool files (excluding `index.ts` and files starting with `_`)
     pub tool_count: usize,
 
     /// Last generation timestamp

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -12,7 +12,9 @@
 //! `mcp_execution_core::metadata`, so no re-parsing of generated source is
 //! needed at all.
 
-use mcp_execution_core::metadata::{METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ServerMetadata};
+use mcp_execution_core::metadata::{
+    INDEX_FILE_NAME, METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ServerMetadata,
+};
 use regex::Regex;
 use serde::Deserialize;
 use serde_saphyr::budget::{BudgetBreach, BudgetReport};
@@ -365,9 +367,6 @@ async fn verify_tool_files_on_disk(
     tools: &[mcp_execution_core::metadata::ToolMetadata],
     meta_path: &Path,
 ) -> Result<Vec<String>, ScanError> {
-    // Generated aggregator file, not a per-tool file — never expected in the sidecar.
-    const INDEX_FILE_NAME: &str = "index.ts";
-
     let mut expected_files: std::collections::HashSet<String> =
         std::collections::HashSet::with_capacity(tools.len());
 

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -297,8 +297,12 @@ catches even a non-existent target and a Windows root-without-prefix path
 like `\pwn\evil`), then, if the joined path exists, re-checked via
 canonicalization against the canonicalized root (catches a symlink planted
 inside it). The scan itself (`spawn_blocking`, nested `read_dir`) counts
-`.ts` files per subdirectory (excluding `_`-prefixed and `_runtime`) and the
-subdirectory's mtime as `generated_at`.
+`.ts` files per subdirectory, excluding `index.ts` (the package's
+always-present re-export entry point, matched case-insensitively against
+`INDEX_FILE_NAME` for consistency with `disambiguate_output_filename`'s own
+handling of `index` — issue #477) and files starting with `_` (defensive:
+real generator output never places a `_`-prefixed `.ts` file at this level),
+and the subdirectory's mtime as `generated_at`.
 
 ### `generate_skill`
 


### PR DESCRIPTION
## Summary
- `list_generated_servers`'s `tool_count` field counted `index.ts` (the always-present package re-export entry point) alongside real per-tool `.ts` files, over-reporting by exactly one for every generated server.
- Hoisted the shared `index.ts` filename constant into `mcp_execution_core::metadata` (reused by `mcp-skill`'s sidecar verification, removing a duplicated literal) and compare case-insensitively, matching the existing tool-name disambiguation rule for a tool named "index".
- Updated `specs/server/spec.md` and the `GeneratedServerInfo::tool_count` doc comment to describe the corrected behavior.

## Test plan
- [x] `cargo nextest run --workspace -E 'package(mcp-execution-server)'` — 231/231 pass, including 2 new regression tests covering the `index.ts` exclusion and the zero-tool-files case
- [x] `cargo nextest run --workspace --all-features --no-fail-fast` — 1372/1372 pass
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo test --doc --all-features --workspace`

Closes #477