### PR TITLE
fix(core): close symlink and create_dir races in resolve_confined_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--from-config`. It now conflicts with `--from-config` at clap parse time, matching the
   existing treatment of the other non-selector flags (`--arg`, `--env`, `--cwd`, the two
   timeout overrides) (#492).
+- **`mcp-execution-server`**: `save_skill`'s file write no longer follows a symlink planted at the
+  target path after `resolve_skill_output_path`'s confinement check but before the write. The
+  check deliberately never creates the terminal path component (the caller writes it), leaving a
+  window a plain `tokio::fs::write` would fall into — the new `mcp_execution_core::write_confined_file`
+  closes it for that exact path on Unix by opening with `O_CREAT | O_TRUNC | O_NOFOLLOW` inside a
+  single `spawn_blocking` call, so there is no separate check-then-write step left to race, and the
+  write keeps the same disconnect-safe atomicity `tokio::fs::write` already had. Windows has no
+  usable equivalent flag for this open (the candidate, `FILE_FLAG_OPEN_REPARSE_POINT`, cannot be
+  combined with the create+truncate open this function needs), so it relies on a `symlink_metadata`
+  pre-check that remains TOCTOU against a racing process — documented as such rather than claimed
+  as closed. Overwrite semantics for a pre-existing regular file are unchanged. This closes the
+  race for the terminal path only on Unix — a symlink swapped in for a parent directory (e.g.
+  `{server_id}/` itself) after the check, or a hardlink at the target, are documented residual gaps
+  on every platform, not silently claimed as closed (#496).
+- **`mcp-execution-core`**: `resolve_confined_path` no longer fails one of two callers racing to
+  resolve the same not-yet-existing confined directory. `create_dir`'s `ErrorKind::AlreadyExists`
+  is now tolerated for both the segment directory and each lenient intermediate directory, and the
+  concurrent winner's directory is re-validated under the exact same confinement rule the loser
+  would have applied had it already existed at call time — this closes the race without weakening
+  either directory-kind's symlink-rejection guarantee (#491).
 - **`mcp-execution-server`**: `list_generated_servers`'s `tool_count` no longer over-reports by
   one for every generated server. The directory-scan filter counted every `.ts` file not starting
   with `_`, which included `index.ts` — the package's always-present re-export entry point,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ version = "0.9.0"
 dependencies = [
  "chrono",
  "dirs",
+ "libc",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dirs = "6.0"
 futures-util = "0.3"
 handlebars = "6.4"
 http = "1"
+libc = "0.2"
 mcp-execution-codegen = { path = "crates/mcp-codegen", version = "0.9.0" }
 mcp-execution-core = { path = "crates/mcp-core", version = "0.9.0" }
 mcp-execution-files = { path = "crates/mcp-files", version = "0.9.0" }

--- a/crates/mcp-core/Cargo.toml
+++ b/crates/mcp-core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "rt"] }
 # Backs `path::first_disallowed_identifier_char`, which gates `ServerId::new`/`ToolName::new`
 # on every platform — unlike `unicode-normalization` below, this cannot be target-gated.
 unicode-security = { workspace = true }
@@ -31,6 +31,11 @@ unicode-security = { workspace = true }
 [target.'cfg(any(windows, target_os = "macos"))'.dependencies]
 unicode-normalization = { workspace = true }
 
+# Only `confinement.rs`'s `write_confined_file` uses this, to pass `O_NOFOLLOW` to
+# `std::fs::OpenOptions::custom_flags` (issue #496).
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/mcp-core/src/confinement.rs
+++ b/crates/mcp-core/src/confinement.rs
@@ -16,6 +16,7 @@
 //! walk, and the terminal-component check — lives here.
 
 use std::ffi::OsStr;
+use std::io::{ErrorKind, Write};
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
 
@@ -40,7 +41,11 @@ pub enum ConfinementTarget<'a> {
     /// resolved directory is confinement-checked and canonicalized but not created.
     Directory(&'a OsStr),
     /// The caller writes the file itself, so the resolved path is confinement-checked but
-    /// neither created nor canonicalized.
+    /// neither created nor canonicalized. [`write_confined_file`] closes the symlink-planting
+    /// race at this exact terminal path between that check and the write itself (issue #496); a
+    /// plain [`tokio::fs::write`] does not. It does not defend against a symlink swapped in for a
+    /// parent directory after the check, nor a hardlink at the target — see its own doc comment
+    /// for the residual.
     File(&'a OsStr),
 }
 
@@ -169,7 +174,18 @@ pub enum ConfinementError {
 /// call starts — whether at `segment` or at any deeper component — is resolved and rejected
 /// *before* this function creates anything under it or descends into it. This is a check against
 /// pre-existing state, not a concurrency guarantee: it does not defend against a symlink planted
-/// by a racing process between this function's checks and the caller's subsequent write.
+/// by a racing process between this function's checks and the caller's subsequent write (see
+/// [`write_confined_file`], which closes that gap for the write itself at the terminal path —
+/// though not against a parent directory swapped for a symlink after this function returns, nor
+/// a hardlink at the target; see its own doc comment for the residual).
+///
+/// Directory creation along the walk *is* safe against concurrent callers resolving the same
+/// not-yet-existing path: `ErrorKind::AlreadyExists` from creating `segment`'s own directory or
+/// any `relative_dirs` component is tolerated, and the entry left behind by the caller that won
+/// the race is then validated exactly as if it had already existed when this call started -
+/// rejected under the same rules (symlink, wrong kind) rather than trusted just because someone
+/// else created it (issue #491). This is the only race this function defends against; the
+/// terminal `target` component is still never created, per the paragraph above.
 ///
 /// # Errors
 ///
@@ -231,10 +247,31 @@ pub async fn resolve_confined_path(
     }
 }
 
+/// Validates `segment_dir`, which is already known to exist (`meta` is its `symlink_metadata`),
+/// under [`resolve_segment_dir`]'s strict policy: rejected outright if it's a symlink (regardless
+/// of where it points), or if it exists as anything other than a directory.
+fn validate_existing_segment_dir(
+    segment_dir: &Path,
+    meta: &std::fs::Metadata,
+) -> Result<(), ConfinementError> {
+    if meta.file_type().is_symlink() {
+        return Err(ConfinementError::SegmentIsSymlink {
+            path: sanitize_path_for_error(segment_dir),
+        });
+    }
+    if !meta.is_dir() {
+        return Err(ConfinementError::NotADirectory {
+            path: sanitize_path_for_error(segment_dir),
+        });
+    }
+    Ok(())
+}
+
 /// Resolves and confines `segment`'s own directory under `canonical_root`, rejecting it outright
 /// if it already exists as a symlink rather than resolving and re-checking it (see
 /// [`resolve_confined_path`]'s doc comment for why). Creates the directory if it doesn't exist
-/// yet.
+/// yet; if a concurrent caller creates it first, `ErrorKind::AlreadyExists` is tolerated and the
+/// winner's directory is validated exactly as if it had already existed (issue #491).
 async fn resolve_segment_dir(
     canonical_root: &Path,
     component: Component<'_>,
@@ -247,29 +284,46 @@ async fn resolve_segment_dir(
         });
     }
     if let Ok(meta) = tokio::fs::symlink_metadata(&segment_dir).await {
-        if meta.file_type().is_symlink() {
-            return Err(ConfinementError::SegmentIsSymlink {
-                path: sanitize_path_for_error(&segment_dir),
-            });
-        }
-        if !meta.is_dir() {
-            return Err(ConfinementError::NotADirectory {
-                path: sanitize_path_for_error(&segment_dir),
-            });
-        }
-    } else {
-        tokio::fs::create_dir(&segment_dir)
-            .await
-            .map_err(|source| ConfinementError::CreateDir {
+        validate_existing_segment_dir(&segment_dir, &meta)?;
+    } else if let Err(source) = tokio::fs::create_dir(&segment_dir).await {
+        if source.kind() != ErrorKind::AlreadyExists {
+            return Err(ConfinementError::CreateDir {
                 path: sanitize_path_for_error(&segment_dir),
                 source,
-            })?;
+            });
+        }
+        let meta = tokio::fs::symlink_metadata(&segment_dir).await?;
+        validate_existing_segment_dir(&segment_dir, &meta)?;
     }
     Ok(segment_dir)
 }
 
+/// Confirms `current`, which is already known to exist, resolves (as a symlink or otherwise) to a
+/// directory still confined to `segment_dir` - [`resolve_lenient_component`]'s lenient policy,
+/// which resolves and re-checks an existing symlink rather than rejecting it outright.
+async fn validate_existing_lenient_component(
+    current: &mut PathBuf,
+    segment_dir: &Path,
+) -> Result<(), ConfinementError> {
+    let resolved = tokio::fs::canonicalize(&current).await?;
+    if !resolved.starts_with(segment_dir) {
+        return Err(ConfinementError::Escape {
+            path: sanitize_path_for_error(current),
+        });
+    }
+    if !tokio::fs::metadata(&resolved).await?.is_dir() {
+        return Err(ConfinementError::NotADirectory {
+            path: sanitize_path_for_error(current),
+        });
+    }
+    *current = resolved;
+    Ok(())
+}
+
 /// Confines `current` to `segment_dir`, resolving (and confirming) an existing symlink rather
-/// than rejecting it outright, or creating the directory if it's missing.
+/// than rejecting it outright, or creating the directory if it's missing. If a concurrent caller
+/// creates it first, `ErrorKind::AlreadyExists` is tolerated and the winner's directory is
+/// validated exactly as if it had already existed (issue #491).
 async fn resolve_lenient_component(
     current: &mut PathBuf,
     segment_dir: &Path,
@@ -280,29 +334,17 @@ async fn resolve_lenient_component(
         });
     }
     match tokio::fs::symlink_metadata(&current).await {
-        Ok(_) => {
-            let resolved = tokio::fs::canonicalize(&current).await?;
-            if !resolved.starts_with(segment_dir) {
-                return Err(ConfinementError::Escape {
-                    path: sanitize_path_for_error(current),
-                });
+        Ok(_) => validate_existing_lenient_component(current, segment_dir).await,
+        Err(_) => match tokio::fs::create_dir(&current).await {
+            Ok(()) => Ok(()),
+            Err(source) if source.kind() == ErrorKind::AlreadyExists => {
+                validate_existing_lenient_component(current, segment_dir).await
             }
-            if !tokio::fs::metadata(&resolved).await?.is_dir() {
-                return Err(ConfinementError::NotADirectory {
-                    path: sanitize_path_for_error(current),
-                });
-            }
-            *current = resolved;
-            Ok(())
-        }
-        Err(_) => {
-            tokio::fs::create_dir(&current)
-                .await
-                .map_err(|source| ConfinementError::CreateDir {
-                    path: sanitize_path_for_error(current),
-                    source,
-                })
-        }
+            Err(source) => Err(ConfinementError::CreateDir {
+                path: sanitize_path_for_error(current),
+                source,
+            }),
+        },
     }
 }
 
@@ -360,6 +402,119 @@ async fn resolve_terminal(
             Ok(final_path)
         }
     }
+}
+
+/// Writes `content` to `path`, refusing to follow a symlink planted at `path`'s exact location
+/// after a caller's [`ConfinementTarget::File`] confinement check but before this call.
+///
+/// [`ConfinementTarget::File`]'s own doc comment calls out the gap this closes: resolving and
+/// confinement-checking a file target deliberately does not create it, so nothing stops a
+/// symlink from being planted at the resolved path between that check and the caller's write -
+/// and a plain [`tokio::fs::write`] would follow it, redirecting the write outside the confined
+/// directory (issue #496).
+///
+/// The entire check-then-write sequence runs inside a single [`tokio::task::spawn_blocking`]
+/// call, using `std::fs` rather than `tokio::fs`: this preserves the same atomicity a plain
+/// `tokio::fs::write` already had - once the blocking task is queued, dropping the returned
+/// future (e.g. because a client disconnected and `rmcp` drops the handler future) does not stop
+/// or partially undo a write that already started running on the blocking pool. An async-native
+/// version built from `tokio::fs::OpenOptions` plus `AsyncWriteExt::write_all` would not have
+/// this property: each `.await` point is a place a dropped future can land between `O_TRUNC`
+/// truncating the file and the content actually being written, leaving a 0-byte file behind
+/// instead of either the old or the new content — worse than not attempting the write at all.
+///
+/// On Unix, the open that creates or truncates `path` also carries `O_NOFOLLOW`, so the kernel
+/// rejects a symlinked terminal component (dangling or not) as part of that same syscall - there
+/// is no separate check-then-write step left for a racing process to land in between *for that
+/// exact path*. A pre-existing regular file is still opened and truncated normally: `O_NOFOLLOW`
+/// only rejects a symlink at the final path component, so this does not change overwrite
+/// semantics for a caller that already decided (via its own `exists()`/`overwrite` check) that
+/// clobbering an existing file is fine.
+///
+/// **Residual gaps, even on Unix**: `O_NOFOLLOW` only guards the *terminal* component. Something
+/// with write access further up the confined path (e.g. `{server_id}/` itself) could rename that
+/// directory aside and drop a symlink in its place after the caller's confinement check but
+/// before this call — the open then traverses the symlinked *parent* and still escapes, one
+/// directory level up from what a flag on the final `open` call can see. A hardlink planted at
+/// `path` (same filesystem) is also not a symlink, so `O_NOFOLLOW` does not reject it, and the
+/// write clobbers whatever the hardlink points at. Neither is defended against here; closing them
+/// would need a directory file descriptor captured during the confinement walk itself
+/// (`openat`/`openat2` with `RESOLVE_NO_SYMLINKS` on Linux) rather than a flag on the terminal
+/// open call alone.
+///
+/// Windows has no usable equivalent for this specific open, even though `custom_flags` is exposed
+/// there too (`std::fs::OpenOptions::custom_flags` via `std::os::windows::fs::OpenOptionsExt`):
+/// `FILE_FLAG_OPEN_REPARSE_POINT`, the flag that opens a reparse point (Windows's symlink
+/// mechanism) itself, is documented by `CreateFileW` as unusable together with `CREATE_ALWAYS` —
+/// which is exactly what a `create(true).truncate(true)` open maps to — and even where it can be
+/// used, it does not reject on open the way `O_NOFOLLOW` does; it hands back a handle to the link
+/// itself, which a plain write would still land on. So Windows relies solely on an
+/// immediately-preceding [`std::fs::symlink_metadata`] check, still inside the same blocking
+/// closure and so still with no yield point in between - this narrows the window against a
+/// symlink already present when the check runs, but remains genuinely open (not just narrowed) to
+/// a symlink a racing *process* plants between that check and the `open` call, since there is no
+/// single-syscall check-and-open on this platform. This crate's test suite has no Windows symlink
+/// coverage — creating a symlink there requires a privilege most CI runners don't grant.
+///
+/// # Errors
+///
+/// Returns [`ConfinementError::Io`] if the symlink check (Windows only), the open, or the write
+/// failed - including the platform's "too many levels of symbolic links" error on Unix when
+/// `path`'s terminal component is a symlink - or if the blocking task itself panicked.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::write_confined_file;
+/// use tempfile::TempDir;
+///
+/// let dir = TempDir::new().unwrap();
+/// let path = dir.path().join("SKILL.md");
+/// tokio::runtime::Builder::new_current_thread()
+///     .build()
+///     .unwrap()
+///     .block_on(write_confined_file(&path, b"---\nname: demo\n---\n"))
+///     .unwrap();
+/// assert_eq!(std::fs::read(&path).unwrap(), b"---\nname: demo\n---\n");
+/// ```
+pub async fn write_confined_file(path: &Path, content: &[u8]) -> Result<(), ConfinementError> {
+    let path = path.to_path_buf();
+    let content = content.to_vec();
+    // The first `?` propagates a `JoinError` (the blocking task panicked or was cancelled,
+    // wrapped via `Error::other`); the second propagates `write_confined_file_blocking`'s own
+    // `io::Result`. Both convert to `ConfinementError` via its `#[from] std::io::Error` variant.
+    tokio::task::spawn_blocking(move || write_confined_file_blocking(&path, &content))
+        .await
+        .map_err(std::io::Error::other)??;
+    Ok(())
+}
+
+/// The synchronous body of [`write_confined_file`], run inside a single `spawn_blocking` call so
+/// the check-then-write sequence is atomic with respect to the calling future being dropped.
+fn write_confined_file_blocking(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    #[cfg(not(unix))]
+    if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        return Err(std::io::Error::new(
+            ErrorKind::AlreadyExists,
+            "refusing to write through a pre-existing symlink",
+        ));
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    // No Windows equivalent: `FILE_FLAG_OPEN_REPARSE_POINT` is documented as unusable together
+    // with `CREATE_ALWAYS` (what `create(true).truncate(true)` maps to), and even where usable it
+    // doesn't reject on open the way `O_NOFOLLOW` does - see this function's doc comment. Windows
+    // relies solely on the `symlink_metadata` pre-check above.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+
+    let mut file = options.open(path)?;
+    file.write_all(content)?;
+    file.flush()
 }
 
 #[cfg(test)]
