### PR TITLE
fix: guard write_file_atomic against symlinks and reexport skill hint constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sha2` 0.11 dependency (`default-features = false`) and enables `chrono`'s `serde` feature on
   `mcp-execution-core`, pulling in `digest`, `block-buffer`, `crypto-common`, `hybrid-array`, and
   `typenum` as new transitive dependencies (#468).
+- **`mcp-execution-core`**: `confinement::open_confined_write` — the symlink-planting guard
+  extracted out of `write_confined_file`'s blocking body into its own public, synchronous
+  primitive, so a caller that stages content into a separate `.tmp` path before renaming it into
+  place (rather than writing directly to the final path, `write_confined_file`'s own shape) can
+  apply the identical `O_NOFOLLOW`/pre-existing-symlink guard instead of hand-rolling it.
+  Re-exported from the crate root alongside the existing confinement API (#504).
+- **`mcp-execution-skill`**: `MAX_USE_CASE_HINT_LENGTH` and `MAX_USE_CASE_HINTS` are now
+  re-exported from the crate root's `pub use types::{...}` block, matching this crate's own spec's
+  documented public API surface. Both constants have existed in `types.rs` since #429 but were
+  never re-exported at the crate root (#494).
 
 ### Changed
 
@@ -812,6 +822,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the operator chose themselves would not defend against anything an attacker able to plant a
   symlink under it could not already do to any other path this process touches, so it keeps its
   existing narrower, traversal-only validation (#501).
+- **`mcp-execution-files`**: `write_file_atomic`'s temp-file write — the `.tmp` staging path used
+  by its atomic-write path — now opens via `mcp_execution_core::open_confined_write` instead of a
+  plain `fs::File::create`, refusing to follow a symlink pre-planted at that path. Previously, a
+  symlink planted ahead of time at the predictable `{target}.tmp` location was followed by the
+  write, redirecting file content anywhere the process could write — reachable via
+  `FilesBuilder::build_and_export`'s top-level file writes (#504).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,7 @@ dependencies = [
  "dhat",
  "dirs",
  "mcp-execution-codegen",
+ "mcp-execution-core",
  "rayon",
  "tempfile",
  "thiserror",

--- a/crates/mcp-core/src/confinement.rs
+++ b/crates/mcp-core/src/confinement.rs
@@ -492,6 +492,51 @@ pub async fn write_confined_file(path: &Path, content: &[u8]) -> Result<(), Conf
 /// The synchronous body of [`write_confined_file`], run inside a single `spawn_blocking` call so
 /// the check-then-write sequence is atomic with respect to the calling future being dropped.
 fn write_confined_file_blocking(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut file = open_confined_write(path)?;
+    file.write_all(content)?;
+    file.flush()
+}
+
+/// Opens `path` for writing, refusing to follow a pre-existing symlink planted at that exact
+/// location.
+///
+/// The same guard [`write_confined_file`] applies, factored out as its own blocking, synchronous
+/// primitive. [`write_confined_file`] stages content in memory and writes it to its *final* path
+/// in one call; a caller that instead needs to stage into a separate `.tmp` path and `rename` it into
+/// place (e.g. `mcp-execution-files`' `write_file_atomic`) cannot reuse that function directly,
+/// since the symlink race it closes is specific to the exact path passed in — here, the `.tmp`
+/// staging path rather than the final one (issue #504). Exposing this primitive lets both crates
+/// share one guard instead of each hand-rolling its own.
+///
+/// On Unix, the open that creates or truncates `path` carries `O_NOFOLLOW`, so the kernel rejects
+/// a symlinked terminal component (dangling or not) as part of that same syscall. Windows has no
+/// equivalent flag usable together with `create(true).truncate(true)` (see
+/// [`write_confined_file`]'s doc comment for why), so it relies solely on a
+/// [`std::fs::symlink_metadata`] pre-check with no yield point before the open — this narrows but
+/// does not close the window against a symlink planted by a racing process between the two.
+///
+/// A pre-existing regular file is still opened and truncated normally: this only rejects a
+/// symlink at the final path component, not an ordinary overwrite.
+///
+/// # Errors
+///
+/// Returns an error if the symlink check (Windows only) or the open failed — including the
+/// platform's "too many levels of symbolic links" error on Unix when `path`'s terminal component
+/// is a symlink.
+///
+/// # Examples
+///
+/// ```
+/// use mcp_execution_core::open_confined_write;
+/// use std::io::Write;
+/// use tempfile::TempDir;
+///
+/// let dir = TempDir::new().unwrap();
+/// let path = dir.path().join("staged.tmp");
+/// let mut file = open_confined_write(&path).unwrap();
+/// file.write_all(b"content").unwrap();
+/// ```
+pub fn open_confined_write(path: &Path) -> std::io::Result<std::fs::File> {
     #[cfg(not(unix))]
     if std::fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
         return Err(std::io::Error::new(
@@ -512,9 +557,7 @@ fn write_confined_file_blocking(path: &Path, content: &[u8]) -> std::io::Result<
         options.custom_flags(libc::O_NOFOLLOW);
     }
 
-    let mut file = options.open(path)?;
-    file.write_all(content)?;
-    file.flush()
+    options.open(path)
 }
 
 #[cfg(test)]

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -72,7 +72,8 @@ pub use path::{
 
 // Re-export the shared path-confinement walk
 pub use confinement::{
-    ConfinementError, ConfinementTarget, resolve_confined_path, write_confined_file,
+    ConfinementError, ConfinementTarget, open_confined_write, resolve_confined_path,
+    write_confined_file,
 };
 
 // Re-export Debug-redaction helpers shared by secret-shaped fields

--- a/crates/mcp-files/Cargo.toml
+++ b/crates/mcp-files/Cargo.toml
@@ -22,6 +22,7 @@ parallel = ["dep:rayon"]
 dhat = { workspace = true, optional = true }
 dirs.workspace = true
 mcp-execution-codegen.workspace = true
+mcp-execution-core.workspace = true
 rayon = { workspace = true, optional = true }
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/mcp-files/src/builder.rs
+++ b/crates/mcp-files/src/builder.rs
@@ -1013,4 +1013,27 @@ mod tests {
         assert_eq!(content.len(), 100_000);
         assert_eq!(vfs.file_count(), 1);
     }
+
+    /// End-to-end regression for issue #504, through the actual production call path
+    /// (`build_and_export` -> this module's own `write_file_atomic` wrapper ->
+    /// `crate::filesystem::write_file_atomic`) rather than the lower-level unit test in
+    /// `filesystem.rs`. A bare top-level file (no `/` in its VFS path) is the shape that
+    /// reaches a predictable, attacker-plantable `.tmp` staging path: a symlink pre-planted
+    /// there must not be followed by the export.
+    #[test]
+    #[cfg(unix)]
+    fn test_build_and_export_rejects_a_symlink_planted_at_a_bare_file_tmp_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("real.ts");
+
+        std::os::unix::fs::symlink(&outside_file, temp_dir.path().join("test.ts.tmp")).unwrap();
+
+        let result = FilesBuilder::new()
+            .add_file("/test.ts", "attacker-controlled")
+            .build_and_export(temp_dir.path());
+
+        assert!(result.is_err());
+        assert!(!outside_file.exists());
+    }
 }

