### PR TITLE
fix(cli): distinguish config-load errors and reject symlinked entries in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes to match (additive, so existing deserializers are unaffected). A caller sending
   `"use_case_hints": []` also sees a small `generation_prompt` shape change: the previously
   emitted, fully-empty `### Use Case Hints` wrapped block no longer appears (#473).
+- **`mcp-execution-cli`**: `setup`'s `check_files_executable` no longer follows symlinks while
+  walking `~/.claude/servers/` to `chmod` generated `.ts` files. Two vectors were closed: a
+  symlinked server-id directory previously let the walk descend into and `chmod` an arbitrary
+  directory elsewhere on disk, and — not covered by the original report — a symlinked `.ts` file
+  inside an otherwise legitimate server directory previously let `chmod` land on its target
+  anywhere the process could reach. Both levels of the walk now check entry kind via
+  `DirEntry::file_type()` (which does not traverse symlinks) and skip symlinked entries instead of
+  following them, mirroring the guard semantics `mcp_execution_core::confinement` already uses.
+  `SetupResult` gained a `skipped_entries: usize` field (breaking change, acceptable pre-1.0.0) so
+  a planted symlink is surfaced to the user rather than silently ignored; the walk itself is now
+  exposed as `check_files_executable_in(servers_dir: &Path)` for testing without `HOME` mutation
+  (#476).
+- **`mcp-execution-cli`**: `server validate` no longer labels every configuration-lookup failure
+  as "Server not found in configuration", even when `~/.claude/mcp.json` itself is missing or
+  malformed — the same class of mislabeling #304 fixed for entries present but failing security
+  validation, left unaddressed for the file-load path. `get_mcp_server_entry` is now split into
+  `load_mcp_config` and `lookup_server_entry`, letting `validate_command` report a config-load
+  failure with its true cause and reserve the "not found" message for a genuinely absent server
+  name, matching the framing `generate --from-config`, `server list`, and `server info` already
+  use for the same three underlying conditions (#479).
 - **`mcp-execution-server`**: a `categorized_tools` entry whose `name` cannot be resolved to a raw
   introspected tool now reports which of two distinct causes applies, instead of one message
   covering both regardless of which occurred: "not found in introspected tools" when no raw tool

--- a/crates/mcp-cli/src/commands/common.rs
+++ b/crates/mcp-cli/src/commands/common.rs
@@ -383,11 +383,16 @@ fn load_mcp_config_from(path: &Path) -> Result<McpConfig> {
 ///
 /// Delegates to [`load_mcp_config_from`] after resolving the default path.
 ///
+/// `pub(crate)` (rather than private) so callers that must distinguish "config file itself is
+/// missing/malformed" from "the config loaded but doesn't have this server" — `server
+/// validate` (#479) — can call this and [`lookup_server_entry`] separately instead of treating
+/// both failure modes as the same generic error the way [`get_mcp_server_entry`] does.
+///
 /// # Errors
 ///
 /// Returns an error if the home directory cannot be determined, the file
 /// cannot be read, or the JSON is malformed.
-fn load_mcp_config() -> Result<McpConfig> {
+pub(crate) fn load_mcp_config() -> Result<McpConfig> {
     let home = dirs::home_dir().context("failed to get home directory")?;
     load_mcp_config_from(&home.join(".claude").join("mcp.json"))
 }
@@ -488,7 +493,24 @@ pub(crate) fn get_mcp_server(name: &str) -> Result<(ServerId, ServerConfig, McpS
 /// present.
 pub(crate) fn get_mcp_server_entry(name: &str) -> Result<(ServerId, McpServerEntry)> {
     let config = load_mcp_config()?;
+    lookup_server_entry(&config, name)
+}
 
+/// Looks up `name` within an already-loaded [`McpConfig`], returning its [`ServerId`] and entry.
+///
+/// Split out from [`get_mcp_server_entry`] so callers that need "config file itself is
+/// missing/malformed" and "the config loaded but doesn't have this server" to produce distinct
+/// messages — `server validate` (#479) — can call [`load_mcp_config`] and this function
+/// separately instead of collapsing both failure modes into one generic error.
+///
+/// # Errors
+///
+/// Returns an error if the named server is not present in `config`, or its name is not a valid
+/// [`ServerId`].
+pub(crate) fn lookup_server_entry(
+    config: &McpConfig,
+    name: &str,
+) -> Result<(ServerId, McpServerEntry)> {
     let entry = config
         .mcp_servers
         .get(name)
@@ -1119,6 +1141,56 @@ mod tests {
         let result = load_mcp_config_from(file.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("parse MCP config"));
+    }
+
+    // ── config-load vs. name-lookup error distinction (#479) ──
+
+    #[test]
+    fn test_lookup_server_entry_absent_name_errors_not_found() {
+        let json = r#"{"mcpServers": {"github": {"command": "node"}}}"#;
+        let file = create_test_config(json);
+        let config = load_mcp_config_from(file.path()).unwrap();
+
+        let result = lookup_server_entry(&config, "nonexistent");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not found in ~/.claude/mcp.json")
+        );
+    }
+
+    #[test]
+    fn test_config_load_and_lookup_errors_are_distinguishable() {
+        // Regression test for #479: `server validate` used to unconditionally label every
+        // `get_mcp_server_entry` failure as "not found", even when the real problem was that
+        // `~/.claude/mcp.json` itself was missing or malformed. Config-load failures (missing
+        // file, malformed JSON) and a genuinely absent server name must produce distinct,
+        // non-overlapping messages when handled as the two separate steps `load_mcp_config`/
+        // `lookup_server_entry` now allow.
+        let missing = load_mcp_config_from(Path::new("/nonexistent/path/mcp.json"))
+            .unwrap_err()
+            .to_string();
+        assert!(missing.contains("failed to read"));
+        assert!(!missing.contains("not found in ~/.claude/mcp.json"));
+
+        let malformed_file = create_test_config("not valid json");
+        let malformed = load_mcp_config_from(malformed_file.path())
+            .unwrap_err()
+            .to_string();
+        assert!(malformed.contains("parse MCP config"));
+        assert!(!malformed.contains("not found in ~/.claude/mcp.json"));
+
+        let json = r#"{"mcpServers": {"github": {"command": "node"}}}"#;
+        let ok_file = create_test_config(json);
+        let config = load_mcp_config_from(ok_file.path()).unwrap();
+        let not_found = lookup_server_entry(&config, "missing")
+            .unwrap_err()
+            .to_string();
+        assert!(not_found.contains("not found in ~/.claude/mcp.json"));
+        assert!(!not_found.contains("failed to read"));
+        assert!(!not_found.contains("parse MCP config"));
     }
 
     // ── mixed stdio/http/sse configs (#210) ──

--- a/crates/mcp-cli/src/commands/server.rs
+++ b/crates/mcp-cli/src/commands/server.rs
@@ -6,6 +6,7 @@
 use crate::actions::ServerAction;
 use crate::commands::common::{
     McpServerEntry, McpTransport, build_core_config, get_mcp_server_entry, list_mcp_servers,
+    load_mcp_config, lookup_server_entry,
 };
 use crate::formatters::escape_error_text;
 use anyhow::{Context, Result};
@@ -324,7 +325,10 @@ async fn list_servers(output_format: OutputFormat) -> Result<ExitCode> {
 /// An entry whose `url` (or other field) fails [`build_core_config`]'s security validation is
 /// reported the same way as an entry that is well-formed but unreachable — a structured
 /// `"status": "unavailable"` [`ServerInfo`] through `output_format`, not a raw, unformatted error
-/// (#305). Only a genuinely absent entry propagates as `Err` via [`get_mcp_server_entry`].
+/// (#305). [`get_mcp_server_entry`]'s own errors — a missing/malformed `~/.claude/mcp.json` as
+/// well as a genuinely absent server name — are not caught here and still propagate as `Err`
+/// (unlike `server validate`, which distinguishes these cases into its own structured
+/// `ValidationResult`, #479).
 async fn show_server_info(server: String, output_format: OutputFormat) -> Result<ExitCode> {
     let (server_id, entry) = get_mcp_server_entry(&server)?;
     let command = build_command_string(&entry);
@@ -422,8 +426,26 @@ fn unavailable_server_info(server: String, command: String) -> ServerInfo {
 /// [`build_core_config`]'s security validation (e.g. an invalid URL scheme) is reported with a
 /// message describing that specific problem, not the "not found" message reserved for a
 /// genuinely absent entry (#304).
+///
+/// Config loading and name lookup are performed as two separate steps (via [`load_mcp_config`]
+/// and [`lookup_server_entry`], rather than the combined [`get_mcp_server_entry`]) so a missing
+/// or malformed `~/.claude/mcp.json` produces its own message instead of being collapsed into
+/// "server not found" — mirroring how `generate --from-config`/`server info`/`server list`
+/// report the same underlying conditions (#479).
 async fn validate_command(server_name: String, output_format: OutputFormat) -> Result<ExitCode> {
-    let (server_id, entry) = match get_mcp_server_entry(&server_name) {
+    let config = match load_mcp_config() {
+        Ok(config) => config,
+        Err(e) => {
+            let result = ValidationResult {
+                command: server_name,
+                valid: false,
+                message: format!("Failed to read server configuration: {e}"),
+            };
+            return crate::formatters::emit(&result, output_format, ExitCode::ERROR);
+        }
+    };
+
+    let (server_id, entry) = match lookup_server_entry(&config, &server_name) {
         Ok(result) => result,
         Err(e) => {
             let result = ValidationResult {
@@ -1300,6 +1322,71 @@ mod tests {
 
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("\"status\":\"unavailable\""));
+    }
+
+    // ── validate_command config-load vs. name-lookup error paths (#479) ──
+    //
+    // `validate_command`'s message field is only ever printed to stdout (see
+    // `with_home_pointed_at` doc comment above), so — like the #280/#304 regression tests above
+    // — these assert on `ExitCode` only. The message-content distinction itself is covered
+    // directly in `common.rs`'s `test_config_load_and_lookup_errors_are_distinguishable`; what
+    // these confirm is that all three underlying conditions (missing config file, malformed
+    // JSON, genuinely absent server name) are reachable through `validate_command` and still
+    // resolve to a structured `ExitCode::ERROR` result rather than an unhandled `Err`.
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_validate_command_missing_config_file_reports_error() {
+        // HOME points at a fresh temp dir with no `.claude/mcp.json` at all.
+        let temp = tempfile::TempDir::new().unwrap();
+
+        let result = with_home_pointed_at(temp.path(), || {
+            run(
+                ServerAction::Validate {
+                    command: "anything".to_string(),
+                },
+                OutputFormat::Json,
+            )
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), ExitCode::ERROR);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_validate_command_malformed_config_reports_error() {
+        let temp = write_test_mcp_config("not valid json");
+
+        let result = with_home_pointed_at(temp.path(), || {
+            run(
+                ServerAction::Validate {
+                    command: "anything".to_string(),
+                },
+                OutputFormat::Json,
+            )
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), ExitCode::ERROR);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_validate_command_unknown_server_name_reports_error() {
+        let temp = write_test_mcp_config(r#"{"mcpServers": {"unrelated": {"command": "node"}}}"#);
+
+        let result = with_home_pointed_at(temp.path(), || {
+            run(
+                ServerAction::Validate {
+                    command: "nonexistent-server".to_string(),
+                },
+                OutputFormat::Json,
+            )
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), ExitCode::ERROR);
     }
 
     #[test]

--- a/crates/mcp-cli/src/commands/setup.rs
+++ b/crates/mcp-cli/src/commands/setup.rs
@@ -7,7 +7,11 @@
 
 use anyhow::{Context, Result};
 use mcp_execution_core::cli::{ExitCode, OutputFormat};
+#[cfg(unix)]
+use mcp_execution_core::sanitize_path_for_error;
 use serde::Serialize;
+#[cfg(unix)]
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::process::Command;
@@ -29,6 +33,7 @@ use tokio::process::Command;
 ///     mcp_config_found: true,
 ///     servers_dir_found: true,
 ///     files_made_executable: 3,
+///     skipped_entries: 0,
 /// };
 ///
 /// assert_eq!(result.files_made_executable, 3);
@@ -47,6 +52,11 @@ pub struct SetupResult {
     /// Number of `.ts` files made executable under `~/.claude/servers/`.
     /// Always `0` on non-Unix platforms.
     pub files_made_executable: usize,
+    /// Number of symlinked entries skipped while walking
+    /// `~/.claude/servers/` — a symlinked server-id directory or a
+    /// symlinked `.ts` file inside an otherwise legitimate server
+    /// directory. Always `0` on non-Unix platforms.
+    pub skipped_entries: usize,
 }
 
 /// Runs the setup command.
@@ -93,7 +103,8 @@ pub async fn run(output_format: OutputFormat) -> Result<ExitCode> {
     let mcp_config_path = get_mcp_config_path()?;
     let mcp_config_found = mcp_config_path.exists();
 
-    let (servers_dir_found, files_made_executable) = check_files_executable().await?;
+    let (servers_dir_found, files_made_executable, skipped_entries) =
+        check_files_executable().await?;
 
     let result = SetupResult {
         node_version,
@@ -101,6 +112,7 @@ pub async fn run(output_format: OutputFormat) -> Result<ExitCode> {
         mcp_config_found,
         servers_dir_found,
         files_made_executable,
+        skipped_entries,
     };
 
     if output_format == OutputFormat::Pretty {
@@ -141,6 +153,17 @@ fn print_pretty_summary(result: &SetupResult) {
                 println!(
                     "✓ Made {} TypeScript files executable",
                     result.files_made_executable
+                );
+            }
+            if result.skipped_entries > 0 {
+                println!(
+                    "⚠ Skipped {} symlinked entr{} under the servers directory (see warnings above)",
+                    result.skipped_entries,
+                    if result.skipped_entries == 1 {
+                        "y"
+                    } else {
+                        "ies"
+                    }
                 );
             }
         } else {
@@ -226,8 +249,9 @@ async fn check_node_version() -> Result<String> {
 ///
 /// # Platform Support
 ///
-/// - Unix/Linux/macOS: Sets permissions, returns `(servers_dir_found, files_made_executable)`
-/// - Windows: No-op, always returns `(false, 0)`
+/// - Unix/Linux/macOS: Sets permissions, returns
+///   `(servers_dir_found, files_made_executable, skipped_entries)`
+/// - Windows: No-op, always returns `(false, 0, 0)`
 ///
 /// # Errors
 ///
@@ -235,51 +259,119 @@ async fn check_node_version() -> Result<String> {
 /// - Home directory cannot be determined
 /// - Permission changes fail
 #[cfg(unix)]
-async fn check_files_executable() -> Result<(bool, usize)> {
-    use std::os::unix::fs::PermissionsExt;
-    use tokio::fs;
-
+async fn check_files_executable() -> Result<(bool, usize, usize)> {
     let servers_dir = get_servers_dir()?;
-
-    // Check if servers directory exists
-    if !servers_dir.exists() {
-        return Ok((false, 0));
-    }
-
-    // Walk through all .ts files and make them executable
-    let mut count = 0;
-    let mut entries = fs::read_dir(&servers_dir).await?;
-
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-
-        if path.is_dir() {
-            // Recurse into server directories
-            if let Ok(mut server_entries) = fs::read_dir(&path).await {
-                while let Some(server_entry) = server_entries.next_entry().await? {
-                    let file_path = server_entry.path();
-
-                    if file_path.extension().and_then(|s| s.to_str()) == Some("ts") {
-                        let metadata = fs::metadata(&file_path).await?;
-                        let mut perms = metadata.permissions();
-                        perms.set_mode(0o755); // rwxr-xr-x
-                        fs::set_permissions(&file_path, perms).await?;
-                        count += 1;
-                    }
-                }
-            }
-        }
-    }
-
-    Ok((true, count))
+    check_files_executable_in(&servers_dir).await
 }
 
 /// Checks for and makes TypeScript files executable (Unix only).
 ///
 /// No-op on non-Unix platforms, since file permissions are not checked there.
 #[cfg(not(unix))]
-async fn check_files_executable() -> Result<(bool, usize)> {
-    Ok((false, 0))
+async fn check_files_executable() -> Result<(bool, usize, usize)> {
+    Ok((false, 0, 0))
+}
+
+/// Walks `servers_dir` and makes every `.ts` file executable (0755), rejecting
+/// symlinked entries at both levels of the walk rather than following them.
+///
+/// A symlinked server-id directory (outer level) or a symlinked `.ts` file
+/// inside an otherwise legitimate server directory (inner level) is skipped
+/// and counted in `skipped_entries` rather than chmod'd, since following
+/// either would let a planted symlink redirect a permission change to any
+/// file the process can reach outside `servers_dir`. Entry kind is checked
+/// with [`std::fs::DirEntry::file_type`] (via its `tokio` equivalent), which
+/// — like `symlink_metadata` — does not traverse symlinks, so the check
+/// itself cannot be tricked into following the entry it's inspecting.
+///
+/// This is a check against pre-existing state, not a concurrency guarantee:
+/// it does not defend against a symlink planted by a racing process between
+/// this function's kind check and the subsequent `set_permissions` call (see
+/// `mcp_execution_core::confinement`'s equivalent TOCTOU note). A hardlink
+/// inside `servers_dir` pointing at a file outside it is also indistinguishable
+/// from a regular file by `file_type` and is not defended against; both are
+/// accepted as out of scope.
+///
+/// # Errors
+///
+/// Returns error if a directory cannot be read, an entry's file type cannot
+/// be determined, or permission changes fail (other than a bare `read_dir`
+/// failure on a server subdirectory, which is skipped and warned about).
+#[cfg(unix)]
+async fn check_files_executable_in(servers_dir: &Path) -> Result<(bool, usize, usize)> {
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::fs;
+
+    // Check if servers directory exists
+    if !servers_dir.exists() {
+        return Ok((false, 0, 0));
+    }
+
+    let root = fs::canonicalize(servers_dir).await?;
+
+    // Walk through all .ts files and make them executable
+    let mut count = 0;
+    let mut skipped = 0;
+    let mut entries = fs::read_dir(&root).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+
+        let file_type = entry.file_type().await?;
+        if file_type.is_symlink() {
+            tracing::warn!(
+                path = %sanitize_path_for_error(&path),
+                "skipping symlinked entry under the servers directory"
+            );
+            skipped += 1;
+            continue;
+        }
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        // Recurse into the server directory
+        let mut server_entries = match fs::read_dir(&path).await {
+            Ok(server_entries) => server_entries,
+            Err(error) => {
+                tracing::warn!(
+                    path = %sanitize_path_for_error(&path),
+                    %error,
+                    "skipping unreadable server directory"
+                );
+                continue;
+            }
+        };
+
+        while let Some(server_entry) = server_entries.next_entry().await? {
+            let file_path = server_entry.path();
+
+            if file_path.extension().and_then(|s| s.to_str()) != Some("ts") {
+                continue;
+            }
+
+            let file_type = server_entry.file_type().await?;
+            if file_type.is_symlink() {
+                tracing::warn!(
+                    path = %sanitize_path_for_error(&file_path),
+                    "skipping symlinked .ts file under the servers directory"
+                );
+                skipped += 1;
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+
+            let metadata = fs::metadata(&file_path).await?;
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o755); // rwxr-xr-x
+            fs::set_permissions(&file_path, perms).await?;
+            count += 1;
+        }
+    }
+
+    Ok((true, count, skipped))
 }
 
 /// Gets the path to ~/.claude/mcp.json
@@ -342,6 +434,90 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_files_executable_in_makes_real_ts_files_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let servers_dir = tempfile::TempDir::new().unwrap();
+        let my_server_dir = servers_dir.path().join("my-server");
+        tokio::fs::create_dir_all(&my_server_dir).await.unwrap();
+        let tool_path = my_server_dir.join("tool.ts");
+        tokio::fs::write(&tool_path, "// tool").await.unwrap();
+
+        let (servers_dir_found, files_made_executable, skipped_entries) =
+            check_files_executable_in(servers_dir.path()).await.unwrap();
+
+        assert!(servers_dir_found);
+        assert_eq!(files_made_executable, 1);
+        assert_eq!(skipped_entries, 0);
+        let mode = tokio::fs::metadata(&tool_path)
+            .await
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_files_executable_in_skips_symlinked_server_dir() {
+        let servers_dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let target_path = outside.path().join("target.ts");
+        tokio::fs::write(&target_path, "// outside").await.unwrap();
+        std::os::unix::fs::symlink(outside.path(), servers_dir.path().join("evil-server")).unwrap();
+
+        let (servers_dir_found, files_made_executable, skipped_entries) =
+            check_files_executable_in(servers_dir.path()).await.unwrap();
+
+        assert!(servers_dir_found);
+        assert_eq!(files_made_executable, 0);
+        assert_eq!(skipped_entries, 1);
+        let mode = std::os::unix::fs::PermissionsExt::mode(
+            &tokio::fs::metadata(&target_path)
+                .await
+                .unwrap()
+                .permissions(),
+        );
+        assert_eq!(
+            mode & 0o111,
+            0,
+            "symlinked target must not become executable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_files_executable_in_skips_symlinked_ts_file() {
+        let servers_dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let target_path = outside.path().join("target.ts");
+        tokio::fs::write(&target_path, "// outside").await.unwrap();
+
+        let legit_server_dir = servers_dir.path().join("legit-server");
+        tokio::fs::create_dir_all(&legit_server_dir).await.unwrap();
+        std::os::unix::fs::symlink(&target_path, legit_server_dir.join("link.ts")).unwrap();
+
+        let (servers_dir_found, files_made_executable, skipped_entries) =
+            check_files_executable_in(servers_dir.path()).await.unwrap();
+
+        assert!(servers_dir_found);
+        assert_eq!(files_made_executable, 0);
+        assert_eq!(skipped_entries, 1);
+        let mode = std::os::unix::fs::PermissionsExt::mode(
+            &tokio::fs::metadata(&target_path)
+                .await
+                .unwrap()
+                .permissions(),
+        );
+        assert_eq!(
+            mode & 0o111,
+            0,
+            "symlinked target must not become executable"
+        );
+    }
+
     #[test]
     fn test_setup_result_serialization() {
         let result = SetupResult {
@@ -350,6 +526,7 @@ mod tests {
             mcp_config_found: true,
             servers_dir_found: true,
             files_made_executable: 3,
+            skipped_entries: 0,
         };
 
         let json = serde_json::to_string(&result).unwrap();
@@ -366,6 +543,7 @@ mod tests {
             mcp_config_found: false,
             servers_dir_found: true,
             files_made_executable: 7,
+            skipped_entries: 0,
         };
 
         let formatted =
@@ -386,6 +564,7 @@ mod tests {
             mcp_config_found: true,
             servers_dir_found: false,
             files_made_executable: 0,
+            skipped_entries: 0,
         };
 
         let formatted =

--- a/specs/cli/spec.md
+++ b/specs/cli/spec.md
@@ -532,14 +532,46 @@ itself was already safe (issue #346, S1).
 
 Validates the local runtime is ready to execute generated tools:
 1. Checks `node --version` is ≥ 18.0.0 (hard error if missing/older).
-2. On Unix only: makes every `.ts` file under `~/.claude/servers/` executable
-   (`files_made_executable` count) and reports whether a servers directory
-   exists at all.
+2. On Unix only: makes every `.ts` file directly inside each server directory
+   under `~/.claude/servers/` executable (`files_made_executable` count) —
+   the walk is exactly two levels deep and does not descend into further
+   nested subdirectories (e.g. `{server-id}/_runtime/`) — skipping symlinked
+   entries rather than following them (`skipped_entries` count), and reports
+   whether a servers directory exists at all.
 3. Reports whether `~/.claude/mcp.json` exists, printing a starter example
    if not.
 
 Non-Unix platforms always report `servers_dir_found: false`,
-`files_made_executable: 0` (permission bits aren't a concept there).
+`files_made_executable: 0`, `skipped_entries: 0` (permission bits aren't a
+concept there).
+
+**Symlink rejection** (issue #476): the walk is confined to `~/.claude/servers/`
+by rejecting symlinked entries outright rather than resolving and re-checking
+them, at both levels of the walk — mirroring the guard semantics of
+`mcp_execution_core::confinement::resolve_confined_path` (not reused directly,
+since that function creates directories for caller-supplied paths and this
+walk enumerates existing entries and must create nothing):
+- Outer level: a symlinked server-id entry under `~/.claude/servers/` is
+  skipped (would otherwise let `chmod` descend into an arbitrary directory
+  elsewhere on disk).
+- Inner level: a symlinked `.ts` file inside an otherwise legitimate server
+  directory is skipped (would otherwise `chmod` its target anywhere the
+  process can reach).
+
+Entry kind is checked via `DirEntry::file_type()` (does not traverse
+symlinks), and each skipped entry increments `SetupResult::skipped_entries`
+and emits a `tracing::warn!` with the sanitized path, so a planted symlink is
+surfaced to the user instead of silently ignored. This is a check against
+pre-existing state, not a concurrency guarantee: it does not defend against a
+symlink planted by a racing process between the kind check and the
+subsequent `set_permissions` call (same non-guarantee documented for
+`resolve_confined_path`), nor against a hardlink inside the servers tree
+pointing outside it, which `file_type()` cannot distinguish from a regular
+file — both are accepted as out of scope.
+
+The core walk is exposed as `check_files_executable_in(servers_dir: &Path)`
+for testing without `HOME` mutation; the public, no-argument
+`check_files_executable()` resolves `~/.claude/servers/` and delegates to it.
 
 ## 11. `completions` Command (`commands/completions.rs`)
 


### PR DESCRIPTION
## Summary

Two independent CLI bug fixes, bundled as they touch the same crate and were triaged together:

- **#479** — `server validate` labeled every `get_mcp_server_entry` failure as "Server not found in configuration", even when `~/.claude/mcp.json` itself was missing or malformed rather than the named server being absent. `get_mcp_server_entry` is split into `load_mcp_config` and `lookup_server_entry`, so `validate_command` now reports a config-load failure with its true cause and reserves "not found" for a genuinely absent server name, matching the framing `generate --from-config`, `server list`, and `server info` already use.
- **#476** (security) — `setup`'s `check_files_executable` followed symlinks while walking `~/.claude/servers/` to `chmod` generated `.ts` files, at two levels: a symlinked server-id directory, and a symlinked `.ts` file inside an otherwise legitimate directory (the second vector was not in the original report, found during audit). Both levels now check entry kind via `DirEntry::file_type()` and skip symlinked entries, mirroring the guard semantics already used by `mcp_execution_core::confinement`. `SetupResult` gains a `skipped_entries` field so a planted symlink is surfaced instead of silently ignored.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1378 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests for both fixes (config-load vs. absent-server message distinction for #479; both symlink vectors for #476)
- [x] `specs/cli/spec.md` updated to reflect the new symlink-rejection behavior and walk depth
- [x] `CHANGELOG.md` updated under `[Unreleased]`