### PR TITLE
feat!: add generation provenance to _meta.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Breaking` entry below). Adds the `unicode-security` 0.1.2 dependency (unconditional, unlike
   the existing platform-gated `unicode-normalization`), pulling in `unicode-script` 0.5.8 as a
   new transitive dependency (#433).
+- **`mcp-execution-core`**: new `provenance` module — `GenerationProvenance`, `ConfigFingerprint`,
+  `ToolDigest`, and `ToolDigestEntry<'a>` — recording when and against what server state a
+  `_meta.json` sidecar was generated, so a future comparison mechanism can detect that the
+  server's connection parameters or tool surface changed since generation. `ConfigFingerprint`
+  and `ToolDigest` are SHA-256 digests over an explicit, length-framed preimage (never `Debug`
+  output or serialized JSON, both of which lack a stability guarantee this needs); the
+  fingerprint excludes every secret-bearing `ServerConfig` value (argument/env/header/query
+  values, userinfo) by construction, so rotating a credential never registers as drift. Adds the
+  `sha2` 0.11 dependency (`default-features = false`) and enables `chrono`'s `serde` feature on
+  `mcp-execution-core`, pulling in `digest`, `block-buffer`, `crypto-common`, `hybrid-array`, and
+  `typenum` as new transitive dependencies (#468).
 
 ### Changed
 
@@ -189,6 +200,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **`mcp-execution-core`**: `METADATA_SCHEMA_VERSION` bumped from `1` to `2`. `ServerMetadata`
+  gained a new required field, `provenance: GenerationProvenance` — not `Option`, since a
+  `schema_version: 1` sidecar (which has no `provenance` key at all) is now rejected by a
+  schema-version check before any consumer constructs a `ServerMetadata`, so an `Option` every
+  consumer would have to unwrap could never actually be `None`. Any `_meta.json` sidecar written
+  by a `generate` run before this change no longer parses: re-run `generate` to produce a v2
+  sidecar. `mcp-execution-codegen`'s `ProgressiveGenerator::generate`/`generate_with_categories`
+  both gained a required `&ServerConfig` parameter (used to compute `provenance` from the same
+  inputs the run is generating from, so the digest can't drift from the emitted files) —
+  source-breaking for every caller. `mcp-execution-skill`'s `scan_tools_directory` now reads
+  `schema_version` from a minimal probe *before* attempting a typed `ServerMetadata` parse, so a
+  genuine v1 sidecar correctly surfaces `ScanError::UnsupportedSchema` instead of a generic
+  "missing field `provenance`" `ScanError::MetadataParse`; `UnsupportedSchema`'s message also
+  gained the "re-run `generate`" guidance its sibling `StaleMetadata` already carried. Also,
+  `ConfigFingerprint`/`ToolDigest`'s `Deserialize` is now routed through a validating
+  `TryFrom<String>` (new `DigestFormatError`), mirroring `ServerId`/`ToolName`'s pattern: a
+  `_meta.json` whose `provenance.config_fingerprint`/`tool_digest` is not exactly 64 lowercase
+  hex characters now fails to deserialize instead of silently producing a value that violates
+  the documented shape (#468).
 - **`mcp-execution-skill`**: `SkillMetadataError` gained a new `NameTooLong { len, limit }`
   variant, returned by `extract_skill_metadata` when the frontmatter `name` exceeds
   `MAX_SKILL_NAME_LENGTH` (see the `### Fixed` entry below). Source-breaking for any downstream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +655,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thousands",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -970,6 +998,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1382,9 +1419,11 @@ dependencies = [
 name = "mcp-execution-core"
 version = "0.9.0"
 dependencies = [
+ "chrono",
  "dirs",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2317,6 +2356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2773,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ schemars = "1.2"
 serde = "1.0"
 serde-saphyr = { version = "1.0.1", default-features = false, features = ["deserialize", "serialize"] }
 serde_json = "1.0"
+sha2 = { version = "0.11", default-features = false }
 tempfile = "3.27"
 thiserror = "2.0"
 tokio = "1.52"

--- a/crates/mcp-cli/src/commands/generate.rs
+++ b/crates/mcp-cli/src/commands/generate.rs
@@ -181,7 +181,7 @@ pub async fn run(
     }
 
     let server_dir_name = resolve_server_dir_name(&server_info, id_from_unvalidated_config_key)?;
-    let generated_code = generate_code(&server_info)?;
+    let generated_code = generate_code(&server_info, &server_config)?;
 
     let base_dir = resolve_base_dir(output_dir)?;
     let output_path = base_dir.join(&server_dir_name);
@@ -251,10 +251,10 @@ async fn discover_server_info(
 /// # Errors
 ///
 /// Returns an error if the code generator fails to initialize or generate code.
-fn generate_code(server_info: &ServerInfo) -> Result<GeneratedCode> {
+fn generate_code(server_info: &ServerInfo, server_config: &ServerConfig) -> Result<GeneratedCode> {
     let generator = ProgressiveGenerator::new().context("failed to create code generator")?;
     let generated_code = generator
-        .generate(server_info)
+        .generate(server_info, server_config)
         .context("failed to generate TypeScript code")?;
 
     info!(
@@ -520,6 +520,15 @@ mod tests {
         }
     }
 
+    /// `ServerConfig` passed alongside `create_mock_server_info`'s output so `generate` can
+    /// stamp generation provenance.
+    fn create_mock_server_config() -> ServerConfig {
+        ServerConfig::builder()
+            .command("test-command".to_string())
+            .build()
+            .unwrap()
+    }
+
     #[test]
     fn test_generation_result_serialization() {
         let result = GenerationResult {
@@ -661,7 +670,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_mock_server_info();
 
-        let result = generator.generate(&server_info);
+        let result = generator.generate(&server_info, &create_mock_server_config());
         assert!(result.is_ok());
 
         let code = result.unwrap();
@@ -720,7 +729,9 @@ mod tests {
     fn test_dry_run_collects_file_metadata() {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_mock_server_info();
-        let generated_code = generator.generate(&server_info).unwrap();
+        let generated_code = generator
+            .generate(&server_info, &create_mock_server_config())
+            .unwrap();
 
         let server_dir_name = server_info.id.to_string();
         let files: Vec<FilePreview> = generated_code
@@ -755,7 +766,9 @@ mod tests {
 
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_mock_server_info();
-        let generated_code = generator.generate(&server_info).unwrap();
+        let generated_code = generator
+            .generate(&server_info, &create_mock_server_config())
+            .unwrap();
 
         // Simulate what dry-run does: collect metadata without touching the filesystem
         let server_dir_name = server_info.id.to_string();
@@ -963,7 +976,9 @@ mod tests {
 
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_mock_server_info();
-        let generated_code = generator.generate(&server_info).unwrap();
+        let generated_code = generator
+            .generate(&server_info, &create_mock_server_config())
+            .unwrap();
 
         let result = export_generated_code(generated_code, &base_dir, &escape_target);
 

--- a/crates/mcp-cli/src/commands/skill.rs
+++ b/crates/mcp-cli/src/commands/skill.rs
@@ -451,8 +451,17 @@ mod tests {
         METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata,
         ToolMetadata,
     };
-    use mcp_execution_core::{ServerId, ToolName};
+    use mcp_execution_core::provenance::GenerationProvenance;
+    use mcp_execution_core::{ServerConfig, ServerId, ToolName};
     use tempfile::TempDir;
+
+    fn test_provenance() -> GenerationProvenance {
+        let config = ServerConfig::builder()
+            .command("test-command".to_string())
+            .build()
+            .unwrap();
+        GenerationProvenance::capture(&config, &[])
+    }
 
     /// Writes a minimal `_meta.json` sidecar with a single tool into `server_dir`,
     /// matching what `mcp-execution-codegen` would emit for a generated server.
@@ -478,6 +487,7 @@ mod tests {
                     description: Some("Test input".to_string()),
                 }],
             }],
+            provenance: test_provenance(),
         };
 
         let content = serde_json::to_string_pretty(&meta).unwrap();
@@ -1127,6 +1137,7 @@ mod tests {
                     parameters: vec![],
                 },
             ],
+            provenance: test_provenance(),
         };
         let content = serde_json::to_string_pretty(&meta).unwrap();
         std::fs::write(server_dir.join(METADATA_FILE_NAME), content).unwrap();

--- a/crates/mcp-codegen/README.md
+++ b/crates/mcp-codegen/README.md
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 2. Generate progressive loading files
     let generator = ProgressiveGenerator::new()?;
-    let code = generator.generate(&info)?;
+    let code = generator.generate(&info, &config)?;
 
     println!("Generated {} files", code.file_count());
     Ok(())

--- a/crates/mcp-codegen/benches/code_generation.rs
+++ b/crates/mcp-codegen/benches/code_generation.rs
@@ -12,10 +12,18 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
-use mcp_execution_core::{ServerId, ToolName};
+use mcp_execution_core::{ServerConfig, ServerId, ToolName};
 use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
 use serde_json::json;
 use std::hint::black_box;
+
+/// `ServerConfig` passed alongside `ServerInfo` so `generate` can stamp generation provenance.
+fn bench_config() -> ServerConfig {
+    ServerConfig::builder()
+        .command("bench-command".to_string())
+        .build()
+        .unwrap()
+}
 
 // ============================================================================
 // Test Data Generators
@@ -165,12 +173,13 @@ fn bench_full_generation_scaling(c: &mut Criterion) {
 
     for count in [1, 10, 50, 100, 500, 1000] {
         let server_info = create_server_info(count, create_moderate_tool);
+        let config = bench_config();
         let generator = ProgressiveGenerator::new().expect("Generator should initialize");
 
         group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _count| {
             b.iter(|| {
-                let result = generator.generate(black_box(&server_info));
+                let result = generator.generate(black_box(&server_info), black_box(&config));
                 assert!(result.is_ok());
             });
         });
@@ -192,12 +201,13 @@ fn bench_schema_complexity(c: &mut Criterion) {
 
     for (name, tool_creator) in complexities {
         let server_info = create_server_info(tool_count, tool_creator);
+        let config = bench_config();
         let generator = ProgressiveGenerator::new().expect("Generator should initialize");
 
         group.throughput(Throughput::Elements(tool_count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(name), name, |b, _| {
             b.iter(|| {
-                let result = generator.generate(black_box(&server_info));
+                let result = generator.generate(black_box(&server_info), black_box(&config));
                 assert!(result.is_ok());
             });
         });
@@ -284,12 +294,13 @@ fn bench_memory_patterns(c: &mut Criterion) {
 
     // Single generation with measurements
     let server_info = create_server_info(100, create_moderate_tool);
+    let config = bench_config();
     let generator = ProgressiveGenerator::new().expect("Generator should initialize");
 
     group.bench_function("generate_100_tools", |b| {
         b.iter(|| {
             let generated = generator
-                .generate(black_box(&server_info))
+                .generate(black_box(&server_info), black_box(&config))
                 .expect("Should succeed");
             // Force evaluation of all generated files
             for file in &generated.files {

--- a/crates/mcp-codegen/src/lib.rs
+++ b/crates/mcp-codegen/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let generator = ProgressiveGenerator::new()?;
-//! // generator.generate(&server_info)?;
+//! // generator.generate(&server_info, &server_config)?;
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -17,7 +17,7 @@
 //! let info = introspector.discover_server(server_id, &config).await?;
 //!
 //! let generator = ProgressiveGenerator::new()?;
-//! let code = generator.generate(&info)?;
+//! let code = generator.generate(&info, &config)?;
 //!
 //! // Generated files:
 //! // - index.ts (re-exports)
@@ -45,7 +45,8 @@ use mcp_execution_core::metadata::{
     INDEX_FILE_NAME, METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata,
     ServerMetadata, ToolMetadata,
 };
-use mcp_execution_core::{Error, Result};
+use mcp_execution_core::provenance::{GenerationProvenance, ToolDigestEntry};
+use mcp_execution_core::{Error, Result, ServerConfig};
 use mcp_execution_introspector::{ServerInfo, ToolInfo};
 use std::collections::{HashMap, HashSet};
 
@@ -222,6 +223,8 @@ impl ProgressiveGenerator<'_> {
     /// # Arguments
     ///
     /// * `server_info` - MCP server introspection data
+    /// * `server_config` - The [`ServerConfig`] used to connect to and introspect the server,
+    ///   used to stamp the `_meta.json` sidecar's [`GenerationProvenance`]
     ///
     /// # Returns
     ///
@@ -238,7 +241,7 @@ impl ProgressiveGenerator<'_> {
     /// ```no_run
     /// use mcp_execution_codegen::progressive::ProgressiveGenerator;
     /// use mcp_execution_introspector::{ServerInfo, ServerCapabilities};
-    /// use mcp_execution_core::ServerId;
+    /// use mcp_execution_core::{ServerConfig, ServerId};
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let generator = ProgressiveGenerator::new()?;
@@ -254,8 +257,9 @@ impl ProgressiveGenerator<'_> {
     ///         supports_prompts: false,
     ///     },
     /// };
+    /// let config = ServerConfig::builder().command("/path/to/github-server".to_string()).build()?;
     ///
-    /// let code = generator.generate(&info)?;
+    /// let code = generator.generate(&info, &config)?;
     ///
     /// // Files generated:
     /// // - index.ts
@@ -267,8 +271,12 @@ impl ProgressiveGenerator<'_> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn generate(&self, server_info: &ServerInfo) -> Result<GeneratedCode> {
-        self.generate_with_categories(server_info, &HashMap::new())
+    pub fn generate(
+        &self,
+        server_info: &ServerInfo,
+        server_config: &ServerConfig,
+    ) -> Result<GeneratedCode> {
+        self.generate_with_categories(server_info, server_config, &HashMap::new())
     }
 
     /// Generates progressive loading files with categorization metadata.
@@ -280,6 +288,8 @@ impl ProgressiveGenerator<'_> {
     /// # Arguments
     ///
     /// * `server_info` - MCP server introspection data
+    /// * `server_config` - The [`ServerConfig`] used to connect to and introspect the server,
+    ///   used to stamp the `_meta.json` sidecar's [`GenerationProvenance`]
     /// * `categorizations` - Map of tool name to categorization metadata
     ///
     /// # Returns
@@ -295,7 +305,7 @@ impl ProgressiveGenerator<'_> {
     /// ```no_run
     /// use mcp_execution_codegen::progressive::{ProgressiveGenerator, ToolCategorization};
     /// use mcp_execution_introspector::{ServerInfo, ServerCapabilities};
-    /// use mcp_execution_core::ServerId;
+    /// use mcp_execution_core::{ServerConfig, ServerId};
     /// use std::collections::HashMap;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -312,6 +322,7 @@ impl ProgressiveGenerator<'_> {
     ///         supports_prompts: false,
     ///     },
     /// };
+    /// let config = ServerConfig::builder().command("/path/to/github-server".to_string()).build()?;
     ///
     /// let mut categorizations = HashMap::new();
     /// categorizations.insert("create_issue".to_string(), ToolCategorization {
@@ -320,7 +331,7 @@ impl ProgressiveGenerator<'_> {
     ///     short_description: "Create a new issue".to_string(),
     /// });
     ///
-    /// let code = generator.generate_with_categories(&info, &categorizations)?;
+    /// let code = generator.generate_with_categories(&info, &config, &categorizations)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -331,6 +342,7 @@ impl ProgressiveGenerator<'_> {
     pub fn generate_with_categories(
         &self,
         server_info: &ServerInfo,
+        server_config: &ServerConfig,
         categorizations: &HashMap<String, ToolCategorization>,
     ) -> Result<GeneratedCode> {
         if categorizations.is_empty() {
@@ -373,7 +385,7 @@ impl ProgressiveGenerator<'_> {
         add_tracked(
             &mut code,
             &mut total_bytes,
-            Self::create_metadata_file(server_info, tool_metadata)?,
+            Self::create_metadata_file(server_info, server_config, tool_metadata)?,
         )?;
 
         tracing::debug!("Generated {}", METADATA_FILE_NAME);
@@ -838,20 +850,38 @@ impl ProgressiveGenerator<'_> {
     /// Builds the `_meta.json` sidecar file from per-tool metadata already collected
     /// during the tool-file generation loop.
     ///
+    /// Computes [`GenerationProvenance`] from `server_config` and `server_info.tools` — the
+    /// same inputs this whole call is generating from — so the recorded digest can never drift
+    /// from the files actually emitted.
+    ///
     /// # Errors
     ///
     /// Returns error if the metadata cannot be serialized to JSON (should not happen
     /// with these plain-data types).
     fn create_metadata_file(
         server_info: &ServerInfo,
+        server_config: &ServerConfig,
         tools: Vec<ToolMetadata>,
     ) -> Result<GeneratedFile> {
+        let digest_entries: Vec<ToolDigestEntry<'_>> = server_info
+            .tools
+            .iter()
+            .map(|tool| ToolDigestEntry {
+                name: tool.name.as_str(),
+                description: &tool.description,
+                input_schema: &tool.input_schema,
+                output_schema: tool.output_schema.as_ref(),
+            })
+            .collect();
+        let provenance = GenerationProvenance::capture(server_config, &digest_entries);
+
         let meta = ServerMetadata {
             schema_version: METADATA_SCHEMA_VERSION,
             server_id: server_info.id.clone(),
             server_name: server_info.name.clone(),
             server_version: server_info.version.clone(),
             tools,
+            provenance,
         };
 
         let content =
@@ -1275,6 +1305,13 @@ mod tests {
         }
     }
 
+    fn test_config() -> mcp_execution_core::ServerConfig {
+        mcp_execution_core::ServerConfig::builder()
+            .command("test-command".to_string())
+            .build()
+            .unwrap()
+    }
+
     #[test]
     fn test_progressive_generator_new() {
         let generator = ProgressiveGenerator::new();
@@ -1286,7 +1323,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         // Should generate:
         // - 2 tool files
@@ -1319,7 +1356,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let index_file = code.files.iter().find(|f| f.path == "index.ts").unwrap();
 
         assert!(
@@ -1340,7 +1377,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         let tsconfig_file = code
             .files
@@ -1366,7 +1403,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         let package_json_file = code
             .files
@@ -1391,7 +1428,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let meta_file = code.files.iter().find(|f| f.path == "_meta.json").unwrap();
         let meta: ServerMetadata = serde_json::from_str(&meta_file.content).unwrap();
 
@@ -1416,6 +1453,68 @@ mod tests {
         assert!(title.required);
     }
 
+    /// The `_meta.json` sidecar carries `schema_version: 2` and 64-hex-char provenance fields,
+    /// and two runs against identical input agree on the fingerprint and digest — only
+    /// `generated_at` is allowed to differ between them.
+    #[test]
+    fn test_generate_meta_json_provenance_is_stable_across_runs() {
+        let generator = ProgressiveGenerator::new().unwrap();
+        let server_info = create_test_server_info();
+        let config = test_config();
+
+        let first = generator.generate(&server_info, &config).unwrap();
+        let first_meta_file = first.files.iter().find(|f| f.path == "_meta.json").unwrap();
+        let first_meta: ServerMetadata = serde_json::from_str(&first_meta_file.content).unwrap();
+
+        // Guarantees the two `generated_at` timestamps differ (rather than merely being
+        // "unlikely to collide"), so the assertion below actually exercises "only generated_at
+        // differs" instead of passing vacuously if both calls happened to land in the same
+        // clock tick.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        let second = generator.generate(&server_info, &config).unwrap();
+        let second_meta_file = second
+            .files
+            .iter()
+            .find(|f| f.path == "_meta.json")
+            .unwrap();
+        let second_meta: ServerMetadata = serde_json::from_str(&second_meta_file.content).unwrap();
+
+        assert_eq!(first_meta.schema_version, 2);
+        assert_eq!(first_meta.provenance.config_fingerprint.as_str().len(), 64);
+        assert!(
+            first_meta
+                .provenance
+                .config_fingerprint
+                .as_str()
+                .chars()
+                .all(|c| c.is_ascii_hexdigit())
+        );
+        assert_eq!(first_meta.provenance.tool_digest.as_str().len(), 64);
+        assert!(
+            first_meta
+                .provenance
+                .tool_digest
+                .as_str()
+                .chars()
+                .all(|c| c.is_ascii_hexdigit())
+        );
+
+        assert_eq!(
+            first_meta.provenance.config_fingerprint,
+            second_meta.provenance.config_fingerprint
+        );
+        assert_eq!(
+            first_meta.provenance.tool_digest,
+            second_meta.provenance.tool_digest
+        );
+        assert_ne!(
+            first_meta.provenance.generated_at, second_meta.provenance.generated_at,
+            "the two calls must actually be stamped at different times for \"only generated_at \
+             differs\" to be a meaningful claim"
+        );
+    }
+
     #[test]
     fn test_generate_with_categories_meta_json_includes_categorization() {
         let generator = ProgressiveGenerator::new().unwrap();
@@ -1432,7 +1531,7 @@ mod tests {
         );
 
         let code = generator
-            .generate_with_categories(&server_info, &categorizations)
+            .generate_with_categories(&server_info, &test_config(), &categorizations)
             .unwrap();
         let meta_file = code.files.iter().find(|f| f.path == "_meta.json").unwrap();
         let meta: ServerMetadata = serde_json::from_str(&meta_file.content).unwrap();
@@ -1498,7 +1597,7 @@ mod tests {
         };
 
         let generator = ProgressiveGenerator::new().unwrap();
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         // The sidecar carries the raw, untruncated, unescaped, non-flattened description.
         let meta_file = code.files.iter().find(|f| f.path == "_meta.json").unwrap();
@@ -1790,7 +1889,7 @@ mod tests {
             },
         };
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         let typescript_names = resolve_typescript_names(&server_info.tools);
         assert_eq!(
@@ -1868,7 +1967,7 @@ mod tests {
             },
         };
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         let typescript_names = resolve_typescript_names(&server_info.tools);
         assert_eq!(
@@ -1924,7 +2023,7 @@ mod tests {
             },
         };
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let typescript_names = resolve_typescript_names(&server_info.tools);
 
         assert_ne!(
@@ -2116,7 +2215,7 @@ mod tests {
             "required": []
         });
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let tool = code
             .files
             .iter()
@@ -2149,7 +2248,7 @@ mod tests {
             "required": []
         });
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let tool = code
             .files
             .iter()
@@ -2204,7 +2303,7 @@ mod tests {
         );
 
         let code = generator
-            .generate_with_categories(&server_info, &categorizations)
+            .generate_with_categories(&server_info, &test_config(), &categorizations)
             .unwrap();
         let index = code.files.iter().find(|f| f.path == "index.ts").unwrap();
 
@@ -2390,7 +2489,7 @@ mod tests {
         let mut server_info = create_test_server_info();
         server_info.tools[0].name = ToolName::new(raw_name).unwrap();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let tool = code
             .files
             .iter()
@@ -2440,7 +2539,7 @@ mod tests {
         let hostile_name = format!("a{}", "'".repeat(250));
         server_info.tools[0].name = ToolName::new(hostile_name).unwrap();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let tool = code
             .files
             .iter()
@@ -2758,7 +2857,7 @@ mod tests {
             output_schema: None,
         }];
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let tool_file = code.files.iter().find(|f| f.path == "delete_2.ts").unwrap();
 
         assert!(!tool_file.content.contains("export async function delete("));
@@ -2788,7 +2887,7 @@ mod tests {
             },
         ];
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         // Both tools must produce distinct files: no silent overwrite.
         let tool_files: Vec<&str> = code
@@ -2838,7 +2937,7 @@ mod tests {
             },
         ];
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         let dup_files: Vec<&str> = code
             .files
@@ -3039,7 +3138,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let bridge = code
             .files
             .iter()
@@ -3140,7 +3239,7 @@ mod tests {
         server_info.tools[0].description =
             "Compares values: a < b && b > c, or use \"quotes\" & don't forget 'em".to_string();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let tool = code
             .files
             .iter()
@@ -3169,7 +3268,7 @@ mod tests {
         server_info.name = "Evil */ injection".to_string();
         server_info.version = "1.0\n<script>".to_string();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let index = code.files.iter().find(|f| f.path == "index.ts").unwrap();
 
         // Raw injected strings must not appear in the output.
@@ -3210,7 +3309,7 @@ mod tests {
         );
 
         let code = generator
-            .generate_with_categories(&server_info, &categorizations)
+            .generate_with_categories(&server_info, &test_config(), &categorizations)
             .unwrap();
         let tool = code
             .files
@@ -3266,7 +3365,7 @@ mod tests {
         let server_info = server_info_with_tool_count(MAX_GENERATED_FILES - FIXED_FILE_COUNT + 1);
         let generator = ProgressiveGenerator::new().unwrap();
 
-        let result = generator.generate(&server_info);
+        let result = generator.generate(&server_info, &test_config());
 
         assert!(result.is_err());
         assert!(result.unwrap_err().is_resource_limit_exceeded());
@@ -3277,7 +3376,7 @@ mod tests {
         let server_info = server_info_with_tool_count(MAX_GENERATED_FILES - FIXED_FILE_COUNT);
         let generator = ProgressiveGenerator::new().unwrap();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
 
         assert_eq!(code.file_count(), MAX_GENERATED_FILES);
     }
@@ -3287,7 +3386,8 @@ mod tests {
         let server_info = server_info_with_tool_count(MAX_GENERATED_FILES - FIXED_FILE_COUNT + 1);
         let generator = ProgressiveGenerator::new().unwrap();
 
-        let result = generator.generate_with_categories(&server_info, &HashMap::new());
+        let result =
+            generator.generate_with_categories(&server_info, &test_config(), &HashMap::new());
 
         assert!(result.is_err());
         assert!(result.unwrap_err().is_resource_limit_exceeded());

--- a/crates/mcp-codegen/src/progressive/generator.rs
+++ b/crates/mcp-codegen/src/progressive/generator.rs
@@ -3183,7 +3183,7 @@ mod tests {
         let generator = ProgressiveGenerator::new().unwrap();
         let server_info = create_test_server_info();
 
-        let code = generator.generate(&server_info).unwrap();
+        let code = generator.generate(&server_info, &test_config()).unwrap();
         let bridge = code
             .files
             .iter()

--- a/crates/mcp-codegen/src/progressive/mod.rs
+++ b/crates/mcp-codegen/src/progressive/mod.rs
@@ -51,7 +51,7 @@
 //!
 //! // Generate progressive loading files
 //! let generator = ProgressiveGenerator::new()?;
-//! let code = generator.generate(&info)?;
+//! let code = generator.generate(&info, &config)?;
 //!
 //! // Files are generated, ready to write to disk
 //! for file in &code.files {

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -1178,7 +1178,7 @@ fn test_runtime_bridge_rejects_env_name_outside_charset() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1231,7 +1231,7 @@ fn test_runtime_bridge_rejects_too_many_arguments() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1283,7 +1283,7 @@ fn test_runtime_bridge_rejects_argument_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1333,7 +1333,7 @@ fn test_runtime_bridge_rejects_too_many_env_vars() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1386,7 +1386,7 @@ fn test_runtime_bridge_rejects_env_value_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1740,7 +1740,7 @@ fn test_runtime_bridge_rejects_http_transport_url_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1791,7 +1791,7 @@ fn test_runtime_bridge_rejects_http_transport_too_many_headers() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1844,7 +1844,7 @@ fn test_runtime_bridge_rejects_http_transport_header_value_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1897,7 +1897,7 @@ fn test_runtime_bridge_rejects_non_string_env_value() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1948,7 +1948,7 @@ fn test_runtime_bridge_rejects_non_string_header_value() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2002,7 +2002,7 @@ fn test_runtime_bridge_rejects_string_env() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2054,7 +2054,7 @@ fn test_runtime_bridge_rejects_array_env() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2107,7 +2107,7 @@ fn test_runtime_bridge_rejects_argument_too_long_multibyte_utf8() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2160,7 +2160,7 @@ fn test_runtime_bridge_rejects_command_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2211,7 +2211,7 @@ fn test_runtime_bridge_rejects_env_name_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2263,7 +2263,7 @@ fn test_runtime_bridge_rejects_http_transport_header_name_too_long() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2319,7 +2319,7 @@ fn test_runtime_bridge_accepts_argument_count_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2372,7 +2372,7 @@ fn test_runtime_bridge_accepts_argument_length_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2423,7 +2423,7 @@ fn test_runtime_bridge_accepts_env_count_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2477,7 +2477,7 @@ fn test_runtime_bridge_accepts_env_value_length_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2531,7 +2531,7 @@ fn test_runtime_bridge_accepts_url_length_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2585,7 +2585,7 @@ fn test_runtime_bridge_accepts_header_count_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2640,7 +2640,7 @@ fn test_runtime_bridge_accepts_header_value_length_at_cap() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files

--- a/crates/mcp-codegen/tests/progressive_generation.rs
+++ b/crates/mcp-codegen/tests/progressive_generation.rs
@@ -4,11 +4,20 @@
 //! for progressive loading pattern.
 
 use mcp_execution_codegen::progressive::ProgressiveGenerator;
-use mcp_execution_core::{Error, ServerId, ToolName};
+use mcp_execution_core::{Error, ServerConfig, ServerId, ToolName};
 use mcp_execution_introspector::{ServerCapabilities, ServerInfo, ToolInfo};
 use serde_json::json;
 use std::collections::HashMap;
 use std::process::Command;
+
+/// Creates a mock `ServerConfig` for testing, passed alongside `ServerInfo` so
+/// `generate`/`generate_with_categories` can stamp generation provenance.
+fn test_config() -> ServerConfig {
+    ServerConfig::builder()
+        .command("test-command".to_string())
+        .build()
+        .unwrap()
+}
 
 /// Creates a mock server info for testing.
 fn create_test_server_info() -> ServerInfo {
@@ -92,7 +101,7 @@ fn test_progressive_generator_creates_correct_number_of_files() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     // Should generate:
@@ -139,7 +148,7 @@ fn test_generate_with_categories_wraps_non_object_schema_as_script_generation_er
     };
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
 
-    let result = generator.generate_with_categories(&server_info, &HashMap::new());
+    let result = generator.generate_with_categories(&server_info, &test_config(), &HashMap::new());
 
     match result {
         Err(Error::ScriptGenerationError {
@@ -164,7 +173,7 @@ fn test_progressive_tool_files_exist() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let file_paths: Vec<_> = code.files.iter().map(|f| f.path.as_str()).collect();
@@ -198,7 +207,7 @@ fn test_progressive_tool_file_structure() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let create_issue_file = code
@@ -258,7 +267,7 @@ fn test_progressive_tool_file_has_proper_types() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let create_issue_file = code
@@ -292,7 +301,7 @@ fn test_progressive_index_structure() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let index_file = code
@@ -346,7 +355,7 @@ fn test_progressive_index_doc_comment_not_prematurely_closed() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let index_file = code
@@ -383,7 +392,7 @@ fn test_progressive_index_uses_ts_specifiers_not_js() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let index_file = code
@@ -416,7 +425,7 @@ fn test_progressive_runtime_bridge_structure() {
     let server_info = create_test_server_info();
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let bridge_file = code
@@ -476,7 +485,7 @@ fn test_progressive_generator_with_empty_server() {
     };
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     // Should generate:
@@ -520,7 +529,7 @@ fn test_progressive_tool_camel_case_conversion() {
     };
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     // Should convert snake_case to camelCase for filename
@@ -580,7 +589,7 @@ fn test_progressive_tool_with_complex_types() {
     };
 
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let tool_file = code
@@ -754,7 +763,7 @@ fn test_generated_tool_passes_tsc_noemit() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let dir = tempfile::tempdir().expect("Failed to create temp dir");
@@ -835,7 +844,7 @@ fn test_generated_index_resolves_at_runtime_under_node_esm() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
 
     let dir = tempfile::tempdir().expect("Failed to create temp dir");
@@ -1037,7 +1046,7 @@ fn test_runtime_bridge_rejects_forbidden_env_var_before_spawn() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1433,7 +1442,7 @@ fn test_runtime_bridge_rejects_http_transport_with_clear_error_not_crash() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1490,7 +1499,7 @@ fn test_runtime_bridge_rejects_http_transport_bad_url_scheme() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1538,7 +1547,7 @@ fn test_runtime_bridge_rejects_http_transport_missing_url() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1586,7 +1595,7 @@ fn test_runtime_bridge_rejects_http_transport_unsafe_headers() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1634,7 +1643,7 @@ fn test_runtime_bridge_rejects_http_transport_control_char_in_header_value() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -1685,7 +1694,7 @@ fn test_runtime_bridge_rejects_http_transport_duplicate_case_insensitive_headers
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2701,7 +2710,7 @@ fn test_runtime_bridge_rejects_when_child_exits_before_responding() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2754,7 +2763,7 @@ fn test_runtime_bridge_times_out_when_server_never_replies() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -2821,7 +2830,7 @@ fn test_runtime_bridge_dispatches_concurrent_out_of_order_responses_by_request_i
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3011,7 +3020,7 @@ fn test_runtime_bridge_surfaces_tool_error_with_empty_content() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3062,7 +3071,7 @@ fn test_runtime_bridge_returns_structured_content_when_content_empty() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3108,7 +3117,7 @@ fn test_runtime_bridge_rejects_empty_content_without_structured_content() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3156,7 +3165,7 @@ fn test_runtime_bridge_rejects_null_first_content_element() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3205,7 +3214,7 @@ fn test_runtime_bridge_falls_back_to_structured_content_on_null_first_content_el
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3251,7 +3260,7 @@ fn test_runtime_bridge_treats_null_structured_content_as_absent() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files
@@ -3297,7 +3306,7 @@ fn test_runtime_bridge_surfaces_structured_content_on_tool_error() {
     let generator = ProgressiveGenerator::new().expect("Failed to create generator");
     let server_info = create_test_server_info();
     let code = generator
-        .generate(&server_info)
+        .generate(&server_info, &test_config())
         .expect("Failed to generate code");
     let bridge = code
         .files

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -15,9 +15,11 @@ categories = ["development-tools"]
 workspace = true
 
 [dependencies]
+chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 # Backs `path::first_disallowed_identifier_char`, which gates `ServerId::new`/`ToolName::new`

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -41,6 +41,7 @@ mod types;
 
 pub mod cli;
 pub mod metadata;
+pub mod provenance;
 pub mod untrusted;
 
 // Re-export error types

--- a/crates/mcp-core/src/metadata.rs
+++ b/crates/mcp-core/src/metadata.rs
@@ -14,7 +14,10 @@
 //!
 //! ```
 //! use mcp_execution_core::metadata::{ServerMetadata, ToolMetadata, METADATA_SCHEMA_VERSION};
-//! use mcp_execution_core::{ServerId, ToolName};
+//! use mcp_execution_core::provenance::GenerationProvenance;
+//! use mcp_execution_core::{ServerConfig, ServerId, ToolName};
+//!
+//! let config = ServerConfig::builder().command("docker".to_string()).build().unwrap();
 //!
 //! let meta = ServerMetadata {
 //!     schema_version: METADATA_SCHEMA_VERSION,
@@ -29,6 +32,7 @@
 //!         description: Some("Creates a new issue".to_string()),
 //!         parameters: vec![],
 //!     }],
+//!     provenance: GenerationProvenance::capture(&config, &[]),
 //! };
 //!
 //! let json = serde_json::to_string_pretty(&meta).unwrap();
@@ -36,6 +40,7 @@
 //! assert_eq!(round_tripped, meta);
 //! ```
 
+use crate::provenance::GenerationProvenance;
 use crate::{ServerId, ToolName};
 use serde::{Deserialize, Serialize};
 
@@ -46,14 +51,18 @@ use serde::{Deserialize, Serialize};
 /// loudly (via a schema-version mismatch check) instead of silently
 /// misinterpreting the new shape.
 ///
+/// Bumped from `1` to `2` when [`ServerMetadata::provenance`] was added: a `schema_version: 1`
+/// sidecar has no `provenance` key at all, so a consumer must check this value *before*
+/// attempting a typed deserialization (see `mcp-execution-skill`'s parser).
+///
 /// # Examples
 ///
 /// ```
 /// use mcp_execution_core::metadata::METADATA_SCHEMA_VERSION;
 ///
-/// assert_eq!(METADATA_SCHEMA_VERSION, 1);
+/// assert_eq!(METADATA_SCHEMA_VERSION, 2);
 /// ```
-pub const METADATA_SCHEMA_VERSION: u32 = 1;
+pub const METADATA_SCHEMA_VERSION: u32 = 2;
 
 /// Filename of the sidecar metadata file emitted alongside generated tool files.
 ///
@@ -96,7 +105,10 @@ pub const INDEX_FILE_NAME: &str = "index.ts";
 ///
 /// ```
 /// use mcp_execution_core::metadata::{ServerMetadata, METADATA_SCHEMA_VERSION};
-/// use mcp_execution_core::ServerId;
+/// use mcp_execution_core::provenance::GenerationProvenance;
+/// use mcp_execution_core::{ServerConfig, ServerId};
+///
+/// let config = ServerConfig::builder().command("docker".to_string()).build().unwrap();
 ///
 /// let meta = ServerMetadata {
 ///     schema_version: METADATA_SCHEMA_VERSION,
@@ -104,6 +116,7 @@ pub const INDEX_FILE_NAME: &str = "index.ts";
 ///     server_name: "GitHub".to_string(),
 ///     server_version: "1.0.0".to_string(),
 ///     tools: vec![],
+///     provenance: GenerationProvenance::capture(&config, &[]),
 /// };
 ///
 /// assert_eq!(meta.tools.len(), 0);
@@ -132,6 +145,15 @@ pub struct ServerMetadata {
 
     /// Metadata for every generated tool, in generation order.
     pub tools: Vec<ToolMetadata>,
+
+    /// When and against what server state this sidecar was generated.
+    ///
+    /// Required rather than `Option`: a `schema_version: 1` sidecar (produced before this
+    /// field existed) is rejected by the schema-version check before a consumer ever
+    /// constructs a `ServerMetadata`, so every value that exists already carries real
+    /// provenance — see `mcp-execution-skill`'s parser and
+    /// [`crate::provenance::GenerationProvenance`]'s own doc comment.
+    pub provenance: GenerationProvenance,
 }
 
 /// Structured metadata for a single generated tool.
@@ -213,7 +235,16 @@ pub struct ParameterMetadata {
 #[cfg(test)]
 mod tests {
     use super::{METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata, ToolMetadata};
-    use crate::{ServerId, ToolName};
+    use crate::provenance::GenerationProvenance;
+    use crate::{ServerConfig, ServerId, ToolName};
+
+    fn test_provenance() -> GenerationProvenance {
+        let config = ServerConfig::builder()
+            .command("docker".to_string())
+            .build()
+            .unwrap();
+        GenerationProvenance::capture(&config, &[])
+    }
 
     #[test]
     fn round_trips_through_json() {
@@ -235,6 +266,7 @@ mod tests {
                     description: Some("Issue title".to_string()),
                 }],
             }],
+            provenance: test_provenance(),
         };
 
         let json = serde_json::to_string_pretty(&meta).unwrap();
@@ -246,7 +278,7 @@ mod tests {
     #[test]
     fn deserializes_minimal_tool() {
         let json = r#"{
-            "schema_version": 1,
+            "schema_version": 2,
             "server_id": "github",
             "server_name": "GitHub",
             "server_version": "1.0.0",
@@ -257,7 +289,12 @@ mod tests {
                 "keywords": [],
                 "description": null,
                 "parameters": []
-            }]
+            }],
+            "provenance": {
+                "generated_at": "2026-01-01T00:00:00Z",
+                "config_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
+                "tool_digest": "0000000000000000000000000000000000000000000000000000000000000000"
+            }
         }"#;
 
         let meta: ServerMetadata = serde_json::from_str(json).unwrap();
@@ -265,5 +302,22 @@ mod tests {
         assert_eq!(meta.tools.len(), 1);
         assert!(meta.tools[0].category.is_none());
         assert!(meta.tools[0].keywords.is_empty());
+    }
+
+    /// A genuine `schema_version: 1` sidecar has no `provenance` key at all — typed
+    /// deserialization must fail (a consumer is expected to check `schema_version` *first*, see
+    /// `mcp-execution-skill`'s parser, rather than rely on this generic failure).
+    #[test]
+    fn deserialize_rejects_v1_shaped_document_missing_provenance() {
+        let json = r#"{
+            "schema_version": 1,
+            "server_id": "github",
+            "server_name": "GitHub",
+            "server_version": "1.0.0",
+            "tools": []
+        }"#;
+
+        let result: Result<ServerMetadata, _> = serde_json::from_str(json);
+        assert!(result.is_err());
     }
 }

--- a/crates/mcp-core/src/provenance.rs
+++ b/crates/mcp-core/src/provenance.rs
@@ -1,0 +1,1308 @@
+//! Generation provenance for the `_meta.json` sidecar: when, and against what server state,
+//! a `generate` run produced its output.
+//!
+//! `mcp-execution-codegen` writes an exported TypeScript bindings tree alongside a `_meta.json`
+//! sidecar, but nothing recorded when that generation happened or what the connected server
+//! looked like at the time. This module gives [`crate::metadata::ServerMetadata`] a
+//! [`GenerationProvenance`] field so a future comparison mechanism can detect that a server's
+//! configuration or tool surface has changed since the bindings were generated — see
+//! `.local/specs/016-meta-json-generation-provenance/spec.md` for the full design record.
+//!
+//! # What provenance does and does not answer
+//!
+//! Provenance answers "has the server's exposed surface, or the identity of the endpoint we
+//! generated from, changed since generation?" It does **not** answer "would re-running
+//! `generate` today produce byte-identical files?" — collision-disambiguating TypeScript names
+//! and tool categorization both affect generated output without affecting either digest below.
+//!
+//! # Hashing approach
+//!
+//! Both [`ConfigFingerprint`] and [`ToolDigest`] are SHA-256 digests (hex-encoded, lowercase)
+//! over a hand-built preimage — never over `Debug` output (no stability guarantee) or a
+//! `serde_json::Value`'s serialized bytes (this workspace enables `serde_json/preserve_order`
+//! transitively via `handlebars`, and even without that, a `HashMap`-backed preimage would vary
+//! by process). Every preimage is built from the `Preimage` length-framing primitive over an
+//! explicitly sorted, fixed field order, so two semantically identical inputs always hash
+//! identically regardless of map iteration order — see [`ConfigFingerprint::compute`] and
+//! [`ToolDigest::compute`] for the exact field lists.
+//!
+//! [`ConfigFingerprint`] deliberately excludes every secret-bearing *value* (argument values,
+//! environment variable values, header values, query-parameter values, userinfo) from its
+//! preimage — only structural signal (names, counts, the URL's scheme/authority/path) goes in.
+//! Rotating a credential must never register as configuration drift.
+
+use crate::redact::{UrlTailKind, split_url};
+use crate::server_config::{ServerConfig, Transport};
+use crate::untrusted::sanitize_untrusted_inline;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Domain-separation tag for [`ConfigFingerprint::compute`]'s preimage.
+const CONFIG_FINGERPRINT_DOMAIN: &str = "mcp-execution:config-fingerprint:v1";
+
+/// Domain-separation tag for a single tool entry's preimage, hashed inside
+/// [`ToolDigest::compute`].
+const TOOL_ENTRY_DOMAIN: &str = "mcp-execution:tool-entry:v1";
+
+/// Domain-separation tag for [`ToolDigest::compute`]'s aggregate preimage.
+const TOOL_DIGEST_DOMAIN: &str = "mcp-execution:tool-digest:v1";
+
+/// Tag byte marking a URL that [`split_url`] parsed successfully, in
+/// [`push_url_and_headers`]'s preimage contribution.
+const URL_PARSED: u8 = 0;
+/// Tag byte marking a URL [`split_url`] could not parse, standing in for the whole
+/// scheme/authority/path/query contribution (N3: a distinct tag, not a literal `<unparseable>`
+/// string, so no real URL content can collide with it).
+const URL_UNPARSEABLE: u8 = 1;
+
+/// Tag byte marking a named query parameter in [`push_query_param_names`]'s preimage
+/// contribution, followed by the framed name.
+const QUERY_PARAM_NAMED: u8 = 0;
+/// Tag byte marking a bare query parameter (no `=`) — carries no following bytes, so it can
+/// never collide with a real parameter literally named `<bare>` (N3).
+const QUERY_PARAM_BARE: u8 = 1;
+
+/// Type tag for [`hash_value_into`]'s recursive walk over a `serde_json::Value`.
+mod value_tag {
+    pub(super) const NULL: u8 = 0;
+    pub(super) const BOOL: u8 = 1;
+    pub(super) const NUMBER: u8 = 2;
+    pub(super) const STRING: u8 = 3;
+    pub(super) const ARRAY: u8 = 4;
+    pub(super) const OBJECT: u8 = 5;
+}
+
+/// Accumulates a hash preimage as a byte buffer under one framing convention: every
+/// variable-length value is prefixed with its length as a big-endian `u64` before its bytes
+/// ([`Self::str`]/[`Self::bytes`]); every fixed-width value (a count, a presence/tag byte) is
+/// written raw ([`Self::u64`]/[`Self::byte`]/[`Self::raw_32`]). Fixed field order plus this
+/// framing makes the encoding unambiguous without any separator or escaping — see the module
+/// docs for why this replaces both `Debug` output and JSON serialization as a preimage source.
+struct Preimage(Vec<u8>);
+
+impl Preimage {
+    const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Length-prefixed raw bytes.
+    fn bytes(&mut self, bytes: &[u8]) -> &mut Self {
+        let len = bytes.len() as u64;
+        self.0.extend_from_slice(&len.to_be_bytes());
+        self.0.extend_from_slice(bytes);
+        self
+    }
+
+    /// Length-prefixed UTF-8 text.
+    fn str(&mut self, s: &str) -> &mut Self {
+        self.bytes(s.as_bytes())
+    }
+
+    /// A fixed-width count. Not length-prefixed: a `u64`'s width is already fixed, so framing
+    /// it would only waste bytes without resolving any ambiguity.
+    fn u64(&mut self, n: u64) -> &mut Self {
+        self.0.extend_from_slice(&n.to_be_bytes());
+        self
+    }
+
+    /// A single presence/tag byte.
+    fn byte(&mut self, b: u8) -> &mut Self {
+        self.0.push(b);
+        self
+    }
+
+    /// 32 raw bytes (a nested SHA-256 digest). Fixed-width by construction, so — like
+    /// [`Self::u64`] — no length prefix is needed.
+    fn raw_32(&mut self, bytes: [u8; 32]) -> &mut Self {
+        self.0.extend_from_slice(&bytes);
+        self
+    }
+
+    /// Hashes the accumulated buffer with SHA-256.
+    fn finish(&self) -> [u8; 32] {
+        Sha256::digest(&self.0).into()
+    }
+}
+
+/// Hex-encodes `bytes` as lowercase hex, one `{:02x}` pair per byte.
+///
+/// `sha2`'s digest output type does not implement [`std::fmt::LowerHex`], so `format!("{:x}",
+/// ...)` is not available — this explicit loop is the documented replacement (see spec §10)
+/// rather than pulling in a dedicated hex-encoding crate for eight lines.
+fn hex_encode(bytes: [u8; 32]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // Infallible: `String`'s `fmt::Write` impl never returns `Err`.
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// Error returned when a candidate string is not a well-formed digest: exactly 64 lowercase
+/// ASCII hex characters (a hex-encoded SHA-256 digest).
+///
+/// Returned by both [`ConfigFingerprint`] and [`ToolDigest`]'s `TryFrom<String>` impl, which
+/// their `#[serde(try_from = "String")]` `Deserialize` routes every deserialization through —
+/// mirroring [`crate::ServerId`]/[`crate::ToolName`]'s validated-newtype pattern (see their own
+/// doc comments): no separate, unvalidated deserialization path exists for either type, so a
+/// hand-edited `_meta.json` cannot produce a value violating `as_str`'s documented
+/// "64-character lowercase-hex" contract.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::provenance::{ConfigFingerprint, DigestFormatError};
+///
+/// let err = ConfigFingerprint::try_from("not-a-digest".to_string()).unwrap_err();
+/// assert!(matches!(err, DigestFormatError { .. }));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("invalid digest {value:?}: must be exactly 64 lowercase hex characters")]
+pub struct DigestFormatError {
+    /// Sanitized form of the rejected input (see
+    /// [`sanitize_untrusted_inline`](crate::untrusted::sanitize_untrusted_inline)): this value
+    /// comes from an on-disk `_meta.json` a caller may have hand-edited, so it is treated as
+    /// untrusted the same way `ServerIdError`/`ToolNameError` treat their own rejected input.
+    value: String,
+}
+
+/// Validates that `candidate` is exactly 64 lowercase ASCII hex characters, the shape every
+/// [`ConfigFingerprint`]/[`ToolDigest`] produced by [`hex_encode`] always has.
+fn validate_digest_string(candidate: String) -> Result<String, DigestFormatError> {
+    let is_valid = candidate.len() == 64
+        && candidate
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b));
+    if is_valid {
+        Ok(candidate)
+    } else {
+        Err(DigestFormatError {
+            value: sanitize_untrusted_inline(&candidate),
+        })
+    }
+}
+
+/// A stable fingerprint of the [`ServerConfig`] used to connect to and introspect a server,
+/// recorded so a later comparison can detect that connection parameters changed.
+///
+/// Newtype over a 64-character lowercase-hex `String` (a SHA-256 digest), rather than a bare
+/// `String`, for the same reason [`crate::ServerId`]/[`crate::ToolName`] are newtypes: two
+/// same-shaped hex strings sitting adjacent in `crate::metadata::GenerationProvenance` are
+/// trivially swappable by accident, and a single-field newtype still serializes transparently
+/// as a JSON string. [`Deserialize`] is routed through [`TryFrom<String>`] (via
+/// `#[serde(try_from = "String")]`), so a value read back from disk is validated the same way
+/// [`crate::ServerId`]/[`crate::ToolName`] are — see [`DigestFormatError`].
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::provenance::ConfigFingerprint;
+/// use mcp_execution_core::ServerConfig;
+///
+/// let config = ServerConfig::builder().command("docker".to_string()).build().unwrap();
+/// let fingerprint = ConfigFingerprint::compute(&config);
+/// assert_eq!(fingerprint.as_str().len(), 64);
+/// assert!(fingerprint.as_str().chars().all(|c| c.is_ascii_hexdigit()));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct ConfigFingerprint(String);
+
+impl TryFrom<String> for ConfigFingerprint {
+    type Error = DigestFormatError;
+
+    /// Delegates to `validate_digest_string` — the sole entry point [`Deserialize`] uses.
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate_digest_string(value).map(Self)
+    }
+}
+
+impl ConfigFingerprint {
+    /// Computes a fingerprint of `config`, sufficient to detect that connection parameters
+    /// changed, without persisting any secret-bearing value.
+    ///
+    /// The preimage carries, in a fixed order: a domain tag; the transport discriminant
+    /// (`stdio`/`http`/`sse`); for `stdio`, `command`, `cwd` presence, argument *count*, and
+    /// every environment variable *name* (sorted); for `http`/`sse`, the URL's canonical
+    /// `scheme://authority/path` form, its query-parameter *names* (deduplicated, sorted), a
+    /// userinfo-present marker, and every header *name* (ASCII-lowercased, sorted). No argument
+    /// value, environment/header value, query-parameter value, or userinfo is ever fed — see
+    /// the module docs.
+    ///
+    /// `ServerConfig::connect_timeout`/`discover_timeout` are deliberately excluded: they bound
+    /// how long the client waits for a response, not what the server exposes, so changing one
+    /// must not register as a change to the server's identity or tool surface.
+    ///
+    /// Residual collision, documented rather than fixed: every URL `split_url` cannot parse —
+    /// including two configs whose only difference is inside the ambiguous userinfo case it
+    /// rejects, e.g. `https://u:p/w@a.com` vs. `https://u:p/w@b.com` — collapses onto the same
+    /// `URL_UNPARSEABLE` marker and therefore the same fingerprint. This is the same class of
+    /// secrecy-over-precision tradeoff as the other residual collisions in this family (query
+    /// values, userinfo credentials): the input a real fingerprint would need to distinguish
+    /// them is exactly the text this function refuses to hash.
+    ///
+    /// # Examples
+    ///
+    /// Configs differing only in secret-bearing values fingerprint identically:
+    ///
+    /// ```
+    /// use mcp_execution_core::provenance::ConfigFingerprint;
+    /// use mcp_execution_core::ServerConfig;
+    ///
+    /// let a = ServerConfig::builder()
+    ///     .command("docker".to_string())
+    ///     .env("TOKEN".to_string(), "secret-a".to_string())
+    ///     .build()
+    ///     .unwrap();
+    /// let b = ServerConfig::builder()
+    ///     .command("docker".to_string())
+    ///     .env("TOKEN".to_string(), "secret-b".to_string())
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// assert_eq!(ConfigFingerprint::compute(&a), ConfigFingerprint::compute(&b));
+    /// ```
+    #[must_use]
+    pub fn compute(config: &ServerConfig) -> Self {
+        let mut pre = Preimage::new();
+        pre.str(CONFIG_FINGERPRINT_DOMAIN);
+
+        match config.transport() {
+            Transport::Stdio {
+                command,
+                args,
+                env,
+                cwd,
+            } => {
+                pre.str("stdio");
+                pre.str(command);
+                match cwd {
+                    Some(path) => {
+                        pre.byte(1);
+                        pre.bytes(path.as_os_str().as_encoded_bytes());
+                    }
+                    None => {
+                        pre.byte(0);
+                    }
+                }
+                pre.u64(args.len() as u64);
+
+                let mut names: Vec<&str> = env.keys().map(String::as_str).collect();
+                names.sort_unstable();
+                pre.u64(names.len() as u64);
+                for name in names {
+                    pre.str(name);
+                }
+            }
+            Transport::Http { url, headers } => {
+                pre.str("http");
+                push_url_and_headers(&mut pre, url, headers);
+            }
+            Transport::Sse { url, headers } => {
+                pre.str("sse");
+                push_url_and_headers(&mut pre, url, headers);
+            }
+        }
+
+        Self(hex_encode(pre.finish()))
+    }
+
+    /// Returns the fingerprint as a 64-character lowercase-hex string slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::provenance::ConfigFingerprint;
+    /// use mcp_execution_core::ServerConfig;
+    ///
+    /// let config = ServerConfig::builder().command("docker".to_string()).build().unwrap();
+    /// let fingerprint = ConfigFingerprint::compute(&config);
+    /// assert!(!fingerprint.as_str().is_empty());
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Query-parameter name classification fed into [`push_query_param_names`]'s preimage
+/// contribution. `Bare` sorts before every `Named` variant (see the derived [`Ord`]), giving a
+/// deterministic total order regardless of how many bare parameters a query string carries —
+/// they collapse to a single deduplicated entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum QueryParamName<'a> {
+    /// A `?token` segment with no `=`: the text is indistinguishable from a value, so only the
+    /// fact that *some* bare parameter existed is preserved (see spec §6).
+    Bare,
+    /// A `name=value` segment's `name` half.
+    Named(&'a str),
+}
+
+/// Parses `query`'s `&`-separated segments into deduplicated, sorted [`QueryParamName`]s.
+///
+/// Only the segment layout (`name=value` vs. a bare token) is inspected; every value is
+/// discarded before it ever reaches the caller, let alone the hash preimage.
+///
+/// `query` is truncated at the first `#`, if any, before splitting on `&`. This matters because
+/// [`split_url`]'s `Query` tail runs verbatim to the end of the URL by design — a `?`-triggered
+/// tail does not stop at a later `#`, since [`crate::RedactedUrl`]'s `Debug` impl (which shares
+/// that parser) only needs to know *that* a separator was hit, not parse what follows it. This
+/// function does need to parse what follows, so without this truncation a URL fragment
+/// containing its own `&`-separated text would be misread as query parameters — collapsing two
+/// configs with different query strings (`?a=1&b=2` vs `?a=1#&b=2`) onto the same fingerprint,
+/// exactly the false-negative direction NFR-004 forbids.
+fn parse_query_param_names(query: &str) -> Vec<QueryParamName<'_>> {
+    let query = query.find('#').map_or(query, |pos| &query[..pos]);
+
+    let mut names: Vec<QueryParamName<'_>> = query
+        .split('&')
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| match segment.split_once('=') {
+            Some((name, _value)) => QueryParamName::Named(name),
+            None => QueryParamName::Bare,
+        })
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+/// Writes each `name`'s preimage contribution: a type-tag byte (N3) followed by the framed
+/// name for [`QueryParamName::Named`], or nothing further for [`QueryParamName::Bare`] — the
+/// tag byte alone is enough to distinguish a bare marker from a parameter literally named
+/// `<bare>`, which would instead be tagged `QUERY_PARAM_NAMED` and carry that literal text.
+fn push_query_param_names(pre: &mut Preimage, names: &[QueryParamName<'_>]) {
+    pre.u64(names.len() as u64);
+    for name in names {
+        match name {
+            QueryParamName::Named(n) => {
+                pre.byte(QUERY_PARAM_NAMED);
+                pre.str(n);
+            }
+            QueryParamName::Bare => {
+                pre.byte(QUERY_PARAM_BARE);
+            }
+        }
+    }
+}
+
+/// Writes the shared `http`/`sse` portion of [`ConfigFingerprint::compute`]'s preimage: the
+/// URL's canonical form, query-parameter names, a userinfo-present marker, and header names.
+///
+/// Uses [`split_url`] rather than [`crate::RedactedUrl`]'s `Debug` impl (module docs explain
+/// why a `Debug` rendering is unfit as a preimage source) — one parser, two independent
+/// renderings, so the fingerprint's own wire format is pinned by its own tests instead of
+/// inheriting `RedactedUrl`'s.
+fn push_url_and_headers(
+    pre: &mut Preimage,
+    url: &str,
+    headers: &std::collections::HashMap<String, String>,
+) {
+    match split_url(url) {
+        Some(parts) => {
+            pre.byte(URL_PARSED);
+            let canonical = format!("{}://{}{}", parts.scheme, parts.authority, parts.path);
+            pre.str(&canonical);
+
+            let query_names = match parts.tail {
+                Some((UrlTailKind::Query, query)) => parse_query_param_names(query),
+                Some((UrlTailKind::Fragment, _)) | None => Vec::new(),
+            };
+            push_query_param_names(pre, &query_names);
+
+            pre.byte(u8::from(parts.userinfo_present));
+        }
+        None => {
+            pre.byte(URL_UNPARSEABLE);
+        }
+    }
+
+    let mut header_names: Vec<String> = headers.keys().map(|h| h.to_ascii_lowercase()).collect();
+    header_names.sort_unstable();
+    pre.u64(header_names.len() as u64);
+    for name in &header_names {
+        pre.str(name);
+    }
+}
+
+/// A borrowed view over one discovered tool, shaped for [`ToolDigest::compute`] without coupling
+/// `mcp-execution-core` to `mcp-execution-introspector`'s `ToolInfo`.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::provenance::ToolDigestEntry;
+/// use serde_json::json;
+///
+/// let schema = json!({"type": "object"});
+/// let entry = ToolDigestEntry {
+///     name: "create_issue",
+///     description: "Creates a new issue",
+///     input_schema: &schema,
+///     output_schema: None,
+/// };
+/// assert_eq!(entry.name, "create_issue");
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ToolDigestEntry<'a> {
+    /// The tool's MCP name (the call identifier).
+    pub name: &'a str,
+    /// The tool's description, as reported by the server.
+    pub description: &'a str,
+    /// The tool's input JSON Schema.
+    pub input_schema: &'a serde_json::Value,
+    /// The tool's output JSON Schema, if the server reported one.
+    pub output_schema: Option<&'a serde_json::Value>,
+}
+
+/// A stable digest of the discovered tool list (names, descriptions, and input/output schemas)
+/// at generation time, recorded so a later comparison can detect that the server's tool surface
+/// changed.
+///
+/// Newtype over a 64-character lowercase-hex `String` — see [`ConfigFingerprint`]'s doc comment
+/// for why this is a newtype rather than a bare `String`, and for the `TryFrom<String>`/
+/// [`DigestFormatError`] validation its [`Deserialize`] is routed through.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::provenance::{ToolDigest, ToolDigestEntry};
+/// use serde_json::json;
+///
+/// let schema = json!({"type": "object"});
+/// let entries = vec![ToolDigestEntry {
+///     name: "create_issue",
+///     description: "Creates a new issue",
+///     input_schema: &schema,
+///     output_schema: None,
+/// }];
+///
+/// let digest = ToolDigest::compute(&entries);
+/// assert_eq!(digest.as_str().len(), 64);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct ToolDigest(String);
+
+impl TryFrom<String> for ToolDigest {
+    type Error = DigestFormatError;
+
+    /// Delegates to `validate_digest_string` — the sole entry point [`Deserialize`] uses.
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        validate_digest_string(value).map(Self)
+    }
+}
+
+impl ToolDigest {
+    /// Computes an aggregate digest of `entries`, insensitive to input order (including two
+    /// tools sharing the same name in swapped order) but sensitive to any schema/name/
+    /// description edit, tool addition, or tool removal.
+    ///
+    /// Two-level construction: each entry is hashed on its own (domain tag, framed `name`,
+    /// framed `description`, then `input_schema`/`output_schema` via the recursive
+    /// `hash_value_into` walk — `output_schema`'s presence is tagged explicitly, so `None`
+    /// and `Some(Value::Null)` hash differently), the resulting 32-byte digests are sorted, and
+    /// the sorted sequence is hashed into the final aggregate. Sorting digests rather than tool
+    /// names gives a total order even for duplicate tool names, which name-sorting alone would
+    /// leave ambiguous.
+    ///
+    /// # Examples
+    ///
+    /// Reordering the input tool list does not change the digest:
+    ///
+    /// ```
+    /// use mcp_execution_core::provenance::{ToolDigest, ToolDigestEntry};
+    /// use serde_json::json;
+    ///
+    /// let schema_a = json!({"type": "object"});
+    /// let schema_b = json!({"type": "string"});
+    /// let a = ToolDigestEntry { name: "a", description: "", input_schema: &schema_a, output_schema: None };
+    /// let b = ToolDigestEntry { name: "b", description: "", input_schema: &schema_b, output_schema: None };
+    ///
+    /// assert_eq!(
+    ///     ToolDigest::compute(&[a, b]),
+    ///     ToolDigest::compute(&[b, a]),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn compute(entries: &[ToolDigestEntry<'_>]) -> Self {
+        let mut entry_digests: Vec<[u8; 32]> = entries.iter().map(hash_tool_entry).collect();
+        entry_digests.sort_unstable();
+
+        let mut pre = Preimage::new();
+        pre.str(TOOL_DIGEST_DOMAIN);
+        pre.u64(entries.len() as u64);
+        for digest in entry_digests {
+            pre.raw_32(digest);
+        }
+
+        Self(hex_encode(pre.finish()))
+    }
+
+    /// Returns the digest as a 64-character lowercase-hex string slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::provenance::{ToolDigest, ToolDigestEntry};
+    ///
+    /// let digest = ToolDigest::compute(&[] as &[ToolDigestEntry<'_>]);
+    /// assert!(!digest.as_str().is_empty());
+    /// ```
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Hashes a single [`ToolDigestEntry`] into its own 32-byte digest, before the aggregate
+/// [`ToolDigest::compute`] sorts and re-hashes every entry's digest together.
+fn hash_tool_entry(entry: &ToolDigestEntry<'_>) -> [u8; 32] {
+    let mut pre = Preimage::new();
+    pre.str(TOOL_ENTRY_DOMAIN);
+    pre.str(entry.name);
+    pre.str(entry.description);
+    hash_value_into(&mut pre, entry.input_schema);
+    match entry.output_schema {
+        Some(schema) => {
+            pre.byte(1);
+            hash_value_into(&mut pre, schema);
+        }
+        None => {
+            pre.byte(0);
+        }
+    }
+    pre.finish()
+}
+
+/// Recursively feeds a `serde_json::Value` into `pre`, sorting object keys at hash time so the
+/// result never depends on whether `serde_json/preserve_order` is enabled, and never calling
+/// the serializer at all.
+///
+/// Every variant is prefixed with a one-byte type tag ([`value_tag`]) so, for example, the
+/// string `"5"` and the number `5` cannot collide even though their framed bytes would
+/// otherwise be identical. Numbers are hashed via their `to_string()` bytes — `serde_json`'s
+/// `arbitrary_precision` feature is not enabled anywhere in this workspace, so `Value::Number`
+/// is the ordinary, deterministic enum. Array order is preserved (JSON arrays are ordered in
+/// general, e.g. `enum`/`prefixItems`), so reordering one is treated as drift; object key order
+/// is normalized, since JSON objects are unordered by the spec.
+fn hash_value_into(pre: &mut Preimage, value: &serde_json::Value) {
+    match value {
+        serde_json::Value::Null => {
+            pre.byte(value_tag::NULL);
+        }
+        serde_json::Value::Bool(b) => {
+            pre.byte(value_tag::BOOL);
+            pre.byte(u8::from(*b));
+        }
+        serde_json::Value::Number(n) => {
+            pre.byte(value_tag::NUMBER);
+            pre.str(&n.to_string());
+        }
+        serde_json::Value::String(s) => {
+            pre.byte(value_tag::STRING);
+            pre.str(s);
+        }
+        serde_json::Value::Array(items) => {
+            pre.byte(value_tag::ARRAY);
+            pre.u64(items.len() as u64);
+            for item in items {
+                hash_value_into(pre, item);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            pre.byte(value_tag::OBJECT);
+            pre.u64(map.len() as u64);
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable();
+            for key in keys {
+                pre.str(key);
+                hash_value_into(pre, &map[key]);
+            }
+        }
+    }
+}
+
+/// Generation provenance recorded in [`crate::metadata::ServerMetadata`].
+///
+/// Records when a `_meta.json` sidecar was produced, and a fingerprint/digest pair sufficient
+/// for a later comparison to detect that the server changed.
+///
+/// Deliberately not wrapped in `Option` anywhere it's stored: a schema-version check rejects a
+/// pre-provenance (`schema_version: 1`) sidecar before a consumer ever constructs a
+/// [`crate::metadata::ServerMetadata`], so every value that exists already carries real
+/// provenance — see `mcp-execution-skill`'s parser.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::provenance::{GenerationProvenance, ToolDigestEntry};
+/// use mcp_execution_core::ServerConfig;
+///
+/// let config = ServerConfig::builder().command("docker".to_string()).build().unwrap();
+/// let provenance = GenerationProvenance::capture(&config, &[]);
+/// assert_eq!(provenance.tool_digest.as_str().len(), 64);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationProvenance {
+    /// Wall-clock time generation completed, from the `generate` command's own clock.
+    pub generated_at: DateTime<Utc>,
+    /// Fingerprint of the [`ServerConfig`] used to connect to and introspect the server.
+    pub config_fingerprint: ConfigFingerprint,
+    /// Digest of the discovered tool list at generation time.
+    pub tool_digest: ToolDigest,
+}
+
+impl GenerationProvenance {
+    /// Captures provenance for a `generate` run: stamps the current time and computes both the
+    /// config fingerprint and tool digest from the same inputs the run is generating from, so
+    /// the digest can never drift from the emitted files.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mcp_execution_core::provenance::{GenerationProvenance, ToolDigestEntry};
+    /// use mcp_execution_core::ServerConfig;
+    ///
+    /// let config = ServerConfig::builder().command("docker".to_string()).build().unwrap();
+    /// let provenance = GenerationProvenance::capture(&config, &[]);
+    /// assert!(provenance.generated_at <= chrono::Utc::now());
+    /// ```
+    #[must_use]
+    pub fn capture(config: &ServerConfig, tools: &[ToolDigestEntry<'_>]) -> Self {
+        Self {
+            generated_at: Utc::now(),
+            config_fingerprint: ConfigFingerprint::compute(config),
+            tool_digest: ToolDigest::compute(tools),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn stdio_config(command: &str) -> ServerConfig {
+        ServerConfig::builder()
+            .command(command.to_string())
+            .build()
+            .unwrap()
+    }
+
+    // -- Config fingerprint: determinism --
+
+    /// The mandated test: two `HashMap`s built with *different insertion order* must yield
+    /// equal fingerprints. A same-process repeat call cannot catch a `HashMap`-iteration-order
+    /// bug, since a single process's iteration order for a given map is stable across repeated
+    /// reads of the *same* map instance.
+    #[test]
+    fn fingerprint_determinism_env_insertion_order() {
+        let mut env_a = HashMap::new();
+        env_a.insert("ALPHA".to_string(), "1".to_string());
+        env_a.insert("BETA".to_string(), "2".to_string());
+        env_a.insert("GAMMA".to_string(), "3".to_string());
+
+        let mut env_b = HashMap::new();
+        env_b.insert("GAMMA".to_string(), "3".to_string());
+        env_b.insert("ALPHA".to_string(), "1".to_string());
+        env_b.insert("BETA".to_string(), "2".to_string());
+
+        let a = ServerConfig::builder()
+            .command("docker".to_string())
+            .environment(env_a)
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .command("docker".to_string())
+            .environment(env_b)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_determinism_header_insertion_order() {
+        let mut headers_a = HashMap::new();
+        headers_a.insert("X-One".to_string(), "1".to_string());
+        headers_a.insert("X-Two".to_string(), "2".to_string());
+
+        let mut headers_b = HashMap::new();
+        headers_b.insert("X-Two".to_string(), "2".to_string());
+        headers_b.insert("X-One".to_string(), "1".to_string());
+
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .headers(headers_a)
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .headers(headers_b)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    // -- Config fingerprint: security guarantee (positive assertion) --
+
+    #[test]
+    fn fingerprint_equal_when_only_env_values_differ() {
+        let a = ServerConfig::builder()
+            .command("docker".to_string())
+            .env("TOKEN".to_string(), "secret-a".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .command("docker".to_string())
+            .env("TOKEN".to_string(), "secret-b".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_equal_when_only_header_values_differ() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("Authorization".to_string(), "Bearer a".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("Authorization".to_string(), "Bearer b".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_equal_when_only_arg_values_differ() {
+        let a = ServerConfig::builder()
+            .command("npx".to_string())
+            .arg("pkg-a".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .command("npx".to_string())
+            .arg("pkg-b".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_equal_when_only_query_param_values_differ() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp?tenant=alpha".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp?tenant=beta".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_equal_when_only_userinfo_differs() {
+        let a = ServerConfig::builder()
+            .http_transport("https://user:pass-a@api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://user:pass-b@api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    // -- Config fingerprint: sensitivity --
+
+    #[test]
+    fn fingerprint_differs_on_command() {
+        assert_ne!(
+            ConfigFingerprint::compute(&stdio_config("docker")),
+            ConfigFingerprint::compute(&stdio_config("npx")),
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_cwd() {
+        let a = ServerConfig::builder()
+            .command("docker".to_string())
+            .cwd("/tmp/a".into())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .command("docker".to_string())
+            .cwd("/tmp/b".into())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_arg_count() {
+        let a = ServerConfig::builder()
+            .command("docker".to_string())
+            .arg("run".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .command("docker".to_string())
+            .arg("run".to_string())
+            .arg("--rm".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_env_key() {
+        let a = ServerConfig::builder()
+            .command("docker".to_string())
+            .env("ALPHA".to_string(), "1".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .command("docker".to_string())
+            .env("BETA".to_string(), "1".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_header_name() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("X-One".to_string(), "1".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("X-Two".to_string(), "1".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_header_name_case_does_not_change_it() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("Authorization".to_string(), "1".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .header("authorization".to_string(), "1".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_scheme() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .sse_transport("https://api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    /// Unlike `fingerprint_differs_on_scheme` above (which varies the *transport discriminant*,
+    /// http vs sse, while holding the URL's own scheme fixed at `https://` in both branches),
+    /// this isolates the URL's own scheme component — `http://` vs `https://` on an otherwise
+    /// identical `http_transport` config. `ServerConfig` accepts both schemes, so this case is
+    /// reachable and must be covered independently.
+    #[test]
+    fn fingerprint_differs_on_url_scheme_itself() {
+        let a = ServerConfig::builder()
+            .http_transport("http://api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_authority() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api-a.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api-b.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_path() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp-a".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp-b".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    #[test]
+    fn fingerprint_differs_on_query_param_name() {
+        let a = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp?alpha=1".to_string())
+            .build()
+            .unwrap();
+        let b = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp?beta=1".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(
+            ConfigFingerprint::compute(&a),
+            ConfigFingerprint::compute(&b)
+        );
+    }
+
+    // -- URL splitter: exact-string pin + `<bare>`/`<unparseable>` marker cases --
+
+    /// Pins the fingerprint's canonical URL rendering as a wire-format contract: any change to
+    /// this preimage requires a `METADATA_SCHEMA_VERSION` bump.
+    #[test]
+    fn url_canonical_form_exact_string() {
+        let parts = split_url("https://user:pass@api.example.com:8443/mcp/v1?a=1&b=2#frag")
+            .expect("parses");
+        let canonical = format!("{}://{}{}", parts.scheme, parts.authority, parts.path);
+        assert_eq!(canonical, "https://api.example.com:8443/mcp/v1");
+        assert!(parts.userinfo_present);
+    }
+
+    #[test]
+    fn fingerprint_bare_query_param_uses_marker_not_text() {
+        let bare = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp?sk-live-token".to_string())
+            .build()
+            .unwrap();
+        let named = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp?<bare>=1".to_string())
+            .build()
+            .unwrap();
+
+        // The bare marker's tag byte, not literal text, means an actual bare secret-shaped
+        // token and a parameter literally named `<bare>` must fingerprint differently (N3).
+        assert_ne!(
+            ConfigFingerprint::compute(&bare),
+            ConfigFingerprint::compute(&named),
+        );
+    }
+
+    /// Regression for a critic-found collision: `split_url`'s `Query` tail runs verbatim to the
+    /// end of the URL (by design — see its own doc comment), so it can contain a later `#`.
+    /// Without truncating at that `#` before splitting on `&`, `?a=1&b=2` and `?a=1#&b=2` parsed
+    /// to the identical `[Named("a"), Named("b")]` list and therefore the identical fingerprint,
+    /// despite being different query strings (a fragment-only edit registering as false-positive
+    /// query drift, and a real second query parameter hiding behind `#` as a false negative —
+    /// the direction NFR-004 forbids). `parse_query_param_names` must now stop at the first `#`.
+    #[test]
+    fn fingerprint_query_param_names_stop_at_fragment_boundary() {
+        let two_query_params = ServerConfig::builder()
+            .http_transport("https://h.example.com/p?a=1&b=2".to_string())
+            .build()
+            .unwrap();
+        let one_query_param_plus_fragment = ServerConfig::builder()
+            .http_transport("https://h.example.com/p?a=1#&b=2".to_string())
+            .build()
+            .unwrap();
+
+        assert_ne!(
+            ConfigFingerprint::compute(&two_query_params),
+            ConfigFingerprint::compute(&one_query_param_plus_fragment),
+        );
+
+        // The fragment-bearing config must fingerprint the same as one with no `#&b=2` tail at
+        // all — proving the fragment text is excluded entirely, not merely hashed differently.
+        let one_query_param_no_fragment = ServerConfig::builder()
+            .http_transport("https://h.example.com/p?a=1".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(
+            ConfigFingerprint::compute(&one_query_param_plus_fragment),
+            ConfigFingerprint::compute(&one_query_param_no_fragment),
+        );
+    }
+
+    #[test]
+    fn fingerprint_unparseable_url_uses_marker() {
+        // `ServerConfig::build` only enforces an `http`/`https` scheme prefix, so the only way
+        // to reach `split_url`'s `None` case through a validated config is the userinfo
+        // ambiguity it documents: an unencoded '/' inside the password moves the authority
+        // terminator into the middle of the credentials.
+        let config = ServerConfig::builder()
+            .http_transport("https://user:pa/ssw0rd@api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        // Must not panic, and must produce a stable digest distinct from a parseable URL.
+        let fingerprint = ConfigFingerprint::compute(&config);
+        assert_eq!(fingerprint.as_str().len(), 64);
+
+        let parseable = ServerConfig::builder()
+            .http_transport("https://api.example.com/mcp".to_string())
+            .build()
+            .unwrap();
+        assert_ne!(fingerprint, ConfigFingerprint::compute(&parseable));
+    }
+
+    // -- Tool digest --
+
+    fn entry<'a>(name: &'a str, schema: &'a serde_json::Value) -> ToolDigestEntry<'a> {
+        ToolDigestEntry {
+            name,
+            description: "desc",
+            input_schema: schema,
+            output_schema: None,
+        }
+    }
+
+    #[test]
+    fn tool_digest_equal_under_reordered_input() {
+        let schema_a = serde_json::json!({"type": "object"});
+        let schema_b = serde_json::json!({"type": "string"});
+        let a = entry("a", &schema_a);
+        let b = entry("b", &schema_b);
+
+        assert_eq!(ToolDigest::compute(&[a, b]), ToolDigest::compute(&[b, a]),);
+    }
+
+    #[test]
+    fn tool_digest_equal_for_duplicate_names_swapped_order() {
+        let schema_1 = serde_json::json!({"variant": 1});
+        let schema_2 = serde_json::json!({"variant": 2});
+        let first = ToolDigestEntry {
+            name: "dup",
+            description: "",
+            input_schema: &schema_1,
+            output_schema: None,
+        };
+        let second = ToolDigestEntry {
+            name: "dup",
+            description: "",
+            input_schema: &schema_2,
+            output_schema: None,
+        };
+
+        assert_eq!(
+            ToolDigest::compute(&[first, second]),
+            ToolDigest::compute(&[second, first]),
+        );
+    }
+
+    #[test]
+    fn tool_digest_differs_on_schema_edit() {
+        let schema_a = serde_json::json!({"type": "object"});
+        let schema_b = serde_json::json!({"type": "string"});
+        assert_ne!(
+            ToolDigest::compute(&[entry("a", &schema_a)]),
+            ToolDigest::compute(&[entry("a", &schema_b)]),
+        );
+    }
+
+    #[test]
+    fn tool_digest_differs_on_tool_added() {
+        let schema = serde_json::json!({"type": "object"});
+        assert_ne!(
+            ToolDigest::compute(&[entry("a", &schema)]),
+            ToolDigest::compute(&[entry("a", &schema), entry("b", &schema)]),
+        );
+    }
+
+    #[test]
+    fn tool_digest_differs_on_tool_removed() {
+        let schema = serde_json::json!({"type": "object"});
+        assert_ne!(
+            ToolDigest::compute(&[entry("a", &schema), entry("b", &schema)]),
+            ToolDigest::compute(&[entry("a", &schema)]),
+        );
+    }
+
+    #[test]
+    fn tool_digest_equal_for_nested_object_key_reordering() {
+        let schema_a = serde_json::json!({
+            "type": "object",
+            "properties": {"b": {"type": "string"}, "a": {"type": "number"}}
+        });
+        let schema_b = serde_json::json!({
+            "properties": {"a": {"type": "number"}, "b": {"type": "string"}},
+            "type": "object"
+        });
+
+        assert_eq!(
+            ToolDigest::compute(&[entry("t", &schema_a)]),
+            ToolDigest::compute(&[entry("t", &schema_b)]),
+        );
+    }
+
+    /// N1: `output_schema`'s `None` and `Some(Value::Null)` must hash differently — the
+    /// presence byte, not the value walk alone, is what distinguishes them.
+    #[test]
+    fn tool_digest_distinguishes_absent_output_schema_from_null_output_schema() {
+        let input_schema = serde_json::json!({"type": "object"});
+        let null_schema = serde_json::Value::Null;
+
+        let without = ToolDigestEntry {
+            name: "t",
+            description: "",
+            input_schema: &input_schema,
+            output_schema: None,
+        };
+        let with_null = ToolDigestEntry {
+            name: "t",
+            description: "",
+            input_schema: &input_schema,
+            output_schema: Some(&null_schema),
+        };
+
+        assert_ne!(
+            ToolDigest::compute(&[without]),
+            ToolDigest::compute(&[with_null]),
+        );
+    }
+
+    #[test]
+    fn generation_provenance_capture_stamps_current_time() {
+        let config = stdio_config("docker");
+        let before = Utc::now();
+        let provenance = GenerationProvenance::capture(&config, &[]);
+        let after = Utc::now();
+        assert!(provenance.generated_at >= before && provenance.generated_at <= after);
+    }
+
+    #[test]
+    fn provenance_types_are_send_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<GenerationProvenance>();
+        assert_sync::<GenerationProvenance>();
+        assert_send::<ConfigFingerprint>();
+        assert_sync::<ConfigFingerprint>();
+        assert_send::<ToolDigest>();
+        assert_sync::<ToolDigest>();
+    }
+
+    // -- Digest format validation (ConfigFingerprint/ToolDigest TryFrom<String>) --
+
+    #[test]
+    fn digest_try_from_accepts_valid_lowercase_hex() {
+        let valid = "a".repeat(64);
+        assert!(ConfigFingerprint::try_from(valid.clone()).is_ok());
+        assert!(ToolDigest::try_from(valid).is_ok());
+    }
+
+    #[test]
+    fn digest_try_from_rejects_wrong_length() {
+        assert!(ConfigFingerprint::try_from("a".repeat(63)).is_err());
+        assert!(ConfigFingerprint::try_from("a".repeat(65)).is_err());
+        assert!(ConfigFingerprint::try_from(String::new()).is_err());
+    }
+
+    #[test]
+    fn digest_try_from_rejects_uppercase_hex() {
+        let uppercase = "A".repeat(64);
+        assert!(ConfigFingerprint::try_from(uppercase).is_err());
+    }
+
+    #[test]
+    fn digest_try_from_rejects_non_hex_characters() {
+        let mut candidate = "a".repeat(63);
+        candidate.push('g');
+        assert!(ConfigFingerprint::try_from(candidate).is_err());
+    }
+
+    /// A `ConfigFingerprint`/`ToolDigest` deserialized from JSON goes through the same
+    /// validation as direct `TryFrom<String>` construction — there is no bypass via `serde`.
+    #[test]
+    fn digest_deserialize_rejects_malformed_value() {
+        let result: Result<ConfigFingerprint, _> = serde_json::from_str(r#""not-a-digest""#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn digest_deserialize_accepts_valid_value() {
+        let valid = "b".repeat(64);
+        let json = serde_json::to_string(&valid).unwrap();
+        let fingerprint: ConfigFingerprint = serde_json::from_str(&json).unwrap();
+        assert_eq!(fingerprint.as_str(), valid);
+    }
+
+    #[test]
+    fn digest_format_error_sanitizes_rejected_value() {
+        let err = ConfigFingerprint::try_from("bad&value".to_string()).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("bad&amp;value"));
+        assert!(!message.contains("bad&value"));
+    }
+}

--- a/crates/mcp-core/src/redact.rs
+++ b/crates/mcp-core/src/redact.rs
@@ -144,43 +144,138 @@ pub struct RedactedUrl<'a>(pub &'a str);
 
 impl fmt::Debug for RedactedUrl<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Some((scheme, rest)) = self.0.split_once("://") else {
+        let Some(parts) = split_url(self.0) else {
             return f.write_str(REDACTED_PLACEHOLDER);
         };
 
-        let scheme_is_valid = !scheme.is_empty()
-            && scheme
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'));
-        if !scheme_is_valid {
-            return f.write_str(REDACTED_PLACEHOLDER);
+        if parts.userinfo_present {
+            write!(
+                f,
+                "{}://{REDACTED_PLACEHOLDER}@{}{}",
+                parts.scheme, parts.authority, parts.path
+            )?;
+        } else {
+            write!(f, "{}://{}{}", parts.scheme, parts.authority, parts.path)?;
         }
 
-        let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
-        let (authority, remainder) = rest.split_at(authority_end);
-
-        // See the type doc comment: an `@` past the authority terminator
-        // means the terminator landed inside unencoded userinfo rather than
-        // at a true authority boundary, so the split can't be trusted.
-        if remainder.contains('@') {
-            return f.write_str(REDACTED_PLACEHOLDER);
-        }
-
-        let authority = authority.rfind('@').map_or_else(
-            || authority.to_string(),
-            |at| format!("{REDACTED_PLACEHOLDER}@{}", &authority[at + 1..]),
-        );
-
-        let separator_pos = remainder.find(['?', '#']);
-        let path = separator_pos.map_or(remainder, |pos| &remainder[..pos]);
-
-        write!(f, "{scheme}://{authority}{path}")?;
-        if let Some(pos) = separator_pos {
-            let separator = &remainder[pos..=pos];
+        if let Some((kind, _)) = parts.tail {
+            let separator = match kind {
+                UrlTailKind::Query => '?',
+                UrlTailKind::Fragment => '#',
+            };
             write!(f, "{separator}{REDACTED_PLACEHOLDER}")?;
         }
         Ok(())
     }
+}
+
+/// Which separator introduced a [`SplitUrl`]'s `tail` — the first `?` or `#` found after the
+/// authority. Mirrors [`split_url`]'s single-separator rule: whichever character comes first
+/// determines the whole kind, even if the other character also appears later inside `tail`'s
+/// text (e.g. a `#` inside an unparsed query string, or a `?` inside a fragment).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UrlTailKind {
+    /// The separator was `?`: `tail` is the URL's query string.
+    Query,
+    /// The separator was `#`: `tail` is the URL's fragment.
+    Fragment,
+}
+
+/// Parsed pieces of a `scheme://...` URL, shared by [`RedactedUrl`]'s [`Debug`] impl and the
+/// config-fingerprint preimage (`mcp_execution_core::provenance`). Two renderings over one
+/// parser, so they cannot disagree about where the authority ends — see [`split_url`].
+#[derive(Clone, Copy)]
+pub struct SplitUrl<'a> {
+    /// URL scheme, validated to contain only characters legal in a URI scheme.
+    pub(crate) scheme: &'a str,
+    /// Whether the authority carried a `user[:pass]@` prefix. The credentials themselves are
+    /// never exposed by this type — only their presence.
+    pub(crate) userinfo_present: bool,
+    /// Host\[:port\], with any userinfo prefix already stripped.
+    pub(crate) authority: &'a str,
+    /// Path segment, up to (not including) the first `?`/`#` after the authority. Empty if the
+    /// URL has no path.
+    pub(crate) path: &'a str,
+    /// The first `?`/`#` found after the authority, paired with everything from just past that
+    /// character to the end of the URL — verbatim, even if it itself contains further `?`/`#`
+    /// characters. `None` if the URL has no query string or fragment.
+    pub(crate) tail: Option<(UrlTailKind, &'a str)>,
+}
+
+impl fmt::Debug for SplitUrl<'_> {
+    /// Hand-written rather than derived: `tail` carries the raw, unredacted query string or
+    /// fragment — the exact secret-shaped text this module exists to keep out of `Debug`
+    /// output. Currently unreachable from outside the crate (`SplitUrl` is `pub` but `mod
+    /// redact` is private and this type is not re-exported at `lib.rs`), but a derived impl
+    /// would silently reopen that leak the moment either changes, inside the one module whose
+    /// stated purpose is preventing it.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SplitUrl")
+            .field("scheme", &self.scheme)
+            .field("userinfo_present", &self.userinfo_present)
+            .field("authority", &self.authority)
+            .field("path", &self.path)
+            .field(
+                "tail",
+                &self
+                    .tail
+                    .as_ref()
+                    .map(|(kind, _)| (kind, REDACTED_PLACEHOLDER)),
+            )
+            .finish()
+    }
+}
+
+/// Parses `url` into [`SplitUrl`]'s pieces, or returns `None` for every shape [`RedactedUrl`]
+/// redacts in full: no `://`, an invalid scheme, or an authority/userinfo split that can't be
+/// trusted (see [`RedactedUrl`]'s own doc comment for the ambiguity this last case guards
+/// against).
+///
+/// Deliberately parse-free, matching [`RedactedUrl`]'s existing documented tradeoff: this crate
+/// does not depend on the `url` crate, so a URL that a strict parser would accept can still be
+/// rejected here in favor of staying consistent with the rest of this module's boundary.
+pub fn split_url(url: &str) -> Option<SplitUrl<'_>> {
+    let (scheme, rest) = url.split_once("://")?;
+
+    let scheme_is_valid = !scheme.is_empty() && scheme.chars().all(is_scheme_char);
+    if !scheme_is_valid {
+        return None;
+    }
+
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let (authority_with_userinfo, remainder) = rest.split_at(authority_end);
+
+    // See `RedactedUrl`'s doc comment: an `@` past the authority terminator means the
+    // terminator landed inside unencoded userinfo rather than at a true authority boundary, so
+    // the split can't be trusted.
+    if remainder.contains('@') {
+        return None;
+    }
+
+    let (userinfo_present, authority) = authority_with_userinfo
+        .rfind('@')
+        .map_or((false, authority_with_userinfo), |at| {
+            (true, &authority_with_userinfo[at + 1..])
+        });
+
+    let separator_pos = remainder.find(['?', '#']);
+    let path = separator_pos.map_or(remainder, |pos| &remainder[..pos]);
+    let tail = separator_pos.map(|pos| {
+        let kind = if remainder.as_bytes()[pos] == b'?' {
+            UrlTailKind::Query
+        } else {
+            UrlTailKind::Fragment
+        };
+        (kind, &remainder[pos + 1..])
+    });
+
+    Some(SplitUrl {
+        scheme,
+        userinfo_present,
+        authority,
+        path,
+        tail,
+    })
 }
 
 /// Characters legal in a URI scheme, per [`RedactedUrl`]'s own scheme check.
@@ -732,5 +827,39 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(&json_line)
                 .unwrap_or_else(|e| panic!("invalid JSON for {raw:?}: {e}\n{json_line}"));
         }
+    }
+
+    /// `SplitUrl`'s hand-written `Debug` impl (not derived) must redact `tail` the same way
+    /// `RedactedUrl` redacts a query string — a secret placed there must never appear in
+    /// `{:?}` output, even though `SplitUrl` itself is currently unreachable from outside the
+    /// crate.
+    #[test]
+    fn split_url_debug_redacts_tail() {
+        let secret = "sk-secret-token";
+        let url = format!("https://host.com/path?api_key={secret}");
+        let parts = split_url(&url).unwrap();
+        let debug_output = format!("{parts:?}");
+        assert!(!debug_output.contains(secret));
+        assert!(debug_output.contains(REDACTED_PLACEHOLDER));
+        assert!(debug_output.contains("host.com"));
+    }
+
+    /// Companion to the query case above: a fragment must be redacted the same way.
+    #[test]
+    fn split_url_debug_redacts_fragment_tail() {
+        let secret = "sk-secret-fragment";
+        let url = format!("https://host.com/path#{secret}");
+        let parts = split_url(&url).unwrap();
+        let debug_output = format!("{parts:?}");
+        assert!(!debug_output.contains(secret));
+        assert!(debug_output.contains(REDACTED_PLACEHOLDER));
+    }
+
+    /// A URL with no query/fragment must render `tail` as `None`, not a spurious placeholder.
+    #[test]
+    fn split_url_debug_shows_none_tail_when_absent() {
+        let parts = split_url("https://host.com/path").unwrap();
+        let debug_output = format!("{parts:?}");
+        assert!(debug_output.contains("tail: None"));
     }
 }

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -674,8 +674,13 @@ impl GeneratorService {
             )
         })?;
 
-        let code = generate_with_categorization(&generator, &pending.server_info, categorization)
-            .map_err(|e| {
+        let code = generate_with_categorization(
+            &generator,
+            &pending.server_info,
+            &pending.config,
+            categorization,
+        )
+        .map_err(|e| {
             McpError::internal_error(
                 format!("Failed to generate code: {}", describe_with_causes(&e)),
                 None,
@@ -1705,6 +1710,7 @@ fn describe_with_causes(err: &(dyn std::error::Error + 'static)) -> String {
 fn generate_with_categorization(
     generator: &ProgressiveGenerator,
     server_info: &mcp_execution_introspector::ServerInfo,
+    server_config: &mcp_execution_core::ServerConfig,
     categorization: &HashMap<String, &CategorizedTool>,
 ) -> mcp_execution_core::Result<mcp_execution_codegen::GeneratedCode> {
     use mcp_execution_codegen::progressive::ToolCategorization;
@@ -1724,7 +1730,7 @@ fn generate_with_categorization(
         })
         .collect();
 
-    generator.generate_with_categories(server_info, &categorizations)
+    generator.generate_with_categories(server_info, server_config, &categorizations)
 }
 
 /// Splits `CategorizedTool::keywords`' comma-separated wire format into the individual
@@ -1750,6 +1756,21 @@ mod tests {
     // ========================================================================
     // Helper Functions Tests
     // ========================================================================
+
+    /// `ServerConfig` passed alongside a mock `ServerInfo` so `generate_with_categorization`
+    /// can stamp generation provenance.
+    fn test_server_config() -> ServerConfig {
+        ServerConfig::builder()
+            .command("test-command".to_string())
+            .build()
+            .unwrap()
+    }
+
+    /// Provenance for a hand-built `ServerMetadata` sidecar fixture, required now that
+    /// `provenance` is a non-`Option` field.
+    fn test_provenance() -> mcp_execution_core::provenance::GenerationProvenance {
+        mcp_execution_core::provenance::GenerationProvenance::capture(&test_server_config(), &[])
+    }
 
     #[test]
     fn test_extract_parameter_names() {
@@ -1969,7 +1990,12 @@ mod tests {
         let mut categorization = HashMap::new();
         categorization.insert("test_tool".to_string(), &categorized_tool);
 
-        let result = generate_with_categorization(&generator, &server_info, &categorization);
+        let result = generate_with_categorization(
+            &generator,
+            &server_info,
+            &test_server_config(),
+            &categorization,
+        );
         assert!(result.is_ok());
 
         let code = result.unwrap();
@@ -2023,7 +2049,12 @@ mod tests {
         categorization.insert("tool1".to_string(), &tool1);
         categorization.insert("tool2".to_string(), &tool2);
 
-        let result = generate_with_categorization(&generator, &server_info, &categorization);
+        let result = generate_with_categorization(
+            &generator,
+            &server_info,
+            &test_server_config(),
+            &categorization,
+        );
         assert!(result.is_ok());
     }
 
@@ -2046,7 +2077,12 @@ mod tests {
 
         let categorization = HashMap::new();
 
-        let result = generate_with_categorization(&generator, &server_info, &categorization);
+        let result = generate_with_categorization(
+            &generator,
+            &server_info,
+            &test_server_config(),
+            &categorization,
+        );
         assert!(result.is_ok());
     }
 
@@ -4951,6 +4987,7 @@ mod tests {
                     description: None,
                 }],
             }],
+            provenance: test_provenance(),
         };
         let content = serde_json::to_string_pretty(&meta).unwrap();
         tokio::fs::write(target_dir.join(METADATA_FILE_NAME), content)
@@ -5017,6 +5054,7 @@ mod tests {
                     description: None,
                 }],
             }],
+            provenance: test_provenance(),
         };
         let content = serde_json::to_string_pretty(&meta).unwrap();
         tokio::fs::write(target_dir.join(METADATA_FILE_NAME), content)
@@ -5097,6 +5135,7 @@ mod tests {
                     description: None,
                 }],
             }],
+            provenance: test_provenance(),
         };
         let content = serde_json::to_string_pretty(&meta).unwrap();
         tokio::fs::write(target_dir.join(METADATA_FILE_NAME), content)
@@ -5171,6 +5210,7 @@ mod tests {
                     description: None,
                 }],
             }],
+            provenance: test_provenance(),
         };
         let content = serde_json::to_string_pretty(&meta).unwrap();
         tokio::fs::write(target_dir.join(METADATA_FILE_NAME), content)

--- a/crates/mcp-server/tests/skill_tests.rs
+++ b/crates/mcp-server/tests/skill_tests.rs
@@ -3,10 +3,21 @@
 use mcp_execution_core::metadata::{
     METADATA_FILE_NAME, METADATA_SCHEMA_VERSION, ParameterMetadata, ServerMetadata, ToolMetadata,
 };
-use mcp_execution_core::{ServerId, ToolName};
+use mcp_execution_core::provenance::GenerationProvenance;
+use mcp_execution_core::{ServerConfig, ServerId, ToolName};
 use mcp_execution_skill::{ParsedToolFile, ScanError, build_skill_context, scan_tools_directory};
 use tempfile::TempDir;
 use tokio::fs;
+
+/// Provenance for a hand-built `ServerMetadata` sidecar fixture, required now that
+/// `provenance` is a non-`Option` field.
+fn test_provenance() -> GenerationProvenance {
+    let config = ServerConfig::builder()
+        .command("test-command".to_string())
+        .build()
+        .unwrap();
+    GenerationProvenance::capture(&config, &[])
+}
 
 /// Build a `ServerMetadata` sidecar with `count` simple test tools, each with one
 /// required string parameter, and write it as `_meta.json` into `dir`.
@@ -43,6 +54,7 @@ async fn write_metadata_sidecar(dir: &std::path::Path, tool_names: &[&str]) {
                 ],
             })
             .collect(),
+        provenance: test_provenance(),
     };
 
     let content = serde_json::to_string_pretty(&meta).unwrap();
@@ -423,6 +435,7 @@ async fn test_scan_directory_file_too_large() {
             description: Some(String::new()),
             parameters: vec![],
         }],
+        provenance: test_provenance(),
     };
     meta.tools[0].description = Some(large_description);
 

--- a/crates/mcp-skill/src/parser.rs
+++ b/crates/mcp-skill/src/parser.rs
@@ -88,7 +88,10 @@ pub enum ScanError {
     },
 
     /// The sidecar's `schema_version` does not match the version this crate understands.
-    #[error("unsupported metadata schema version: found {found}, expected {expected}")]
+    #[error(
+        "unsupported metadata schema version: found {found}, expected {expected} \
+         (re-run 'generate' to regenerate this server)"
+    )]
     UnsupportedSchema {
         /// Schema version read from the sidecar.
         found: u32,
@@ -134,6 +137,19 @@ pub enum ScanError {
         /// Sanitized path of the sidecar that references `tool`.
         sidecar_path: String,
     },
+}
+
+/// Minimal shape used to read a sidecar's `schema_version` before attempting a typed
+/// [`ServerMetadata`] parse.
+///
+/// A genuine `schema_version: 1` document has no `provenance` key at all, so parsing it
+/// directly as [`ServerMetadata`] would fail with a generic "missing field `provenance`"
+/// [`ScanError::MetadataParse`] before [`ScanError::UnsupportedSchema`] — the error this probe
+/// exists to produce — ever gets a chance to fire. `#[derive(Deserialize)]` ignores unknown
+/// fields by default, so this probe succeeds against both a v1 and a v2 document.
+#[derive(Deserialize)]
+struct SchemaVersionProbe {
+    schema_version: u32,
 }
 
 /// Result of [`scan_tools_directory`]: the parsed tools plus any non-fatal
@@ -311,18 +327,30 @@ pub async fn scan_tools_directory(dir: &Path) -> Result<ScanResult, ScanError> {
 
     let content = tokio::fs::read_to_string(&canonical_meta).await?;
 
-    let meta: ServerMetadata =
+    // `schema_version` is checked from a minimal probe *before* the typed `ServerMetadata`
+    // parse below, not after: a genuine `schema_version: 1` sidecar has no `provenance` key at
+    // all, so a typed parse against the current (v2) shape would fail first with a generic
+    // "missing field `provenance`" `MetadataParse`, and `UnsupportedSchema` — the error this
+    // check exists to produce — could never fire. A bare `#[derive(Deserialize)]` probe ignores
+    // unknown fields by default, so it succeeds against both v1 and v2 documents alike.
+    let probe: SchemaVersionProbe =
         serde_json::from_str(&content).map_err(|source| ScanError::MetadataParse {
             path: sanitize_path_for_error(&meta_path),
             source,
         })?;
 
-    if meta.schema_version != METADATA_SCHEMA_VERSION {
+    if probe.schema_version != METADATA_SCHEMA_VERSION {
         return Err(ScanError::UnsupportedSchema {
-            found: meta.schema_version,
+            found: probe.schema_version,
             expected: METADATA_SCHEMA_VERSION,
         });
     }
+
+    let meta: ServerMetadata =
+        serde_json::from_str(&content).map_err(|source| ScanError::MetadataParse {
+            path: sanitize_path_for_error(&meta_path),
+            source,
+        })?;
 
     if meta.tools.len() > MAX_TOOL_FILES {
         return Err(ScanError::TooManyFiles {
@@ -798,8 +826,17 @@ pub fn extract_skill_metadata(
 mod tests {
     use super::*;
     use mcp_execution_core::metadata::{ParameterMetadata, ToolMetadata};
-    use mcp_execution_core::{ServerId, ToolName};
+    use mcp_execution_core::provenance::GenerationProvenance;
+    use mcp_execution_core::{ServerConfig, ServerId, ToolName};
     use tempfile::TempDir;
+
+    fn test_provenance() -> GenerationProvenance {
+        let config = ServerConfig::builder()
+            .command("test-command".to_string())
+            .build()
+            .unwrap();
+        GenerationProvenance::capture(&config, &[])
+    }
 
     fn sample_metadata(tool_count: usize) -> ServerMetadata {
         ServerMetadata {
@@ -822,6 +859,7 @@ mod tests {
                     }],
                 })
                 .collect(),
+            provenance: test_provenance(),
         }
     }
 
@@ -1070,11 +1108,16 @@ mod tests {
     async fn test_scan_tools_directory_rejects_invalid_server_id_in_valid_json() {
         let temp_dir = TempDir::new().unwrap();
         let json = r#"{
-            "schema_version": 1,
+            "schema_version": 2,
             "server_id": "not/a/valid/id",
             "server_name": "GitHub",
             "server_version": "1.0.0",
-            "tools": []
+            "tools": [],
+            "provenance": {
+                "generated_at": "2026-01-01T00:00:00Z",
+                "config_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
+                "tool_digest": "0000000000000000000000000000000000000000000000000000000000000000"
+            }
         }"#;
         tokio::fs::write(temp_dir.path().join(METADATA_FILE_NAME), json)
             .await
@@ -1090,7 +1133,7 @@ mod tests {
     async fn test_scan_tools_directory_rejects_invalid_tool_name_in_valid_json() {
         let temp_dir = TempDir::new().unwrap();
         let json = r#"{
-            "schema_version": 1,
+            "schema_version": 2,
             "server_id": "github",
             "server_name": "GitHub",
             "server_version": "1.0.0",
@@ -1101,7 +1144,12 @@ mod tests {
                 "keywords": [],
                 "description": null,
                 "parameters": []
-            }]
+            }],
+            "provenance": {
+                "generated_at": "2026-01-01T00:00:00Z",
+                "config_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
+                "tool_digest": "0000000000000000000000000000000000000000000000000000000000000000"
+            }
         }"#;
         tokio::fs::write(temp_dir.path().join(METADATA_FILE_NAME), json)
             .await
@@ -1124,6 +1172,35 @@ mod tests {
         match result {
             Err(ScanError::UnsupportedSchema { found, expected }) => {
                 assert_eq!(found, METADATA_SCHEMA_VERSION + 1);
+                assert_eq!(expected, METADATA_SCHEMA_VERSION);
+            }
+            other => panic!("expected UnsupportedSchema, got: {other:?}"),
+        }
+    }
+
+    /// A genuine `schema_version: 1` sidecar (produced before `provenance` existed) has no
+    /// `provenance` key at all. The probe-before-typed-parse ordering must surface this as
+    /// `UnsupportedSchema { found: 1, expected: 2 }`, not a generic `MetadataParse` "missing
+    /// field `provenance`" error — see the `schema_version` probe's doc comment.
+    #[tokio::test]
+    async fn test_scan_tools_directory_v1_sidecar_missing_provenance_yields_unsupported_schema() {
+        let temp_dir = TempDir::new().unwrap();
+        let json = r#"{
+            "schema_version": 1,
+            "server_id": "github",
+            "server_name": "GitHub",
+            "server_version": "1.0.0",
+            "tools": []
+        }"#;
+        tokio::fs::write(temp_dir.path().join(METADATA_FILE_NAME), json)
+            .await
+            .unwrap();
+
+        let result = scan_tools_directory(temp_dir.path()).await;
+
+        match result {
+            Err(ScanError::UnsupportedSchema { found, expected }) => {
+                assert_eq!(found, 1);
                 assert_eq!(expected, METADATA_SCHEMA_VERSION);
             }
             other => panic!("expected UnsupportedSchema, got: {other:?}"),

--- a/specs/codegen/spec.md
+++ b/specs/codegen/spec.md
@@ -54,8 +54,8 @@ impl GeneratedCode {
 pub struct ProgressiveGenerator<'a> { /* engine: TemplateEngine<'a> */ }
 impl<'a> ProgressiveGenerator<'a> {
     pub fn new() -> Result<Self>;
-    pub fn generate(&self, server_info: &ServerInfo) -> Result<GeneratedCode>;
-    pub fn generate_with_categories(&self, server_info: &ServerInfo, categorizations: &HashMap<String, ToolCategorization>) -> Result<GeneratedCode>;
+    pub fn generate(&self, server_info: &ServerInfo, server_config: &ServerConfig) -> Result<GeneratedCode>;
+    pub fn generate_with_categories(&self, server_info: &ServerInfo, server_config: &ServerConfig, categorizations: &HashMap<String, ToolCategorization>) -> Result<GeneratedCode>;
 }
 pub struct ToolCategorization { pub category: String, pub keywords: Vec<String>, pub short_description: String }
 
@@ -118,7 +118,9 @@ of the sanitizers documented below, run **before** rendering.
 ## 3. Input Contract
 
 `generate`/`generate_with_categories` accept `&ServerInfo` (from
-[[../introspector/spec]]) and an optional `HashMap<String, ToolCategorization>`
+[[../introspector/spec]]), `&ServerConfig` (issue #468 — the config used to connect to and
+introspect the server, consumed only to stamp `_meta.json`'s `provenance` field; see
+[[../core/spec#provenance module (src/provenance.rs)]]), and an optional `HashMap<String, ToolCategorization>`
 keyed by the tool's **raw** name (`ToolInfo.name`), not its
 display-sanitized `typescript_name` — every lookup in
 `generate_with_categories` indexes the map by `tool.name.as_str()` before any
@@ -151,7 +153,7 @@ For a server with N tools, exactly `N + 5` files:
 | `_runtime/mcp-bridge.ts` | Connection management + JSON-RPC client (see [[#Runtime bridge]]) |
 | `package.json` | `{"type":"module","devDependencies":{"@types/node":"^22"}}` |
 | `tsconfig.json` | `target: ES2022`, `module`/`moduleResolution: NodeNext`, `strict: true`, `noEmit: true`, `allowImportingTsExtensions: true`, `skipLibCheck: true`, `types: ["node"]` |
-| `_meta.json` | `mcp_execution_core::metadata::ServerMetadata` (schema_version, server_id/name/version, per-tool metadata incl. **raw, unsanitized** parameter descriptions) |
+| `_meta.json` | `mcp_execution_core::metadata::ServerMetadata` (schema_version, server_id/name/version, per-tool metadata incl. **raw, unsanitized** parameter descriptions, and `provenance`: a `generated_at` timestamp plus a `ConfigFingerprint`/`ToolDigest` pair computed from the same `server_config`/`server_info.tools` this call is generating from — see [[../core/spec#provenance module (src/provenance.rs)]]) |
 
 Each tool's `{Name}Params` is emitted as a `type` alias, not an `interface` —
 only a `type` alias gets the implicit `Record<string, unknown>`-compatible
@@ -426,6 +428,13 @@ Responsibilities:
   extracting twice — the JSDoc-sanitized `PropertyInfo` half feeds the
   `.ts` template, the raw-description half feeds `_meta.json`, sharing one
   schema walk (issue #295).
+- Two `generate`/`generate_with_categories` calls against identical `ServerInfo`/`ServerConfig`
+  input agree on `_meta.json`'s `provenance.config_fingerprint` and `provenance.tool_digest` —
+  only `provenance.generated_at` differs between runs (issue #468). `_meta.json`'s digest is
+  computed from `server_info.tools`, not from the generated `.ts` files' content, so it does
+  **not** detect drift introduced purely by `resolve_typescript_names`' index-based collision
+  suffixes or by a changed `categorizations` map — see
+  [[../core/spec#What provenance does and does not answer]].
 
 ## 13. See Also
 

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -44,6 +44,10 @@ related:
      `mcp-cli`).
    - `metadata` — the `_meta.json` sidecar schema shared by `mcp-codegen`
      (producer) and `mcp-skill`/`mcp-server` (consumers).
+   - `provenance` (issue #468) — `GenerationProvenance`/`ConfigFingerprint`/`ToolDigest`, the
+     generation-timestamp-and-fingerprint data `mcp-codegen` stamps into every
+     `metadata::ServerMetadata` it writes, computed from the same `ServerConfig`/tool list a
+     `generate` run is generating from.
    - `path` — `sanitize_path_for_error` (used by `mcp-skill` and
      `mcp-server` for identical error-message redaction) and
      `contains_parent_dir` (used by both, plus `mcp-cli`, for identical
@@ -66,7 +70,12 @@ related:
      copies of the same algorithm.
    - `redact` — `Debug`-redaction wrapper types (`RedactedItems`,
      `RedactedMapValues`, `RedactedUrl`) used by `ServerConfig` itself and
-     by `mcp-cli`'s CLI-argument types.
+     by `mcp-cli`'s CLI-argument types. `RedactedUrl`'s URL-splitting logic is factored out into
+     a crate-internal `split_url` (issue #468), returning parsed pieces (scheme, userinfo
+     presence, authority, path, query/fragment tail) rather than a formatted string — `Debug`
+     formats those pieces one way, `provenance::ConfigFingerprint::compute` another, so the two
+     can never disagree about where the authority ends, and the fingerprint never depends on a
+     `Debug` rendering's unstable format.
    - `untrusted` — sanitization/boundary-wrapping helpers for
      attacker-controlled MCP-server metadata embedded into Markdown/LLM
      prompts, used by `mcp-skill` and `mcp-server`.
@@ -449,9 +458,9 @@ call `LogFormat::resolve` and then build the same `.boxed()`-branched
 ### `metadata` module (`src/metadata.rs`)
 
 ```rust
-pub const METADATA_SCHEMA_VERSION: u32 = 1;
+pub const METADATA_SCHEMA_VERSION: u32 = 2;
 pub const METADATA_FILE_NAME: &str = "_meta.json";
-pub struct ServerMetadata { schema_version: u32, server_id: ServerId, server_name: String, server_version: String, tools: Vec<ToolMetadata> }
+pub struct ServerMetadata { schema_version: u32, server_id: ServerId, server_name: String, server_version: String, tools: Vec<ToolMetadata>, provenance: GenerationProvenance }
 pub struct ToolMetadata { name: ToolName, typescript_name: String, category: Option<String>, keywords: Vec<String>, description: Option<String>, parameters: Vec<ParameterMetadata> }
 pub struct ParameterMetadata { name, typescript_type, required, description: Option<String> }
 ```
@@ -465,6 +474,78 @@ This is the **wire contract** between `mcp-codegen` (producer, writes
 `METADATA_SCHEMA_VERSION` is the intended way to signal a breaking shape
 change; consumers compare it and fail loudly on mismatch (see
 [[../skill/spec#ScanError]]).
+
+`provenance` (issue #468) is required, not `Option`: a `schema_version: 1` sidecar has no
+`provenance` key at all, and a consumer is expected to check `schema_version` — via a minimal
+probe struct, *before* attempting a typed `ServerMetadata` deserialization (see
+[[../skill/spec#ScanError]]) — so every `ServerMetadata` a consumer actually constructs already
+carries real provenance; an `Option` would encode a state the version check has already ruled
+out.
+
+### `provenance` module (`src/provenance.rs`)
+
+```rust
+pub struct GenerationProvenance { generated_at: DateTime<Utc>, config_fingerprint: ConfigFingerprint, tool_digest: ToolDigest }
+pub struct ConfigFingerprint(String); // 64 lowercase hex chars (SHA-256)
+pub struct ToolDigest(String);        // 64 lowercase hex chars (SHA-256)
+pub struct ToolDigestEntry<'a> { name: &'a str, description: &'a str, input_schema: &'a Value, output_schema: Option<&'a Value> }
+pub struct DigestFormatError { value: String } // not exactly 64 lowercase hex chars
+impl GenerationProvenance { pub fn capture(config: &ServerConfig, tools: &[ToolDigestEntry<'_>]) -> Self; }
+impl ConfigFingerprint { pub fn compute(config: &ServerConfig) -> Self; }
+impl ToolDigest { pub fn compute(entries: &[ToolDigestEntry<'_>]) -> Self; }
+```
+
+`ConfigFingerprint`/`ToolDigest`'s `Deserialize` is routed through `TryFrom<String>` (via
+`#[serde(try_from = "String")]`), mirroring `ServerId`/`ToolName`'s validated-newtype pattern: no
+separate, unvalidated deserialization path exists, so a hand-edited `_meta.json` cannot produce
+one of these types holding a value that violates `as_str`'s documented "64-character
+lowercase-hex" contract. Both types' own `compute` is the only internal construction path and
+always produces a valid value, so this validation only ever fires against externally-sourced
+(deserialized) data.
+
+#### What provenance does and does not answer
+
+Provenance answers **"has the server's exposed surface, or the identity of the endpoint we
+generated from, changed since generation?"** It does **not** answer "would re-running `generate`
+today produce byte-identical files?" — `mcp-codegen`'s collision-disambiguating TypeScript name
+suffixes (index-based, not content-based) and its `categorizations` input both affect generated
+output without affecting either digest. Any future comparison mechanism and all user-facing
+wording must be phrased as "the server changed", never "your files are out of date
+byte-for-byte".
+
+#### Hashing
+
+Both digests are SHA-256 (via the `sha2` crate, `default-features = false`), hex-encoded
+lowercase via an explicit `{:02x}` loop (`sha2`'s digest type has no `LowerHex` impl). Preimages
+are never built from `Debug` output (no stability guarantee — the same objection that rules out
+`std::hash::DefaultHasher`) or from serializing a `serde_json::Value` (this workspace enables
+`serde_json/preserve_order` transitively via `handlebars`, and a `HashMap`-backed preimage would
+vary by process regardless). Instead, one length-framing primitive (`u64` big-endian length ‖
+bytes) builds every preimage from an explicitly sorted, fixed field order.
+
+`ConfigFingerprint::compute`'s preimage carries, in order: a domain tag, the transport
+discriminant (`stdio`/`http`/`sse`), then either `command` + `cwd` presence + argument *count* +
+sorted environment variable *names* (stdio), or the URL's canonical `scheme://authority/path`
+form + deduplicated sorted query-parameter *names* + a userinfo-present marker + sorted
+ASCII-lowercased header *names* (http/sse). **No argument value, environment/header value,
+query-parameter value, or userinfo is ever fed** — this is a deliberate secrecy guarantee, not
+an oversight: rotating a credential must never register as configuration drift. The URL is
+parsed via `redact::split_url` (the same parser `RedactedUrl`'s `Debug` impl uses, factored out
+so the two can't disagree about where the authority ends), never via `RedactedUrl`'s `Debug`
+output itself. A bare query parameter (no `=`) and an unparseable URL each contribute a
+type-tagged marker rather than literal `<bare>`/`<unparseable>` text, so a real parameter or URL
+segment that happens to contain that literal string cannot collide with the marker.
+
+`ToolDigest::compute` is two-level: each tool entry is hashed on its own (domain tag, framed
+`name`/`description`, then `input_schema`/`output_schema` via a recursive `serde_json::Value`
+walk that type-tags every variant and sorts object keys at hash time), the resulting 32-byte
+digests are sorted, and the sorted sequence is hashed into the aggregate — giving a total order
+even for two tools sharing a name. `output_schema`'s `Option` wrapper gets an explicit presence
+byte in the same framing `cwd` already uses, so `None` and `Some(Value::Null)` hash differently.
+
+`GenerationProvenance::capture(config, tools)` stamps `Utc::now()` and computes both digests
+from the same `ServerConfig`/tool list a `generate` call is generating from, so the recorded
+digest can never drift from the emitted files — see [[../codegen/spec]].
 
 ### `path` module (`src/path.rs`)
 

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -123,9 +123,16 @@ never recover parameter descriptions). Now:
    `ScanError::Io` — and requires the resolved sidecar path to
    `starts_with(canonical_base)` — defends against a symlinked
    `_meta.json` escaping the directory (path-traversal via symlink).
-2. Size-checks the sidecar (`MAX_FILE_SIZE`), parses as
-   `mcp_core::metadata::ServerMetadata`, checks
-   `schema_version == METADATA_SCHEMA_VERSION`, checks tool count ≤
+2. Size-checks the sidecar (`MAX_FILE_SIZE`), then reads `schema_version` from a minimal
+   `SchemaVersionProbe { schema_version: u32 }` (a bare `#[derive(Deserialize)]`, which ignores
+   unknown fields by default) and compares it against `METADATA_SCHEMA_VERSION` **before**
+   attempting a typed `mcp_core::metadata::ServerMetadata` parse (issue #468). This ordering is
+   load-bearing, not cosmetic: a genuine `schema_version: 1` sidecar has no `provenance` key at
+   all (that field was added in schema v2, and `ServerMetadata::provenance` is required, not
+   `Option`), so parsing it directly as the current typed shape would fail first with a generic
+   "missing field `provenance`" `ScanError::MetadataParse`, and `ScanError::UnsupportedSchema` —
+   the error this check exists to produce — could never fire. Only once the probe confirms a
+   matching `schema_version` does the typed `ServerMetadata` parse run. Also checks tool count ≤
    `MAX_TOOL_FILES`.
 3. `verify_tool_files_on_disk`: every sidecar entry's `{typescript_name}.ts`
    must exist on disk, or the whole scan fails with
@@ -508,8 +515,9 @@ name before any filesystem work; the rest is delegated with
 ## 9. Error Conditions
 
 `ScanError`: `Io`, `DirectoryNotFound`, `MissingMetadata`,
-`MetadataParse`, `UnsupportedSchema`, `TooManyFiles`, `FileTooLarge`,
-`StaleMetadata`.
+`MetadataParse`, `UnsupportedSchema { found, expected }`, `TooManyFiles`, `FileTooLarge`,
+`StaleMetadata`. `UnsupportedSchema`'s message carries "re-run 'generate' to regenerate this
+server" guidance, matching its sibling `StaleMetadata` (issue #468).
 
 `SkillMetadataError`: `MissingFrontmatter`, `FrontmatterTooLarge`,
 `InvalidYaml`, `MissingField`, `NameTooLong { len, limit }` (issue #419 — `name` exceeded


### PR DESCRIPTION
## Summary
- Adds `mcp_execution_core::provenance` (`GenerationProvenance`, `ConfigFingerprint`, `ToolDigest`) so `_meta.json` records when and against what server state it was generated, closing the gap identified in ADR-369 decision B / §7 item 1.
- Fingerprint/digest are SHA-256 over an explicit, length-framed preimage — never `Debug` output or serialized JSON (this workspace enables `serde_json/preserve_order` transitively via `handlebars`). The config fingerprint excludes every secret-bearing value (argument/env/header/query values, userinfo) by construction, so rotating a credential never registers as drift.
- `METADATA_SCHEMA_VERSION` bumped `1` -> `2`; `ServerMetadata` gained a required `provenance` field. `mcp-execution-skill`'s `scan_tools_directory` now probes `schema_version` before the typed parse, so a pre-existing v1 sidecar surfaces `UnsupportedSchema` (with regeneration guidance) instead of a generic parse error.
- `ProgressiveGenerator::generate`/`generate_with_categories` now take a `&ServerConfig` parameter, computing provenance from the same inputs the run is generating from so the digest can't drift from emitted files.
- `ConfigFingerprint`/`ToolDigest` route `Deserialize` through validated `TryFrom<String>` (mirroring `ServerId`/`ToolName`), so a hand-edited `_meta.json` cannot produce a value violating the documented 64-char lowercase-hex shape.

Design went through two adversarial review rounds (initial critic pass found and the revision fixed a `serde_json` map-ordering non-determinism bug and a schema-version-check ordering bug); implementation was independently validated by test-coverage, performance, and security passes, plus a second adversarial implementation critique that found and a follow-up fix closed a demonstrated `ConfigFingerprint` collision (URL fragment misparsed as query params).

Closes #468.

## Breaking changes
- `_meta.json` sidecars written before this change no longer parse — re-run `generate` to regenerate.
- `ProgressiveGenerator::generate`/`generate_with_categories` signatures changed (added `&ServerConfig` parameter) — source-breaking for callers.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1401 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo deny check` (advisories/bans/licenses/sources all ok)
- [x] `cargo bench --no-run --profile bench-fast`