### PR TITLE
fix: enable serde_json/preserve_order explicitly in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workspace now enables `serde_json/preserve_order` directly instead of relying on it being pulled in
+  transitively through `handlebars`'s `preserve_json_order` default feature. `handlebars` 6.4.4 dropped
+  that default, which would have made `serde_json::Map` fall back to sorted-key (`BTreeMap`) iteration
+  and broken the insertion-order guarantee `mcp-execution-codegen`'s sibling-key collision handling
+  depends on when generating TypeScript interfaces from JSON schemas.
+
 ## [0.10.0] - 2026-08-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rmcp = "3.1"
 schemars = "1.2"
 serde = "1.0"
 serde-saphyr = { version = "1.0.1", default-features = false, features = ["deserialize", "serialize"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 sha2 = { version = "0.11", default-features = false }
 tempfile = "3.27"
 thiserror = "2.0"

--- a/crates/mcp-codegen/src/common/typescript.rs
+++ b/crates/mcp-codegen/src/common/typescript.rs
@@ -503,8 +503,8 @@ mod tests {
         });
 
         let result = json_schema_to_typescript(&schema);
-        // The `preserve_order` feature is enabled transitively (via schemars/rmcp), so
-        // `serde_json::Map` iterates in insertion order: "a-b" claims the base "a_b" first.
+        // The workspace enables `serde_json/preserve_order`, so `serde_json::Map` iterates
+        // in insertion order: "a-b" claims the base "a_b" first.
         assert_eq!(result.matches("a_b?: string").count(), 1, "{result}");
         assert_eq!(result.matches("a_b_2?: number").count(), 1, "{result}");
         assert_eq!(result.matches("a_b_3?: boolean").count(), 1, "{result}");


### PR DESCRIPTION
## Summary
- `serde_json`'s insertion-order `Map` iteration was only enabled transitively through `handlebars`'s `preserve_json_order` default feature.
- `handlebars` 6.4.4 (see #511) dropped that default feature, which silently switched `serde_json::Map` to sorted-key (`BTreeMap`) iteration.
- `mcp-execution-codegen`'s sibling-key collision handling (dedup logic when generating TypeScript interfaces from JSON schemas) relies on insertion order, so this broke `test_json_schema_to_typescript_dedups_three_way_colliding_sibling_keys` on CI run 32278844403.
- Fix: declare `serde_json = { version = "1.0", features = ["preserve_order"] }` directly in the workspace `Cargo.toml` instead of depending on a transitive default from `handlebars`.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo +stable clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --all-features --workspace --no-fail-fast` (1473 passed)
- [x] `cargo test --doc --all-features --workspace`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Verified locally that pinning `handlebars` to 6.4.4 alone reproduces the failure, and that this fix resolves it with `handlebars` 6.4.4