@@ -680,6 +835,139 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(file_err, ConfinementError::WrongTargetKind { .. }));
+    }
+
+    /// Issue #491: two callers racing to resolve the same not-yet-existing segment directory
+    /// must both succeed - the loser's `create_dir` failing with `AlreadyExists` must be
+    /// tolerated and the winner's directory re-validated, not surfaced as a hard error.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_first_time_segment_creation_both_succeed() {
+        let base = TempDir::new().unwrap();
+        let base_a = base.path().to_path_buf();
+        let base_b = base_a.clone();
+
+        let task_a = tokio::spawn(async move {
+            resolve_confined_path(&base_a, "my-server", Path::new(""), None).await
+        });
+        let task_b = tokio::spawn(async move {
+            resolve_confined_path(&base_b, "my-server", Path::new(""), None).await
+        });
+
+        let (a, b) = tokio::join!(task_a, task_b);
+        assert_eq!(a.unwrap().unwrap(), b.unwrap().unwrap());
+    }
+
+    /// Same race as above, one level deeper in the lenient `relative_dirs` walk.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_first_time_relative_dir_creation_both_succeed() {
+        let base = TempDir::new().unwrap();
+        tokio::fs::create_dir_all(base.path().join("my-server"))
+            .await
+            .unwrap();
+        let base_a = base.path().to_path_buf();
+        let base_b = base_a.clone();
+
+        let task_a = tokio::spawn(async move {
+            resolve_confined_path(&base_a, "my-server", Path::new("nested"), None).await
+        });
+        let task_b = tokio::spawn(async move {
+            resolve_confined_path(&base_b, "my-server", Path::new("nested"), None).await
+        });
+
+        let (a, b) = tokio::join!(task_a, task_b);
+        assert_eq!(a.unwrap().unwrap(), b.unwrap().unwrap());
+    }
+
+    /// `write_confined_file`'s check-then-write sequence must run inside a single
+    /// `spawn_blocking` call so it is atomic with respect to the calling future being dropped
+    /// (e.g. `rmcp` dropping `save_skill`'s handler future on client disconnect) - an
+    /// async-native version built from `tokio::fs::OpenOptions` plus `AsyncWriteExt::write_all`
+    /// has multiple `.await` points, any of which a dropped future can land between `O_TRUNC`
+    /// truncating the file and the content being written, leaving a 0-byte file behind. Aborting
+    /// the spawned task immediately after starting it and re-reading the file must therefore
+    /// always observe either the untouched pre-existing content or the fully written new content
+    /// - never a partial or empty file.
+    ///
+    /// A single iteration only lands the abort inside the vulnerable window often enough to
+    /// discriminate the fix from the pre-fix async-await implementation about 60% of the time, so
+    /// this loops several times rather than relying on one attempt.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_confined_file_survives_future_drop_without_partial_write() {
+        const OLD: &[u8] = b"old-content-should-survive-or-be-fully-replaced";
+        const NEW: &[u8] = b"new-content-0123456789";
+
+        for _ in 0..8 {
+            let base = TempDir::new().unwrap();
+            let path = base.path().join("SKILL.md");
+            tokio::fs::write(&path, OLD).await.unwrap();
+
+            let spawn_path = path.clone();
+            let handle = tokio::spawn(async move { write_confined_file(&spawn_path, NEW).await });
+            std::thread::sleep(std::time::Duration::from_micros(1));
+            handle.abort();
+            let _ = handle.await;
+
+            // Poll briefly rather than a flat settle sleep: a blocking task that was already
+            // running when `abort` fired cannot be interrupted mid-flight, but a write this
+            // small finishes in well under a millisecond once scheduled, so most iterations
+            // don't need to wait at all.
+            let mut content = tokio::fs::read(&path).await.unwrap();
+            for _ in 0..50 {
+                if content.as_slice() == OLD || content.as_slice() == NEW {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(2));
+                content = tokio::fs::read(&path).await.unwrap();
+            }
+
+            assert!(
+                content.as_slice() == OLD || content.as_slice() == NEW,
+                "partial/corrupt content observed: {content:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn write_confined_file_creates_new_file() {
+        let base = TempDir::new().unwrap();
+        let path = base.path().join("SKILL.md");
+        write_confined_file(&path, b"content").await.unwrap();
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"content");
+    }
+
+    /// `write_confined_file` must preserve the overwrite semantics of a plain `tokio::fs::write`
+    /// for a pre-existing regular file - only a symlink at the terminal component is rejected.
+    #[tokio::test]
+    async fn write_confined_file_overwrites_existing_regular_file() {
+        let base = TempDir::new().unwrap();
+        let path = base.path().join("SKILL.md");
+        tokio::fs::write(&path, b"old").await.unwrap();
+        write_confined_file(&path, b"new").await.unwrap();
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"new");
+    }
+
+    /// Issue #496: a symlink planted at the confined path after `resolve_confined_path`'s own
+    /// `ConfinementTarget::File` check (which deliberately leaves the terminal component
+    /// uncreated) must not be followed by the write that lands there.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn write_confined_file_rejects_a_symlink_planted_at_the_target() {
+        let base = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("real.md");
+
+        let confined_path = base.path().join("SKILL.md");
+        std::os::unix::fs::symlink(&outside_file, &confined_path).unwrap();
+
+        let err = write_confined_file(&confined_path, b"attacker-controlled")
+            .await
+            .unwrap_err();
+        // Not asserting the specific errno here: `O_NOFOLLOW` on a symlink is `ELOOP` on
+        // Linux/macOS, but other Unix flavors (e.g. FreeBSD) surface `EMLINK` instead. The
+        // load-bearing assertions are that it's an I/O failure at all, and that the write never
+        // reached the symlink's target.
+        assert!(matches!(err, ConfinementError::Io(_)));
+        assert!(!outside_file.exists());
     }
 
     #[cfg(windows)]

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -71,7 +71,9 @@ pub use path::{
 };
 
 // Re-export the shared path-confinement walk