--- a/crates/mcp-files/src/filesystem.rs
+++ b/crates/mcp-files/src/filesystem.rs
@@ -61,6 +61,7 @@
 //! ```
 
 use crate::types::{FileEntry, FilePath, FilesError, FilesResourceKind, Result};
+use mcp_execution_core::open_confined_write;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
@@ -1131,13 +1132,17 @@ impl Default for ExportOptions {
 /// `pub(crate)` so [`crate::builder::FilesBuilder::build_and_export`] can reuse this for
 /// its own bare top-level files, rather than duplicating a weaker (no-`fsync`) atomic
 /// write helper.
+///
+/// The temp file is opened via [`open_confined_write`], which refuses to follow a symlink
+/// planted at the predictable `.tmp` path ahead of time, rather than a plain `fs::File::create`
+/// (issue #504).
 pub(crate) fn write_file_atomic(path: &Path, content: &str, atomic: bool) -> Result<()> {
     if atomic {
         // Atomic write: temp file + rename
         let temp_path = path.with_added_extension("tmp");
 
         // Write to temp file
-        let mut file = fs::File::create(&temp_path).map_err(|e| FilesError::InvalidPath {
+        let mut file = open_confined_write(&temp_path).map_err(|e| FilesError::InvalidPath {
             path: format!("Failed to create temp file {}: {}", temp_path.display(), e),
         })?;
 
@@ -2025,5 +2030,25 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().is_resource_limit_exceeded());
+    }
+
+    /// A symlink pre-planted at the predictable `path.tmp` staging path must not be followed by
+    /// `write_file_atomic`'s temp-file write (issue #504) — the write must fail rather than land
+    /// on whatever the symlink points at.
+    #[test]
+    #[cfg(unix)]
+    fn test_write_file_atomic_rejects_a_symlink_planted_at_the_tmp_path() {
+        let base = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = outside.path().join("real.ts");
+
+        let target_path = base.path().join("tool.ts");
+        let tmp_path = target_path.with_added_extension("tmp");
+        std::os::unix::fs::symlink(&outside_file, &tmp_path).unwrap();
+
+        let result = write_file_atomic(&target_path, "attacker-controlled", true);
+
+        assert!(result.is_err());
+        assert!(!outside_file.exists());
     }
 }

--- a/crates/mcp-skill/src/lib.rs
+++ b/crates/mcp-skill/src/lib.rs
@@ -39,6 +39,7 @@ pub use parser::{
 pub use template::{TemplateError, render_generation_prompt, render_skill_md};
 pub use types::{
     GenerateSkillParams, GenerateSkillResult, MAX_SERVER_ID_LENGTH, MAX_SKILL_NAME_LENGTH,
-    SaveSkillParams, SaveSkillResult, SkillCategory, SkillMetadata, SkillNameError,
-    SkillServerIdError, SkillTool, ToolExample, validate_server_id, validate_skill_name,
+    MAX_USE_CASE_HINT_LENGTH, MAX_USE_CASE_HINTS, SaveSkillParams, SaveSkillResult, SkillCategory,
+    SkillMetadata, SkillNameError, SkillServerIdError, SkillTool, ToolExample, validate_server_id,
+    validate_skill_name,
 };

--- a/specs/README.md
+++ b/specs/README.md
@@ -73,6 +73,7 @@ graph TD
     codegen --> core
     codegen --> introspector
     files --> codegen
+    files --> core
     skill --> core
     server --> core
     server --> introspector

--- a/specs/core/spec.md
+++ b/specs/core/spec.md
@@ -641,6 +641,7 @@ pub async fn resolve_confined_path(
     target: Option<ConfinementTarget<'_>>,
 ) -> Result<PathBuf, ConfinementError>;
 pub async fn write_confined_file(path: &Path, content: &[u8]) -> Result<(), ConfinementError>;
+pub fn open_confined_write(path: &Path) -> std::io::Result<std::fs::File>;
 ```
 
 Issue #395: `mcp-skill::resolve_skill_output_path` and
@@ -724,6 +725,19 @@ directory file descriptor captured during the confinement walk itself (`openat`/
 `RESOLVE_NO_SYMLINKS` on Linux) rather than a flag on the terminal open call alone — out of scope
 for the issue #496 fix, and not silently claimed as covered. On Windows, the process-race gap
 described above is a third, platform-specific residual on top of these two.
+
+**`open_confined_write` exposes the same guard as its own synchronous primitive (issue #504).**
+`write_confined_file` writes caller-supplied content directly to its *final* path in one call; a
+caller that instead needs to stage into a separate `.tmp` path and `rename` it into place —
+`mcp-execution-files`' `write_file_atomic` — cannot reuse `write_confined_file` itself, since the
+symlink race it closes is specific to the exact path passed in (the `.tmp` staging path, not the
+final one). `open_confined_write(path: &Path) -> std::io::Result<std::fs::File>` is the check-and-open
+body extracted out of `write_confined_file`'s blocking closure — same `O_NOFOLLOW`/`symlink_metadata`
+guard, same residual gaps noted above — so both crates share one implementation instead of each
+hand-rolling its own. It is synchronous and not wrapped in `spawn_blocking`, since
+`mcp-execution-files`' export path has no `tokio` runtime dependency to preserve; callers that need
+the same future-drop atomicity `write_confined_file` provides must still run it inside their own
+`spawn_blocking` (or equivalent) rather than calling it directly from async code.
 
 `ConfinementError` is a closed set every caller maps with a **total, 1:1** `From` impl into its
 own pre-existing, byte-identical error enum — `mcp-server::OutputDirError` and
@@ -945,7 +959,7 @@ it would require either a request-wide (not per-field) budget threaded through e
 |---|---|
 | `mcp-introspector` | `ServerConfig`, `ServerId`, `ToolName`, `Transport`, `validate_server_config`, `Error`/`Result` |
 | `mcp-codegen` | `Error`/`Result`, `metadata::*` (writes `_meta.json`), `forbidden_chars`/`forbidden_env_names`/`forbidden_env_prefix`/`env_name_charset_pattern`/`env_name_charset_desc` and `MAX_ARG_COUNT`/`MAX_ARG_LEN`/`MAX_ENV_COUNT`/`MAX_ENV_VALUE_LEN`/`MAX_URL_LEN`/`MAX_HEADER_COUNT`/`MAX_HEADER_VALUE_LEN` (renders all of them into the generated runtime bridge template via `BridgeContext`) |
-| `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen` |
+| `mcp-files` | `Error`/`Result` indirectly via `mcp-codegen`; `confinement::open_confined_write` directly (issue #504) |
 | `mcp-skill` | `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `MAX_SERVER_ID_LENGTH`, `untrusted::*`, `metadata::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path}` |
 | `mcp-server` | `ServerConfig`, `ServerId`, `sanitize_path_for_error`, `contains_parent_dir`, `validate_server_id_slug`, `ServerIdSlugError`, `untrusted::*`, `confinement::{ConfinementError, ConfinementTarget, resolve_confined_path, write_confined_file}`, `cli::{LogFormat, LOG_FORMAT_ENV_VAR}` |
 | `mcp-cli` | `cli::{OutputFormat, ExitCode, LogFormat, LOG_FORMAT_ENV_VAR}`, `ServerConfig`/`ServerConfigBuilder`, `RedactedItems`/`RedactedUrl`, `Error` (for exit-code classification) |

--- a/specs/files/spec.md
+++ b/specs/files/spec.md
@@ -21,7 +21,8 @@ related:
 > Path: `crates/mcp-files`. An in-memory, read-only VFS for generated tool
 > files, plus a high-performance, **atomic** export to the real filesystem.
 > Depends on `mcp-execution-codegen` (for `GeneratedCode` and its derived
-> resource bounds).
+> resource bounds) and, since #504, `mcp-execution-core` directly (for
+> `confinement::open_confined_write`).
 
 ## 1. Responsibility
 
@@ -254,10 +255,14 @@ free-form `resource: String` (issue #343), mirroring `mcp-core::ResourceKind`'s 
 pattern (issue #317, [[../core/spec#`Error` / `Result<T>` (`src/error.rs`)]]) without adding
 variants to that enum: `mcp-core`'s `ResourceKind` already has semantically adjacent variants
 (`GeneratedOutputSize`/`GeneratedFileCount`, the closest neighbors to
-`ExportTotalSize`/`ExportFileCount`), but this crate has no direct dependency on
-`mcp-execution-core` (only a transitive one via `mcp-execution-codegen`), so sharing that enum
-would mean adding a new direct dependency on `mcp-core` for a single error variant — a local enum
-avoids that coupling. Each variant's `Display` reproduces the same wording `check_export_bounds`
+`ExportTotalSize`/`ExportFileCount`), but sharing that enum would mean growing it with a variant
+pair used by exactly one downstream crate for a single error case — a local enum avoids that
+coupling regardless of the dependency edge below. At the time of #343 this crate also had no
+direct dependency on `mcp-execution-core` (only a transitive one via `mcp-execution-codegen`),
+which was the deciding factor then; #504 has since added a direct dependency for
+`confinement::open_confined_write`, so that specific rationale no longer applies, but the
+decision to keep `FilesResourceKind` local stands on the enum-scope argument above and was not
+revisited by #504. Each variant's `Display` reproduces the same wording `check_export_bounds`
 used to build by hand (`"export file count"` / `"export total size"`), so
 `FilesError::ResourceLimitExceeded`'s message is unchanged in substance.
 


### PR DESCRIPTION
## Summary

Two independent, unrelated fixes bundled into one PR (both P2, grouped during priority triage):

- **#504** (security) — `write_file_atomic`'s temp-file write in `mcp-files` followed a symlink planted at its predictable `.tmp` staging path. Extracted `open_confined_write` out of `mcp-core`'s `write_confined_file_blocking` into its own public, reusable primitive and applied it to `write_file_atomic`, closing the gap. Same bug class as #496 and (still open, out of scope here) #501.
- **#494** — `mcp-skill`'s crate root didn't reexport `MAX_USE_CASE_HINT_LENGTH` / `MAX_USE_CASE_HINTS` as its own spec documented. Added both to the crate-root `pub use` block.

`specs/core/spec.md`, `specs/files/spec.md`, and `specs/README.md` updated to reflect the new `open_confined_write` API and the new `mcp-files` -> `mcp-core` dependency edge. `CHANGELOG.md` updated.

## Scope note

#504's own issue body incorrectly stated that #501 (the identical symlink-follow bug in the CLI's `write_skill_md`) was already fixed. It is not — #501 is still open and is being handled separately; this PR does not touch `mcp-cli`.

Three lower-severity, pre-existing gaps surfaced during this PR's security audit were filed as separate follow-up issues rather than bundled in: #505 (`touch_dir`'s unguarded marker-file write), #506 (`write_file_atomic`'s non-atomic branch has no symlink guard), #507 (`open_confined_write`'s doc comment missing residual-gaps caveats).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1466 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression test: symlink planted at `write_file_atomic`'s `.tmp` path is rejected (unit-level, `mcp-files/src/filesystem.rs`)
- [x] New regression test: same, through the actual production call path `FilesBuilder::build_and_export` (`mcp-files/src/builder.rs`)
- [x] `cargo audit` / `cargo deny check` clean