### PR TITLE
fix(cli): reject --header when combined with --from-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mcp-execution-cli`**: `--header` is no longer silently discarded when combined with
+  `--from-config`. It now conflicts with `--from-config` at clap parse time, matching the
+  existing treatment of the other non-selector flags (`--arg`, `--env`, `--cwd`, the two
+  timeout overrides) (#492).
 - **`mcp-execution-server`**: `list_generated_servers`'s `tool_count` no longer over-reports by
   one for every generated server. The directory-scan filter counted every `.ts` file not starting
   with `_`, which included `index.ts` — the package's always-present re-export entry point,

--- a/crates/mcp-cli/src/cli.rs
+++ b/crates/mcp-cli/src/cli.rs
@@ -138,8 +138,9 @@ impl fmt::Debug for Cli {
 pub struct ServerFlags {
     /// Load server configuration from ~/.claude/mcp.json by name
     ///
-    /// When specified, all other server configuration options are ignored.
-    /// The server must be defined in ~/.claude/mcp.json with matching name.
+    /// When specified, all other server configuration options are rejected as
+    /// conflicting arguments. The server must be defined in ~/.claude/mcp.json
+    /// with matching name.
     ///
     /// Example mcp.json (stdio and http entries can be mixed freely):
     /// ```json
@@ -158,7 +159,7 @@ pub struct ServerFlags {
     ///   }
     /// }
     /// ```
-    #[arg(long = "from-config", conflicts_with_all = ["server", "args", "env", "cwd", "http", "sse", "connect_timeout_secs", "discover_timeout_secs"])]
+    #[arg(long = "from-config", conflicts_with_all = ["server", "args", "env", "cwd", "http", "sse", "headers", "connect_timeout_secs", "discover_timeout_secs"])]
     from_config: Option<String>,
 
     /// Server command (binary name or path)
@@ -188,6 +189,9 @@ pub struct ServerFlags {
     sse: Option<String>,
 
     /// HTTP headers in KEY=VALUE format (for HTTP/SSE transport)
+    ///
+    /// Conflicts with `--from-config`: to send headers for a server defined
+    /// in `mcp.json`, add them to its `headers` field instead.
     #[arg(long = "header", num_args = 1)]
     headers: Vec<String>,
 
@@ -720,6 +724,32 @@ mod tests {
             "github",
             "--discover-timeout-secs",
             "90",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_introspect_header_conflicts_with_from_config() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "introspect",
+            "--from-config",
+            "github",
+            "--header",
+            "Authorization=Bearer x",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parsing_generate_header_conflicts_with_from_config() {
+        let result = Cli::try_parse_from([
+            "mcp-cli",
+            "generate",
+            "--from-config",
+            "github",
+            "--header",
+            "Authorization=Bearer x",
         ]);
         assert!(result.is_err());
     }


### PR DESCRIPTION
## Summary
- `--from-config`'s `conflicts_with_all` list was missing `headers`, so `--header` was silently accepted alongside `--from-config` and then discarded downstream instead of producing a clap conflict error, unlike every other non-selector flag (`--arg`, `--env`, `--cwd`, the two timeout overrides).
- Added `"headers"` to the conflict list for both `introspect` and `generate` (both share `ServerFlags`).
- Reworded the `--from-config` and `--header` doc comments to describe the reject-on-conflict behavior accurately.
- Added regression tests for both subcommands.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --no-fail-fast` (1433 passed)
- [x] `cargo test --doc --all-features --workspace`

Closes #492