-pub use confinement::{ConfinementError, ConfinementTarget, resolve_confined_path};
+pub use confinement::{
+    ConfinementError, ConfinementTarget, resolve_confined_path, write_confined_file,
+};
 
 // Re-export Debug-redaction helpers shared by secret-shaped fields
 pub use redact::{

--- a/crates/mcp-server/src/service.rs
+++ b/crates/mcp-server/src/service.rs
@@ -20,7 +20,7 @@ use mcp_execution_core::untrusted::{
     wrap_untrusted_block,
 };
 use mcp_execution_core::{
-    ServerConfig, ServerId, sanitize_path_for_error, validate_server_id_slug,
+    ServerConfig, ServerId, sanitize_path_for_error, validate_server_id_slug, write_confined_file,
 };
 use mcp_execution_files::FilesBuilder;
 use mcp_execution_introspector::{Introspector, ToolInfo};
@@ -1032,19 +1032,28 @@ impl GeneratorService {
     /// directory. Validates that the content contains required YAML
     /// frontmatter.
     ///
+    /// `resolve_skill_output_path` deliberately checks but never creates the terminal path
+    /// component, so the actual write goes through
+    /// [`write_confined_file`](mcp_execution_core::write_confined_file) rather than a plain
+    /// `tokio::fs::write`: on Unix it opens with `O_NOFOLLOW`, so a symlink planted at
+    /// `output_path` between the confinement check above and this call is rejected instead of
+    /// followed (issue #496). This closes the race for `output_path` itself, not for a symlink
+    /// swapped in for `{server_id}/` itself after the check — see `write_confined_file`'s own doc
+    /// comment for the full residual.
+    ///
     /// Observes client-issued cancellation at checkpoints only. `ct.is_cancelled()` is polled twice: on
     /// entry, before any validation and before the parent-directory creation performed by
     /// [`resolve_skill_output_path`](mcp_execution_skill::resolve_skill_output_path); and again
-    /// immediately before `tokio::fs::write` is invoked. Either firing returns
+    /// immediately before `write_confined_file` is invoked. Either firing returns
     /// `McpError::internal_error("save_skill cancelled by client", None)` with no file written - though a
     /// cancellation caught at the second checkpoint may still leave the confined parent directory behind,
     /// exactly as the existing `overwrite`-refused path does.
     ///
-    /// The write itself is never raced against cancellation: `tokio::fs::write` runs on the blocking-task
-    /// pool and, once started, cannot be interrupted - dropping its `JoinHandle` does not stop the queued
-    /// write, it only stops this handler from waiting for it. Racing it would make the response lie
-    /// (telling a cancelled client the write never happened while it still lands on disk moments later),
-    /// which is worse than not attempting cancellation at all. The write is also bounded by
+    /// The write itself is never raced against cancellation: `write_confined_file` runs on the
+    /// blocking-task pool and, once started, cannot be interrupted - dropping its `JoinHandle` does not
+    /// stop the queued write, it only stops this handler from waiting for it. Racing it would make the
+    /// response lie (telling a cancelled client the write never happened while it still lands on disk
+    /// moments later), which is worse than not attempting cancellation at all. The write is also bounded by
     /// [`MAX_SKILL_CONTENT_SIZE`] (100KB), so genuine interruptibility (e.g. a hand-rolled chunked write)
     /// is not worth pursuing for the marginal benefit. The checkpoints are correspondingly narrow: the
     /// pre-write work is a bounded frontmatter parse and one path-resolution walk, so in practice they
@@ -1164,8 +1173,11 @@ impl GeneratorService {
         }
 
         // Write file (parent directory already created and confined by
-        // resolve_skill_output_path)
-        tokio::fs::write(&output_path, &params.content)
+        // resolve_skill_output_path). `write_confined_file` closes the gap
+        // `resolve_skill_output_path` deliberately leaves open at its terminal component (it
+        // checks but never creates the target): a plain `tokio::fs::write` here would follow a
+        // symlink planted at `output_path` between that check and this call (issue #496).
+        write_confined_file(&output_path, params.content.as_bytes())
             .await
             .map_err(|e| McpError::internal_error(format!("Failed to write file: {e}"), None))?;
 
@@ -5805,5 +5817,39 @@ mod tests {
                 .unwrap();
         assert!(server_a_content.contains("name: test"));
         assert!(!server_a_content.contains("hijack"));
+    }
+
+    /// Issue #496: `resolve_skill_output_path`'s own pre-existing-symlink check (exercised by
+    /// `test_save_skill_rejects_dangling_symlink_at_output_path` above) only catches a symlink
+    /// that is already there when `save_skill` starts. This reproduces the actual race window -
+    /// a symlink planted at the resolved path *after* that check succeeds but *before* the write
+    /// - by calling the same two functions `save_skill` calls, in the same order, with the
+    /// symlink planted in between: the write must reject it rather than follow it out of the
+    /// confined directory.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_save_skill_write_step_rejects_symlink_planted_after_confinement_check() {
+        use tempfile::TempDir;
+
+        let skills_dir = TempDir::new().unwrap();
+        let outside_dir = TempDir::new().unwrap();
+        let outside_file = outside_dir.path().join("real.md");
+
+        let output_path = resolve_skill_output_path(skills_dir.path(), "test", None)
+            .await
+            .unwrap();
+        assert!(!output_path.exists());
+
+        // A racing process plants a symlink at the exact resolved path, after the confinement
+        // check above has already run and before the write below.
+        std::os::unix::fs::symlink(&outside_file, &output_path).unwrap();
+
+        let result = write_confined_file(&output_path, b"attacker-controlled").await;
+
+        // Not asserting the specific errno: `O_NOFOLLOW` on a symlink is `ELOOP` on Linux/macOS
+        // but other Unix flavors surface a different one. What matters is that the write failed
+        // and never reached the symlink's target.
+        assert!(result.is_err());
+        assert!(!outside_file.exists());
     }
 }

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -640,6 +640,7 @@ pub async fn resolve_confined_path(
     relative_dirs: &Path,
     target: Option<ConfinementTarget<'_>>,
 ) -> Result<PathBuf, ConfinementError>;
+pub async fn write_confined_file(path: &Path, content: &[u8]) -> Result<(), ConfinementError>;
 ```
 
 Issue #395: `mcp-skill::resolve_skill_output_path` and
@@ -660,6 +661,69 @@ resolved and canonicalized (the typical caller publishes it itself via an atomic
 this asymmetry is deliberate and preserved from both crates' pre-consolidation behavior, not
 unified away. `target: None` returns the walked `relative_dirs` chain itself, with nothing beyond
 the segment directory created.
+
+**Directory creation is idempotent under concurrency (issue #491).** `resolve_confined_path`'s
+segment-directory and lenient-intermediate-directory creation both tolerate
+`ErrorKind::AlreadyExists` from `create_dir`: when two callers race to resolve the same
+not-yet-existing directory, the loser's `create_dir` failing with `AlreadyExists` no longer
+surfaces as `ConfinementError::CreateDir`. Instead the loser re-runs the exact same
+existing-component validation the winner's directory would have gone through had it already been
+there when the walk started (segment directories: rejected if the winner's entry is a symlink or
+non-directory; lenient intermediate directories: resolved and re-confined if the winner's entry is
+a symlink, consistent with that walk's existing lenient policy) — tolerating `AlreadyExists` never
+skips or weakens confinement validation, it only changes which of the two racing callers performed
+the `create_dir` syscall that won. This is the only race `resolve_confined_path` defends against;
+it still does not defend the terminal `target` component against a symlink planted between this
+function's checks and a caller's subsequent write — that gap is what `write_confined_file` closes,
+below.
+
+**`write_confined_file` closes the write-time symlink race for the terminal path (issue #496).** A
+caller that resolved a [`ConfinementTarget::File`] path and is about to create it faces a gap
+`resolve_confined_path` itself cannot close: the terminal component is deliberately checked but
+never created, so a symlink planted at that exact path between the check and a plain
+`tokio::fs::write` would be followed, redirecting the write outside the confined directory.
+
+The entire check-then-write sequence runs inside one `tokio::task::spawn_blocking` call, using
+`std::fs` rather than `tokio::fs`. This is load-bearing, not incidental: an earlier async-native
+version built from `tokio::fs::OpenOptions` plus `AsyncWriteExt::write_all` had a real regression —
+each `.await` point (`open`, `write_all`, `flush`) was a place a dropped future (e.g. `rmcp`
+dropping the handler future on client disconnect) could land between `O_TRUNC` truncating the file
+and the content being written, leaving a 0-byte file where `tokio::fs::write` would have written
+the full content. A single `spawn_blocking` call restores `tokio::fs::write`'s original property:
+once the blocking task is queued, dropping the returned future does not stop or partially undo a
+write that already started running on the blocking pool.
+
+On Unix, `write_confined_file` opens with `O_CREAT | O_TRUNC | O_NOFOLLOW` in a single syscall —
+there is no separate check-then-write step for a racing process to land in between *for that exact
+path*, and a pre-existing *regular* file is still opened and truncated normally (`O_NOFOLLOW` only
+rejects a symlink at the final component), so overwrite semantics for a caller's own
+`exists()`/`overwrite` decision are unaffected.
+
+Windows has no usable equivalent for this specific open. `custom_flags` is exposed there too
+(`std::fs::OpenOptions::custom_flags` via `std::os::windows::fs::OpenOptionsExt`), but the
+candidate flag, `FILE_FLAG_OPEN_REPARSE_POINT`, is documented by `CreateFileW` as unusable
+together with `CREATE_ALWAYS` — which is exactly what `create(true).truncate(true)` maps to — and
+even where it *can* be used, it does not reject on open the way `O_NOFOLLOW` does: it hands back a
+handle to the symbolic link itself, which a subsequent write would still land on. So Windows relies
+solely on an immediately-preceding `std::fs::symlink_metadata` check, still inside the same
+blocking closure and so still with no yield point in between it and the `open` call. That narrows
+the window against a symlink already present when the check runs, but — unlike the Unix path —
+remains genuinely open, not just narrowed, against a symlink a racing *process* plants between the
+check and the open, since there is no single-syscall check-and-open available on this platform.
+This crate's test suite has no Windows symlink coverage (creating one needs a privilege most CI
+runners don't grant).
+
+**Residual gaps — deliberately not claimed as closed.** `O_NOFOLLOW` only guards the *terminal*
+path component, and only on Unix. Something with write access further up the confined path (e.g.
+`{server_id}/` itself) could rename that directory aside and drop a symlink in its place after the
+caller's confinement check but before the write — the open then traverses the symlinked *parent*
+and still escapes, one directory level up from what a flag on the terminal `open` call can see. A
+hardlink planted at the target path (same filesystem) is also not a symlink, so `O_NOFOLLOW` does
+not reject it, and the write clobbers whatever the hardlink points at. Closing either would need a
+directory file descriptor captured during the confinement walk itself (`openat`/`openat2` with
+`RESOLVE_NO_SYMLINKS` on Linux) rather than a flag on the terminal open call alone — out of scope
+for the issue #496 fix, and not silently claimed as covered. On Windows, the process-race gap
+described above is a third, platform-specific residual on top of these two.
 
 `ConfinementError` is a closed set every caller maps with a **total, 1:1** `From` impl into its
 own pre-existing, byte-identical error enum — `mcp-server::OutputDirError` and
@@ -883,7 +947,7 @@ it would require either a request-wide (not per-field) budget threaded through e
 | `mcp-codegen` | `Error`/`Result`, `metadata::*` (writes `_meta.json`), `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix`/`env_name_charset_pattern`/`env_name_charset_desc` and `MAX_ARG_COUNT`/`MAX_ARG_LEN`/`MAX_ENV_COUNT`/`MAX_ENV_VALUE_LEN`/`MAX_URL_LEN`/`MAX_HEADER_COUNT`/`MAX_HEADER_VALUE_LEN` (renders all of them into the generated runtime bridge template via `BridgeContext`) |
 | `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen` |
 | `mcp-skill` | `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `MAX_SERVER_ID_LENGTH`, `untrusted::*`, `metadata::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
-| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}`, `cli::{LogFormat, LOG_FORMAT_ENV_VAR}` |
+| `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path, write_confined_file}`, `cli::{LogFormat, LOG_FORMAT_ENV_VAR}` |
 | `mcp-cli` | `cli::{OutputFormat, ExitCode, LogFormat, LOG_FORMAT_ENV_VAR}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |
 
 ## 4. Defense in Depth
@@ -934,6 +998,13 @@ and byte-preserving of each variant's existing `Display` message.
 | `resolve_confined_path` terminal component exists as the other `ConfinementTarget` kind (file where `Directory` expected, or vice versa) | `WrongTargetKind`, mapped by each caller to its own truthful variant name |
 | `resolve_confined_path` with `target: None` | Returns the walked `relative_dirs` chain itself; nothing beyond the segment directory is created |
 | `resolve_confined_path`'s lenient intermediate walk hits a symlink loop (`ELOOP`) | Surfaces as `Io`, not `Escape` — `canonicalize`'s error propagates via `?` before any confinement comparison runs |
+| Two concurrent callers resolve the same not-yet-existing segment directory or lenient intermediate directory (issue #491) | Both succeed — the loser's `create_dir` `AlreadyExists` is tolerated, and the winner's directory is re-validated under the same rule (strict/symlink-rejecting for the segment directory, lenient/symlink-resolving for an intermediate directory) rather than trusted unconditionally |
+| `create_dir` fails with an error other than `AlreadyExists` (e.g. permission denied) while resolving the segment directory or a lenient intermediate directory | Surfaces as `ConfinementError::CreateDir`, unchanged from before #491 |
+| `write_confined_file` on a path whose terminal component is a symlink (dangling or not), planted after a caller's own confinement check on Unix (issue #496) | Rejected on open — the `O_NOFOLLOW` open fails (`ELOOP`, or a platform-specific equivalent errno on some BSDs) |
+| Same, on Windows | Rejected only if the pre-existing `symlink_metadata` check (run just before `open`, same blocking closure) observes the symlink — genuinely TOCTOU against a symlink a racing *process* plants between that check and `open`, since Windows has no single-syscall `O_NOFOLLOW` equivalent usable with a create+truncate open |
+| `write_confined_file` on a path that already exists as a regular file | Opened and truncated normally, same as a plain `tokio::fs::write` — `O_NOFOLLOW` does not affect non-symlink targets |
+| `write_confined_file`'s caller drops the returned future (e.g. client disconnect) after the write has started | No partial/0-byte file — the whole check-then-write sequence runs inside one `spawn_blocking` call, which cannot be interrupted once queued, matching `tokio::fs::write`'s original atomicity |
+| `write_confined_file` on a path whose *parent* directory is swapped for a symlink after the confinement check but before the call, or on a path that is a pre-existing hardlink to a file outside the confined directory | **Not** defended against on any platform — `O_NOFOLLOW` guards only the terminal component (and only on Unix); documented as a residual gap, not silently claimed as closed |
 | `ServerId::new`/`ToolName::new` rejects an input containing `&`, `<`, `>`, a control character, or a bidi override (issue #446) | The rejected value is sanitized (`untrusted::sanitize_untrusted_inline`) and `&`/`<`/`>` entity-escaped before being stored in `ServerIdError`/`ToolNameError`, so the raw disallowed characters never reach the `Display`/`Debug`-formatted error text an LLM or terminal renders |
 | `ServerId::new`/`ToolName::new` rejects an input containing emoji | **Not** sanitized or stripped — a deliberate accepted-risk exception, not an oversight: emoji is printable, cannot forge Markdown/HTML-like structure the way `&`/`<`/`>` can, and stripping arbitrary non-identifier printables would need a new allowlist pass that risks corrupting legitimate non-ASCII text elsewhere in the sanitizer |
 

--- a/specs/server/spec.md
+++ b/specs/server/spec.md
@@ -337,7 +337,7 @@ Thin MCP-tool wrapper around `mcp_execution_skill::resolve_skill_output_path`
 (`MAX_SKILL_CONTENT_SIZE` = 100 KiB), and that content starts with `---`
 before the more expensive frontmatter parse. Rejects overwriting an existing
 file unless `overwrite: true`. **Deliberately does not observe
-cancellation**: `tokio::fs::write` on the blocking-pool cannot actually be
+cancellation**: `write_confined_file` on the blocking-pool cannot actually be
 interrupted once queued — racing it against `ct.cancelled()` would make the
 response lie (telling a cancelled client the write never happened while it
 still lands on disk moments later), which is worse than not attempting
@@ -346,6 +346,19 @@ synchronous parse cost — `extract_skill_metadata`'s own
 `MAX_FRONTMATTER_SIZE` (8 KiB) on the extracted block is what keeps that
 bounded regardless of overall content size, since YAML parsing isn't
 linear-time on pathological input.
+
+The write itself goes through `mcp_execution_core::write_confined_file` rather than a plain
+`tokio::fs::write` (issue #496): `resolve_skill_output_path` deliberately checks but never
+creates the terminal path component (see [[../skill/spec#8. `resolve_skill_output_path` — Path
+Confinement]]), so a symlink planted at `output_path` between that check and the write would
+otherwise be followed, redirecting the write outside `~/.claude/skills/{server_id}/`.
+`write_confined_file` closes that gap for `output_path` itself, on Unix, by opening with
+`O_NOFOLLOW` in the same syscall that creates/truncates the file, inside a single `spawn_blocking`
+call so a
+client disconnect mid-write can't leave a truncated file behind — it does not defend against a
+symlink swapped in for `{server_id}/` itself after the check, or a hardlink at `output_path`; see
+[[../core/spec#`confinement` module (`src/confinement.rs`)]] for the full guarantee and its
+documented residual.
 
 ## 4. State Management (`StateManager`)
 

--- a/specs/skill/spec.md
+++ b/specs/skill/spec.md
@@ -510,7 +510,12 @@ name before any filesystem work; the rest is delegated with
   never canonicalized even when it doesn't yet exist as a symlink.
 - This is a check against **pre-existing** state at call time — not a
   concurrency guarantee against a symlink planted by a racing process
-  between this check and the caller's write.
+  between this check and the caller's write. `mcp-server`'s `save_skill`
+  closes that gap for its own write via
+  `mcp_execution_core::write_confined_file` (issue #496; see
+  [[../server/spec#save_skill]] and
+  [[../core/spec#`confinement` module (`src/confinement.rs`)]]) rather than
+  by changing this function's own contract.
 
 ## 9. Error Conditions
 


### PR DESCRIPTION
## Summary

- Closes #496 (P1, security): `save_skill`'s file-target confinement check could be bypassed by a symlink planted after the check but before the write. `mcp_execution_core::write_confined_file` now performs the terminal-component check and the write inside a single blocking task, using `O_NOFOLLOW` on Unix so a symlink planted after the check is rejected instead of followed, preserving the same disconnect-safe atomicity `tokio::fs::write` had. Windows has no usable `O_NOFOLLOW`-equivalent for a create+truncate open, so it relies on a `symlink_metadata` pre-check documented as a residual TOCTOU gap against a racing process there.
- Closes #491: `resolve_segment_dir`/`resolve_lenient_component` now tolerate a concurrent `create_dir` racing to `AlreadyExists`, re-running the same existing-component validation used elsewhere so two callers resolving the same not-yet-existing confined directory both succeed instead of one failing with an internal error. Strict-vs-lenient symlink-rejection semantics are preserved.

Went through three rounds of adversarial critique (report-only `rust-critic`) before code review:
- Round 1 found a cancellation-atomicity regression (dropping the write future left a 0-byte file), a doc over-claim about closing the race "completely," and a factually wrong claim about no Windows `O_NOFOLLOW` equivalent existing.
- Round 2's Windows fix (`FILE_FLAG_OPEN_REPARSE_POINT`) turned out to be an invalid flag combination per MSDN (cannot combine with `CREATE_ALWAYS`); replaced with an honest downgrade documenting Windows as pre-check-only.
- Round 3 confirmed clean; code review approved after an independent full CI-suite run.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1458 tests)
- [x] `cargo test --doc --all-features --workspace` (42 doctests)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression test: symlink planted at target path is not followed by `write_confined_file` (#496)
- [x] New regression test: concurrent `resolve_confined_path` callers racing the same not-yet-existing directory both succeed (#491)
- [x] New regression test: dropping the write future mid-flight does not leave a partial/empty file